### PR TITLE
Move some static methods from PrunerVisitor to JavaParserUtil where they belong

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -1,9 +1,14 @@
 package org.checkerframework.specimin;
 
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import org.checkerframework.checker.signature.qual.FullyQualifiedName;
+
+import java.util.Optional;
 
 /**
  * A class containing useful static functions using JavaParser.
@@ -68,4 +73,64 @@ public class JavaParserUtil {
       ClassOrInterfaceType type) {
     return type.resolve().asReferenceType();
   }
+
+    /**
+     * Searches the ancestors of the given node until it finds a class or interface node, and then
+     * returns the fully-qualified name of that class or interface.
+     *
+     * <p>This method will fail if it is called on a node that is not contained in a class or
+     * interface.
+     *
+     * @param node a node contained in a class or interface
+     * @return the fully-qualified name of the inner-most containing class or interface
+     */
+    @SuppressWarnings("signature") // result is a fully-qualified name or else this throws
+    public static @FullyQualifiedName String getEnclosingClassName(Node node) {
+      Node parent = getEnclosingClassLike(node);
+
+      if (parent instanceof ClassOrInterfaceDeclaration) {
+        return ((ClassOrInterfaceDeclaration) parent).getFullyQualifiedName().orElseThrow();
+      }
+
+      if (parent instanceof EnumDeclaration) {
+        return ((EnumDeclaration) parent).getFullyQualifiedName().orElseThrow();
+      }
+
+      throw new RuntimeException("unexpected kind of node: " + parent.getClass());
+    }
+
+    /**
+     * Returns the innermost enclosing class-like element for the given node. A class-like element is
+     * a class, interface, or enum (i.e., something that would be a {@link
+     * javax.lang.model.element.TypeElement} in javac's internal model). This method will throw if no
+     * such element exists.
+     *
+     * @param node a node that is contained in a class-like structure
+     * @return the nearest enclosing class-like node
+     */
+    public static Node getEnclosingClassLike(Node node) {
+      Node parent = node.getParentNode().orElseThrow();
+      while (!(parent instanceof ClassOrInterfaceDeclaration || parent instanceof EnumDeclaration)) {
+        parent = parent.getParentNode().orElseThrow();
+      }
+      return parent;
+    }
+
+    /**
+     * Returns true iff the innermost enclosing class/interface is an enum.
+     *
+     * @param node any node
+     * @return true if the enclosing class is an enum, false otherwise
+     */
+    public static boolean isInEnum(Node node) {
+      Optional<Node> parent = node.getParentNode();
+      while (parent.isPresent()) {
+        Node actualParent = parent.get();
+        if (actualParent instanceof EnumDeclaration) {
+          return true;
+        }
+        parent = actualParent.getParentNode();
+      }
+      return false;
+    }
 }

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -1,6 +1,7 @@
 package org.checkerframework.specimin;
 
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
@@ -96,6 +97,10 @@ public class JavaParserUtil {
         return ((EnumDeclaration) parent).getFullyQualifiedName().orElseThrow();
       }
 
+      if (parent instanceof AnnotationDeclaration) {
+        return ((AnnotationDeclaration) parent).getFullyQualifiedName().orElseThrow();
+      }
+
       throw new RuntimeException("unexpected kind of node: " + parent.getClass());
     }
 
@@ -110,7 +115,9 @@ public class JavaParserUtil {
      */
     public static Node getEnclosingClassLike(Node node) {
       Node parent = node.getParentNode().orElseThrow();
-      while (!(parent instanceof ClassOrInterfaceDeclaration || parent instanceof EnumDeclaration)) {
+      while (!(parent instanceof ClassOrInterfaceDeclaration
+              || parent instanceof EnumDeclaration
+              || parent instanceof AnnotationDeclaration)) {
         parent = parent.getParentNode().orElseThrow();
       }
       return parent;

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -165,7 +165,7 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
       // either.
       return false;
     }
-    Node typeElt = PrunerVisitor.getEnclosingClassLike(method);
+    Node typeElt = JavaParserUtil.getEnclosingClassLike(method);
 
     if (typeElt instanceof EnumDeclaration) {
       EnumDeclaration asEnum = (EnumDeclaration) typeElt;


### PR DESCRIPTION
I noticed that these methods shouldn't be in `PrunerVisitor` while reviewing the changes in #302.