### PR TITLE
Fix Windows tests not running

### DIFF
--- a/src/test/java/org/checkerframework/specimin/SpeciminTestExecutor.java
+++ b/src/test/java/org/checkerframework/specimin/SpeciminTestExecutor.java
@@ -95,7 +95,7 @@ public class SpeciminTestExecutor {
           "check_differences/check_differences.bat",
           outputDir.toAbsolutePath().toString(),
           Path.of("src/test/resources/" + testName + "/expected").toAbsolutePath().toString());
-      return;
+      builder.directory(new File(Path.of(".").toAbsolutePath().toString()));
     } else {
       builder.command(
           "diff",
@@ -105,8 +105,8 @@ public class SpeciminTestExecutor {
           "-B",
           outputDir.toAbsolutePath().toString(),
           Path.of("src/test/resources/" + testName + "/expected").toAbsolutePath().toString());
+      builder.directory(new File(System.getProperty("user.home")));
     }
-    builder.directory(new File(System.getProperty("user.home")));
     Process process;
     try {
       process = builder.start();

--- a/src/test/java/org/checkerframework/specimin/SpeciminTestExecutor.java
+++ b/src/test/java/org/checkerframework/specimin/SpeciminTestExecutor.java
@@ -93,8 +93,13 @@ public class SpeciminTestExecutor {
     if (isWindows) {
       builder.command(
           "check_differences/check_differences.bat",
-          outputDir.toAbsolutePath().toString(),
-          Path.of("src/test/resources/" + testName + "/expected").toAbsolutePath().toString());
+          "\"" + outputDir.toAbsolutePath().toString().replace('\\', '/') + "\"",
+          "\""
+              + Path.of("src/test/resources/" + testName + "/expected")
+                  .toAbsolutePath()
+                  .toString()
+                  .replace('\\', '/')
+              + "\"");
       builder.directory(new File(Path.of(".").toAbsolutePath().toString()));
     } else {
       builder.command(


### PR DESCRIPTION
Windows diff test was previously not running due to an early return statement and an error in working directory (as seen in #327 when windows passed but ubuntu didn't). 