### PR TITLE
Re-organizing and documenting UnsolvedSymbolVisitor

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -711,7 +711,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   // These are the codes from JavaParser, so we optimistically assume that these lines are safe.
   public Visitable visit(CatchClause node, Void arg) {
     /*
-     * This method is a copy from the visit(CatchClause, Void) method of JavaParser. We adds lines to update the local variables and isInsideCatchBlockParameter.
+     * This method is a copy from the visit(CatchClause, Void) method of JavaParser. We add lines to update the set of local variables and isInsideCatchBlockParameter.
      */
     HashSet<String> currentLocalVariables = new HashSet<>();
     currentLocalVariables.add(node.getParameter().getNameAsString());

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1650,27 +1650,12 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     Node parentNode = node.getParentNode().get();
     Type nodeType = node.getType();
 
-    // This scope logic must happen here, because later in this method there is a check for
-    // whether the return type is a type variable, which must succeed if the type variable
-    // was declared for this scope.
     addTypeVariableScope(node.getTypeParameters());
 
     // since this is a return type of a method, it is a dot-separated identifier
     @SuppressWarnings("signature")
     @DotSeparatedIdentifiers String nodeTypeAsString = nodeType.asString();
     @ClassGetSimpleName String nodeTypeSimpleForm = toSimpleName(nodeTypeAsString);
-    if (!this.isTypeVar(nodeTypeSimpleForm)) {
-      // Don't attempt to resolve a type variable, since we will inevitably fail.
-      try {
-        nodeType.resolve();
-      } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
-        // Note that this could also be an interface (if it is used in an implements clause
-        // elsewhere).
-        // updateMissingClass is responsible for fixing this up later after we encounter the
-        // relevant implements clause.
-        updateUnsolvedClassWithClassName(nodeTypeSimpleForm, false, false);
-      }
-    }
 
     if (!insideAnObjectCreation(node)) {
       SimpleName classNodeSimpleName = getSimpleNameOfClass(node);

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -711,7 +711,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   // These are the codes from JavaParser, so we optimistically assume that these lines are safe.
   public Visitable visit(CatchClause node, Void arg) {
     /*
-     * This method is a copy from the visit(CatchClause, Void) method of JavaParser. We add lines to update the set of local variables and isInsideCatchBlockParameter.
+     * This method is a copy from the visit(CatchClause, Void) method of JavaParser. We extend it to update the set of local variables and the flag isInsideCatchBlockParameter
      */
     HashSet<String> currentLocalVariables = new HashSet<>();
     currentLocalVariables.add(node.getParameter().getNameAsString());

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -246,6 +246,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   /** The qualified name of the current class. */
   private String currentClassQualifiedName = "";
 
+  /** Check if the visitor is inside a catch clause. */
+  private boolean insideACatchClause = false;
+
   /**
    * Create a new UnsolvedSymbolVisitor instance
    *
@@ -702,7 +705,11 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     HashSet<String> currentLocalVariables = new HashSet<>();
     currentLocalVariables.add(node.getParameter().getNameAsString());
     localVariables.addFirst(currentLocalVariables);
+    // Since there can not be a catch clause inside a catch clause, we don't need to use a temporary
+    // variable like in the case of insideTargetMethod.
+    insideACatchClause = true;
     Visitable result = super.visit(node, p);
+    insideACatchClause = false;
     localVariables.removeFirst();
     return result;
   }
@@ -1360,7 +1367,8 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       className = typeRawName;
       packageName = getPackageFromClassName(className);
     }
-    classToUpdate = new UnsolvedClassOrInterface(className, packageName, false, isAnInterface);
+    classToUpdate =
+        new UnsolvedClassOrInterface(className, packageName, insideACatchClause, isAnInterface);
 
     classToUpdate.setNumberOfTypeVariables(numberOfArguments);
     classToUpdate.setPreferedTypeVariables(preferredTypeVariables);

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1186,13 +1186,17 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       return result;
     }
     gotException();
+    /*
+     * For an unresolved object creation, the symbols are resolved first before the expression itself is resolved.
+     */
     try {
       List<String> argumentsCreation =
           getArgumentTypesFromObjectCreation(newExpr, getPackageFromClassName(type));
       UnsolvedMethod creationMethod = new UnsolvedMethod("", type, argumentsCreation);
       updateUnsolvedClassWithClassName(type, false, false, creationMethod);
     } catch (Exception q) {
-      // can not solve the parameters for this object creation in this current run
+      // The exception originates from the call to getArgumentTypesFromObjectCreation within the try
+      // block, indicating unresolved parameters in this object creation.
     }
     if (newExpr.getAnonymousClassBody().isPresent()) {
       // Need to do data structure maintenance

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1207,7 +1207,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     }
     gotException();
     /*
-     * For an unresolved object creation, the symbols are resolved first before the expression itself is resolved.
+     * For an unresolved object creation, the arguments are resolved first before the expression itself is resolved.
      */
     try {
       List<String> argumentsCreation =


### PR DESCRIPTION
Professor,

I've made some updates so that `UnsolvedSymbolVisitor` can be more accessible for future programmers.

Initially, I attempted to write perfect specifications so that the `UnsolvedSymbolVisitor`'s functionality could be understood without the need to read the code at all. However, I found this to be more challenging than anticipated—Leslie Lamport makes it sound deceptively simple! As an alternative approach, I've added comments to clarify potentially confusing sections of the code.

Additionally, I've removed the portion of the code responsible for updating parameter types and return types of methods. That functionality is already handled within the visit method for `ClassOrInterfaceType`. (Note: The code for updating parameter types had a useful feature that checked if the parameter was within a catch clause and set the synthetic type to extend Exception. To replicate this, I've introduced a local variable, `insideACatchClause`.)

Please review the changes and let me know if there are any further adjustments needed.

