### PR TITLE
Include methods for all implemented interfaces + annotation type-checker behavior preservation

### DIFF
--- a/src/main/java/org/checkerframework/specimin/AnnotationParameterTypesVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/AnnotationParameterTypesVisitor.java
@@ -241,7 +241,7 @@ public class AnnotationParameterTypesVisitor extends SpeciminStateVisitor {
     try {
       String qualifiedName = anno.resolve().getQualifiedName();
       if (anno.resolve() instanceof ReflectionAnnotationDeclaration
-          && !qualifiedName.startsWith("java.lang")) {
+          && !JavaLangUtils.inJdkPackage(qualifiedName)) {
         // This usually means that JavaParser has resolved this through the import, but there
         // is no file/CompilationUnit behind it, so we should discard it to prevent compile errors
         anno.remove();

--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -287,9 +287,13 @@ public final class JavaLangUtils {
   public static boolean inJdkPackage(String qualifiedName) {
     // TODO: can we get a list of such packages from the JDK instead of using this relatively-coarse
     // heuristic?
+    if (qualifiedName.startsWith("javax.annotation")) {
+      return false;
+    }
+
     return qualifiedName.startsWith("java.")
-            || qualifiedName.startsWith("javax.")
-            || qualifiedName.startsWith("com.sun.")
-            || qualifiedName.startsWith("jdk.");
+        || qualifiedName.startsWith("javax.")
+        || qualifiedName.startsWith("com.sun.")
+        || qualifiedName.startsWith("jdk.");
   }
 }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedAnnotationRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedAnnotationRemoverVisitor.java
@@ -106,7 +106,7 @@ public class UnsolvedAnnotationRemoverVisitor extends ModifierVisitor<Void> {
         // This is fine if it's included in java.lang, but if not, we should treat it as
         // if it were unresolved
 
-        if (!annotationName.startsWith("java.lang")) {
+        if (!JavaLangUtils.inJdkPackage(annotationName)) {
           isResolved = false;
         }
       }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
@@ -455,8 +455,17 @@ public class UnsolvedClassOrInterface {
     // so we need to add this to prevent them
     if (isAnAnnotation) {
       sb.append(
-          "@java.lang.annotation.Target({java.lang.annotation.ElementType.TYPE_USE,"
-              + " java.lang.annotation.ElementType.METHOD})\n");
+          "@java.lang.annotation.Target({ \n"
+              + "\tjava.lang.annotation.ElementType.TYPE, \n"
+              + "\tjava.lang.annotation.ElementType.FIELD, \n"
+              + "\tjava.lang.annotation.ElementType.METHOD, \n"
+              + "\tjava.lang.annotation.ElementType.PARAMETER, \n"
+              + "\tjava.lang.annotation.ElementType.CONSTRUCTOR, \n"
+              + "\tjava.lang.annotation.ElementType.LOCAL_VARIABLE, \n"
+              + "\tjava.lang.annotation.ElementType.ANNOTATION_TYPE,\n"
+              + "\tjava.lang.annotation.ElementType.PACKAGE,\n"
+              + "\tjava.lang.annotation.ElementType.TYPE_USE \n"
+              + "})");
     }
 
     sb.append("public ");

--- a/src/test/java/org/checkerframework/specimin/InterfaceChainTest.java
+++ b/src/test/java/org/checkerframework/specimin/InterfaceChainTest.java
@@ -1,0 +1,19 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that if a class implements an interface which implements another interface, the
+ * methods that need to be implemented still are (to preserve compilability). Test code partially
+ * derived from minimized test code in NullAway issue #102.
+ */
+public class InterfaceChainTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "interfacechain",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#iterator()"});
+  }
+}

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
@@ -1,15 +1,5 @@
 package org.checkerframework.checker.initialization.qual;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Initialized {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
@@ -1,5 +1,15 @@
 package org.checkerframework.checker.initialization.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface Initialized {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/KeyForBottom.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/KeyForBottom.java
@@ -1,15 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface KeyForBottom {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/KeyForBottom.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/KeyForBottom.java
@@ -1,5 +1,15 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface KeyForBottom {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -1,15 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface NonNull {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -1,5 +1,15 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface NonNull {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/Nullable.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/Nullable.java
@@ -1,5 +1,15 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface Nullable {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/Nullable.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/Nullable.java
@@ -1,15 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Nullable {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
@@ -1,5 +1,15 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface UnknownKeyFor {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
@@ -1,15 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface UnknownKeyFor {
 }

--- a/src/test/resources/interfacechain/expected/com/example/Foo.java
+++ b/src/test/resources/interfacechain/expected/com/example/Foo.java
@@ -1,0 +1,37 @@
+package com.example;
+
+import java.util.Iterator;
+
+public class Foo<E> {
+    public Iterator<E> iterator() {
+        return new AbstractLinkedIterator() {
+            @Override
+            E computeNext() {
+                throw new Error();
+            }
+        };
+    }
+
+    public abstract class AbstractLinkedIterator implements Iterator3<E> {
+        abstract E computeNext();
+
+        @Override
+        public E next() {
+            throw new Error();
+        }
+
+        @Override
+        public boolean hasNext() {
+            throw new Error();
+        }
+    }
+
+    public interface Iterator3<E> extends Iterator2<E> {
+    }
+
+    public interface Iterator2<E> extends Iterator1<E> {
+    }
+    
+    public interface Iterator1<E> extends Iterator<E> {
+    }
+}

--- a/src/test/resources/interfacechain/expected/com/example/Foo.java
+++ b/src/test/resources/interfacechain/expected/com/example/Foo.java
@@ -5,7 +5,6 @@ import java.util.Iterator;
 public class Foo<E> {
     public Iterator<E> iterator() {
         return new AbstractLinkedIterator() {
-            @Override
             E computeNext() {
                 throw new Error();
             }
@@ -15,12 +14,10 @@ public class Foo<E> {
     public abstract class AbstractLinkedIterator implements Iterator3<E> {
         abstract E computeNext();
 
-        @Override
         public E next() {
             throw new Error();
         }
 
-        @Override
         public boolean hasNext() {
             throw new Error();
         }

--- a/src/test/resources/interfacechain/input/com/example/Foo.java
+++ b/src/test/resources/interfacechain/input/com/example/Foo.java
@@ -1,0 +1,37 @@
+package com.example;
+
+import java.util.Iterator;
+
+public class Foo<E> {
+    public Iterator<E> iterator() {
+        return new AbstractLinkedIterator() {
+            @Override
+            E computeNext() {
+                throw new Error();
+            }
+        };
+    }
+
+    public abstract class AbstractLinkedIterator implements Iterator3<E> {
+        abstract E computeNext();
+
+        @Override
+        public E next() {
+            throw new Error();
+        }
+
+        @Override
+        public boolean hasNext() {
+            throw new Error();
+        }
+    }
+
+    public interface Iterator3<E> extends Iterator2<E> {
+    }
+
+    public interface Iterator2<E> extends Iterator1<E> {
+    }
+    
+    public interface Iterator1<E> extends Iterator<E> {
+    }
+}

--- a/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
@@ -1,16 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface PostconditionAnnotation {
 
 }

--- a/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
@@ -1,6 +1,16 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface PostconditionAnnotation {
 
 }

--- a/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
@@ -1,16 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface PreconditionAnnotation {
 
 }

--- a/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
@@ -1,6 +1,16 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface PreconditionAnnotation {
 
 }

--- a/src/test/resources/syntheticannotations/expected/com/example/Anno.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Anno.java
@@ -1,6 +1,16 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface Anno {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Anno.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Anno.java
@@ -1,16 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Anno {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Bar.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Bar.java
@@ -1,6 +1,16 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface Bar {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Bar.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Bar.java
@@ -1,16 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Bar {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Baz.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Baz.java
@@ -1,6 +1,16 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface Baz {
 
     public String foo();

--- a/src/test/resources/syntheticannotations/expected/com/example/Baz.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Baz.java
@@ -1,16 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Baz {
 
     public String foo();

--- a/src/test/resources/syntheticannotations/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Foo.java
@@ -1,16 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Foo {
 
     public Deprecated x();

--- a/src/test/resources/syntheticannotations/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Foo.java
@@ -1,6 +1,16 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface Foo {
 
     public Deprecated x();

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Foo.java
@@ -1,5 +1,15 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ 
+    java.lang.annotation.ElementType.TYPE, 
+    java.lang.annotation.ElementType.FIELD, 
+    java.lang.annotation.ElementType.METHOD, 
+    java.lang.annotation.ElementType.PARAMETER, 
+    java.lang.annotation.ElementType.CONSTRUCTOR, 
+    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
+    java.lang.annotation.ElementType.ANNOTATION_TYPE,
+    java.lang.annotation.ElementType.PACKAGE,
+    java.lang.annotation.ElementType.TYPE_USE 
+})
 public @interface Foo {
 }

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Foo.java
@@ -1,15 +1,5 @@
 package com.example;
 
-@java.lang.annotation.Target({ 
-    java.lang.annotation.ElementType.TYPE, 
-    java.lang.annotation.ElementType.FIELD, 
-    java.lang.annotation.ElementType.METHOD, 
-    java.lang.annotation.ElementType.PARAMETER, 
-    java.lang.annotation.ElementType.CONSTRUCTOR, 
-    java.lang.annotation.ElementType.LOCAL_VARIABLE, 
-    java.lang.annotation.ElementType.ANNOTATION_TYPE,
-    java.lang.annotation.ElementType.PACKAGE,
-    java.lang.annotation.ElementType.TYPE_USE 
-})
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Foo {
 }


### PR DESCRIPTION
This PR addresses an issue I discovered while running Specimin on [NullAway issue #102](https://github.com/uber/NullAway/issues/102), where methods in an abstract class present in the parent interface of the implemented interface were not preserved. For example:

Expected:
```java
package com.example;

import java.util.Iterator;

public class Foo<E> {
    public Iterator<E> iterator() {
        return new AbstractLinkedIterator() {
            @Override
            E computeNext() {
                throw new Error();
            }
        };
    }

    public abstract class AbstractLinkedIterator implements Iterator1<E> {
        abstract E computeNext();

        @Override
        public E next() {
            throw new Error();
        }

        @Override
        public boolean hasNext() {
            throw new Error();
        }
    }

    public interface Iterator1<E> extends Iterator<E> {
    }
}
```

Actual:
```java
package com.example;

import java.util.Iterator;

public class Foo<E> {
    public Iterator<E> iterator() {
        return new AbstractLinkedIterator() {
            @Override
            E computeNext() {
                throw new Error();
            }
        };
    }

    public abstract class AbstractLinkedIterator implements Iterator1<E> {
        abstract E computeNext();
    }

    public interface Iterator1<E> extends Iterator<E> {
    }
}
```

The current behavior is to only look for method declarations in the direct parent interface `Iterator1`, but those methods are not present there. This causes them to be removed and thus compile errors ensue. However, I modified `MustImplementMethodsVisitor` to explore all interface ancestors, so the `next()` and `hasNext()` methods are still preserved. The test case can be found in `InterfaceChainTest`.

I also included a small tweak to annotation preservation in this PR; previously, we preserved JDK annotations by seeing if it started with `java.lang`, but I changed it to use `JavaLangUtils.inJdkPackage()` instead after discovering a conflict when looking at [NullAway issue #97](https://github.com/uber/NullAway/issues/97).

Thank you!