### PR TITLE
The scope of primitive arrays is not guaranteed to be a NameExpr

### DIFF
--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -673,9 +673,15 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
       } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
         // when the type is a primitive array, we will have an UnsupportedOperationException
         if (e instanceof UnsupportedOperationException) {
-          updateUsedElementWithPotentialFieldNameExpr(expr.getScope().asNameExpr());
+          Expression scope = expr.getScope();
+          if (scope.isNameExpr()) {
+            updateUsedElementWithPotentialFieldNameExpr(scope.asNameExpr());
+          }
+          // If the scope is not a name expression, then it must be "this" (handled elsewhere),
+          // "super" (handled directly below), or another field access expression (handled by
+          // the visitor), so there's nothing to do.
         }
-        // if the a field is accessed in the form of a fully-qualified path, such as
+        // if a field is accessed in the form of a fully-qualified path, such as
         // org.example.A.b, then other components in the path apart from the class name and field
         // name, such as org and org.example, will also be considered as FieldAccessExpr.
       }

--- a/src/test/java/org/checkerframework/specimin/PrimitiveArrayThisTest.java
+++ b/src/test/java/org/checkerframework/specimin/PrimitiveArrayThisTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that instance fields with primitive array types do not cause a crash in
+ * Specimin.
+ */
+public class PrimitiveArrayThisTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "primitivearraythis",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/primitivearraythis/expected/com/example/Simple.java
+++ b/src/test/resources/primitivearraythis/expected/com/example/Simple.java
@@ -1,0 +1,9 @@
+package com.example;
+
+class Simple {
+    final byte[] values = new byte[10];
+
+    void bar() {
+        int length = this.values.length;
+    }
+}

--- a/src/test/resources/primitivearraythis/expected/com/example/Simple.java
+++ b/src/test/resources/primitivearraythis/expected/com/example/Simple.java
@@ -1,7 +1,7 @@
 package com.example;
 
 class Simple {
-    final byte[] values = new byte[10];
+    final byte[] values = null;
 
     void bar() {
         int length = this.values.length;

--- a/src/test/resources/primitivearraythis/input/com/example/Simple.java
+++ b/src/test/resources/primitivearraythis/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+class Simple {
+    final byte[] values = new byte[10];
+
+    // Target method.
+    void bar() {
+        int length = this.values.length;
+    }
+}


### PR DESCRIPTION
Fixes a set of crashes observed by @jonathan-m-phillips on Randoop of the following form:
```
Exception: java.lang.IllegalStateException,
Message: this.cumulativeSize is not NameExpr, it is FieldAccessExpr\,
Example: com.github.javaparser.ast.expr.Expression.asNameExpr(Expression.java:332)\
```