### PR TITLE
Add an infinite loop defense and extend the fix in #285 to also handle Java 14 pattern variables

### DIFF
--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -1,6 +1,7 @@
 package org.checkerframework.specimin;
 
 import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
@@ -223,13 +224,19 @@ public class SpeciminRunner {
 
     Map<String, String> typesToChange = new HashMap<>();
     Map<String, String> classAndUnresolvedInterface = new HashMap<>();
+
+    // This is a defense against infinite loop bugs. The idea is this:
+    // if we encounter the same set of outputs three times, that's a good indication
+    // that we're in an infinite loop. But, we sometimes encounter the same set
+    // of outputs *twice* during normal operation (because some symbol needs to be
+    // solved). So, we track all previous iterations, and if we ever see the same
+    // outputs we set "problematicIteration" to that one. If we see that output again,
+    // we break the loop below early.
+    Set<UnsolvedSymbolVisitorProgress> previousIterations = new HashSet<>();
+    UnsolvedSymbolVisitorProgress problematicIteration = null;
+
     while (addMissingClass.gettingException()) {
       addMissingClass.setExceptionToFalse();
-      UnsolvedSymbolVisitorProgress workDoneBeforeIteration =
-          new UnsolvedSymbolVisitorProgress(
-              addMissingClass.getPotentialUsedMembers(),
-              addMissingClass.getAddedTargetFiles(),
-              addMissingClass.getSyntheticClassesAsAStringSet());
       for (CompilationUnit cu : parsedTargetFiles.values()) {
         addMissingClass.setImportStatement(cu.getImports());
         // it's important to make sure that getDeclarations and addMissingClass will visit the same
@@ -263,9 +270,24 @@ public class SpeciminRunner {
               addMissingClass.getPotentialUsedMembers(),
               addMissingClass.getAddedTargetFiles(),
               addMissingClass.getSyntheticClassesAsAStringSet());
-      boolean gettingStuck =
-          workDoneAfterIteration.equals(workDoneBeforeIteration)
-              && addMissingClass.gettingException();
+
+      // Infinite loop protection.
+      boolean gettingStuck = previousIterations.contains(workDoneAfterIteration);
+      if (gettingStuck) {
+        if (problematicIteration == null) {
+          problematicIteration = workDoneAfterIteration;
+        } else if (workDoneAfterIteration.equals(problematicIteration)) {
+          // This is the third time that we've made no changes, so we're probably
+          // in an infinite loop.
+          break;
+        }
+      } else { // not getting stuck
+        if (problematicIteration != null && !problematicIteration.equals(workDoneAfterIteration)) {
+          // unset problematicIteration
+          problematicIteration = null;
+        }
+      }
+      previousIterations.add(workDoneAfterIteration);
 
       if (gettingStuck || !addMissingClass.gettingException()) {
         // Three possible cases here:
@@ -520,7 +542,9 @@ public class SpeciminRunner {
       typeSolver.add(new JarTypeSolver(path));
     }
     JavaSymbolSolver symbolSolver = new JavaSymbolSolver(typeSolver);
-    StaticJavaParser.getConfiguration().setSymbolResolver(symbolSolver);
+    StaticJavaParser.getParserConfiguration().setSymbolResolver(symbolSolver);
+    StaticJavaParser.getParserConfiguration()
+        .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -22,6 +22,7 @@ import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.PatternExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.SwitchExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
@@ -754,11 +755,13 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     //
     // This visit method uses this fact to add extends clauses to classes created by
     // UnsolvedSymbolVisitor.
+    ReferenceType referenceType;
     if (node.getPattern().isPresent()) {
-      // TODO: handle JDK14 pattern variables
-      return super.visit(node, p);
+      PatternExpr patternExpr = node.getPattern().get();
+      referenceType = patternExpr.getType();
+    } else {
+      referenceType = node.getType();
     }
-    ReferenceType referenceType = node.getType();
     Expression relationalExpr = node.getExpression();
     String relationalExprFQN, referenceTypeFQN;
     try {

--- a/src/test/java/org/checkerframework/specimin/TwoTypeCorrect2Test.java
+++ b/src/test/java/org/checkerframework/specimin/TwoTypeCorrect2Test.java
@@ -1,0 +1,15 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks that Specimin correctly handles multiple subtyping constraints. */
+public class TwoTypeCorrect2Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "twotypecorrect2",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Type)"});
+  }
+}

--- a/src/test/resources/twotypecorrect2/expected/com/example/Simple.java
+++ b/src/test/resources/twotypecorrect2/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.example.Type;
+import org.example.PrimitiveType;
+import org.example.ClassOrInterfaceType;
+
+class Simple {
+    void bar(Type t) {
+        if (t instanceof PrimitiveType p) {
+        } else if (t instanceof ClassOrInterfaceType c) {
+        }
+    }
+}

--- a/src/test/resources/twotypecorrect2/expected/org/example/ClassOrInterfaceType.java
+++ b/src/test/resources/twotypecorrect2/expected/org/example/ClassOrInterfaceType.java
@@ -1,0 +1,4 @@
+package org.example;
+
+public class ClassOrInterfaceType extends org.example.Type {
+}

--- a/src/test/resources/twotypecorrect2/expected/org/example/PrimitiveType.java
+++ b/src/test/resources/twotypecorrect2/expected/org/example/PrimitiveType.java
@@ -1,0 +1,4 @@
+package org.example;
+
+public class PrimitiveType extends org.example.Type {
+}

--- a/src/test/resources/twotypecorrect2/expected/org/example/Type.java
+++ b/src/test/resources/twotypecorrect2/expected/org/example/Type.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public class Type {
+
+}

--- a/src/test/resources/twotypecorrect2/input/com/example/Simple.java
+++ b/src/test/resources/twotypecorrect2/input/com/example/Simple.java
@@ -1,0 +1,17 @@
+package com.example;
+
+import org.example.Type;
+import org.example.PrimitiveType;
+import org.example.ClassOrInterfaceType;
+
+class Simple {
+    // Target method, based on an example from Randoop. This example differs
+    // from twotypecorrect in that these instanceofs use Java 14 pattern variables.
+    void bar(Type t) {
+        if (t instanceof PrimitiveType p) {
+            // do something with p...
+        } else if (t instanceof ClassOrInterfaceType c) {
+            // do something with c...
+        }
+    }
+}


### PR DESCRIPTION
The change to the infinite loop defense in `SpeciminRunner` would have prevented the infinite loop bug in #279 entirely: instead of an infinite loop, the manifestation of the bug would have been non-compilable output from Specimin, which is much less bad. I've tested that with both the new test case in this PR and the test case in #285.