### PR TITLE
Correctly preserve enum constants that are used in a switch statement, as if they were fields

### DIFF
--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedEnumConstantDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
@@ -819,6 +820,13 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
       updateUsedClassWithQualifiedClassName(
           classFullName, usedTypeElement, nonPrimaryClassesToPrimaryClass);
       usedMembers.add(classFullName + "#" + expr.getNameAsString());
+      updateUsedClassBasedOnType(exprDecl.getType());
+    } else if (exprDecl instanceof ResolvedEnumConstantDeclaration) {
+      String enumFullName = exprDecl.asEnumConstant().getType().describe();
+      updateUsedClassWithQualifiedClassName(
+          enumFullName, usedTypeElement, nonPrimaryClassesToPrimaryClass);
+      // "." and not "#" because enum constants are not fields
+      usedMembers.add(enumFullName + "." + expr.getNameAsString());
       updateUsedClassBasedOnType(exprDecl.getType());
     }
   }

--- a/src/test/java/org/checkerframework/specimin/EnumSwitchTest.java
+++ b/src/test/java/org/checkerframework/specimin/EnumSwitchTest.java
@@ -5,7 +5,9 @@ import org.junit.Test;
 
 /**
  * This test checks for a non-compilation problem that we found when targeting the Checker
- * Framework.
+ * Framework. The problem occurred when an enum constant was referenced without any qualification,
+ * because it was present in the same package as the target and was unambiguous. In that case,
+ * Specimin required special logic to treat it differently than a field.
  */
 public class EnumSwitchTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/EnumSwitchTest.java
+++ b/src/test/java/org/checkerframework/specimin/EnumSwitchTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks for a non-compilation problem that we found when targeting the Checker
+ * Framework.
+ */
+public class EnumSwitchTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "enumswitch",
+        new String[] {"com/example/Simple.java", "com/example/Analysis.java"},
+        new String[] {"com.example.Simple#bar(Analysis)"});
+  }
+}

--- a/src/test/resources/enumswitch/expected/com/example/Analysis.java
+++ b/src/test/resources/enumswitch/expected/com/example/Analysis.java
@@ -2,8 +2,9 @@ package com.example;
 
 public interface Analysis {
 
-    enum Direction{
-        FORWARD, BACKWARD;
+    enum Direction {
+
+        FORWARD, BACKWARD
     }
 
     default Direction getDirection() {

--- a/src/test/resources/enumswitch/expected/com/example/Analysis.java
+++ b/src/test/resources/enumswitch/expected/com/example/Analysis.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public interface Analysis {
+
+    enum Direction{
+        FORWARD, BACKWARD;
+    }
+
+    default Direction getDirection() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/enumswitch/expected/com/example/Simple.java
+++ b/src/test/resources/enumswitch/expected/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+class Simple {
+    void bar(Analysis a) {
+        switch(a.getDirection()) {
+            case FORWARD:
+                System.out.println("forward");
+            case BACKWARD:
+                System.out.println("backward");
+            default:
+                throw new RuntimeException();
+        }
+    }
+}

--- a/src/test/resources/enumswitch/input/com/example/Analysis.java
+++ b/src/test/resources/enumswitch/input/com/example/Analysis.java
@@ -2,7 +2,7 @@ package com.example;
 
 public interface Analysis {
 
-    enum Direction{
+    enum Direction {
         FORWARD, BACKWARD;
     }
 

--- a/src/test/resources/enumswitch/input/com/example/Analysis.java
+++ b/src/test/resources/enumswitch/input/com/example/Analysis.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public interface Analysis {
+
+    enum Direction{
+        FORWARD, BACKWARD;
+    }
+
+    default Direction getDirection() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/enumswitch/input/com/example/Simple.java
+++ b/src/test/resources/enumswitch/input/com/example/Simple.java
@@ -1,0 +1,15 @@
+package com.example;
+
+class Simple {
+    // Target method.
+    void bar(Analysis a) {
+        switch(a.getDirection()) {
+            case FORWARD:
+                System.out.println("forward");
+            case BACKWARD:
+                System.out.println("backward");
+            default:
+                throw new RuntimeException();
+        }
+    }
+}


### PR DESCRIPTION
Based on trying to reproduce #148. The crash that that issue reports no longer is reproducible, but that input does trigger this bug.