### PR TITLE
Avoid clean test problem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,3 +147,12 @@ test {
         showStandardStreams = true
     }
 }
+
+// Avoids "symbol not found" errors in builds immediately after cleaning.
+// Not 100% sure why. One theory: test data would otherwise be treated as
+// code by Gradle?
+sourceSets {
+    test {
+        java.srcDirs = ['src/main/java/', 'src/test/java/']
+    }
+}


### PR DESCRIPTION
@jonathan-m-phillips maybe this is the reason that you saw a large number of "symbol not found" errors: when I ran `./gradlew clean` followed by `./gradlew test`, I found that it fails the first time. This is surprising (and bad) behavior from Specimin's build system.

This PR fixes that sequence of commands by explicitly naming the source sets for the test target. Similar problems might exist for other targets, but I haven't found any yet. For example, running `./gradlew clean` before running the command that I mentioned in [this comment](https://github.com/njit-jerse/specimin/issues/298#issuecomment-2152430474) doesn't cause Specimin to behave any differently.