### PR TITLE
Preserve methods when argument and parameter types are different

### DIFF
--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -172,6 +172,39 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
       return super.visit(decl, p);
     }
 
+    // Check to see if import is used in a separate method used by the target method(s)
+    for (String member : membersToEmpty) {
+      int openParen = member.indexOf('(');
+      int closeParen = member.lastIndexOf(')');
+
+      if (openParen == -1 || closeParen == -1) {
+        continue;
+      }
+
+      String parameters = member.substring(openParen + 1, closeParen);
+
+      int index = parameters.indexOf(classFullName);
+      if (index == -1) {
+        continue;
+      } else if (index == 0) {
+        if (parameters.length() == classFullName.length()) {
+          return super.visit(decl, p);
+        }
+        char after = parameters.charAt(index + classFullName.length());
+        // Check to see generic or if it matches the first parameter
+        if (after == '<' || after == ',') {
+          return super.visit(decl, p);
+        }
+      }
+      // Check to see if it is a parameter
+      else if (index > 1 && parameters.substring(index - 2, index).equals(", ")) {
+        char after = parameters.charAt(index + classFullName.length());
+        if (after == '<' || after == ',') {
+          return super.visit(decl, p);
+        }
+      }
+    }
+
     decl.remove();
     return decl;
   }

--- a/src/test/java/org/checkerframework/specimin/DifferentParamTypesTest.java
+++ b/src/test/java/org/checkerframework/specimin/DifferentParamTypesTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that different parameter and argument types (e.g., ArrayList as the argument and
+ * List as the parameter) don't cause Specimin to mistakenly identify a method as not relevant.
+ */
+public class DifferentParamTypesTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "differentparamtypes",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/differentparamtypes/expected/com/example/Simple.java
+++ b/src/test/resources/differentparamtypes/expected/com/example/Simple.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 class Simple {
     void bar() {
-        foo(new ArrayList<?>());
+        foo(new ArrayList());
     }
 
     void foo(List<?> baz) {

--- a/src/test/resources/differentparamtypes/expected/com/example/Simple.java
+++ b/src/test/resources/differentparamtypes/expected/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class Simple {
+    void bar() {
+        foo(new ArrayList<?>());
+    }
+
+    void foo(List<?> baz) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/differentparamtypes/input/com/example/Simple.java
+++ b/src/test/resources/differentparamtypes/input/com/example/Simple.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 class Simple {
     void bar() {
-        foo(new ArrayList<?>());
+        foo(new ArrayList());
     }
 
     void foo(List<?> baz) {

--- a/src/test/resources/differentparamtypes/input/com/example/Simple.java
+++ b/src/test/resources/differentparamtypes/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class Simple {
+    void bar() {
+        foo(new ArrayList<?>());
+    }
+
+    void foo(List<?> baz) {
+    }
+}


### PR DESCRIPTION
When running on a method which references another method, passing in an argument which has a different type than the parameter type, the output file does not preserve the used method, resulting in unintended behavior. For example, when given this input:

```java
import java.util.ArrayList;
import java.util.List;

class Foo {
    void bar() {
        foo(new ArrayList<?>());
    }
    void foo(List<?> baz) {
    }
}
```

The output only contains the `bar()` method, removing the `foo(List<?>)` method entirely:

```java
import java.util.ArrayList;

class Foo {

    void bar() {
        foo(new ArrayList<>());
    }
}
```

This PR aims to fix this issue by checking the parameters of each method used within the target method with the imports, so they are not removed prematurely and eventually cause an `UnsolvedSymbolException`, causing the removal of the method.

I wasn't able to make sure that this didn't cause any unintended changes as I have a Windows computer (the tester does not work on Windows), so if someone could verify that, that would be great.