### PR TITLE
Preserve `MustImplementMethodsVisitor` method type ancestors

### DIFF
--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -1,14 +1,5 @@
 package org.checkerframework.specimin;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.checkerframework.checker.nullness.qual.Nullable;
-
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -27,6 +18,13 @@ import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaratio
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * If a used class includes methods that must be implemented (because it extends an abstract class

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -265,6 +265,8 @@ public class MustImplementMethodsVisitor extends SpeciminStateVisitor {
       for (String name : typeParametersMap.getNames()) {
         String interfaceViewpointName = name.substring(name.lastIndexOf('.') + 1);
         String localViewpointName = typeParametersMap.getValueBySignature(name).get().describe();
+        // Escape localViewpointName in case it contains special regex characters like []
+        // if the type is an array, for example
         localViewpointName = Pattern.quote(localViewpointName);
         targetSignature = targetSignature.replaceAll(localViewpointName, interfaceViewpointName);
       }

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -184,9 +184,11 @@ public class MustImplementMethodsVisitor extends SpeciminStateVisitor {
             if (usedMembers.contains(methodSignature)) {
               return true;
             }
-            // If the member is not used (inherit from JDK), and we're in an interface or
-            // abstract class, no need to preserve it since original JDK definition will persist
-            if (JavaLangUtils.inJdkPackage(methodSignature) && !isInterfaceOrAbstract) {
+            // If the abstract member is not used, and we're in an interface or abstract class, 
+            // there is no need to preserve it since the original JDK abstract definition will
+            // be inherited
+            if (JavaLangUtils.inJdkPackage(methodSignature)
+                && (!resolvedMethod.isAbstract() || !isInterfaceOrAbstract)) {
               return true;
             }
           }

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -138,22 +138,22 @@ public class MustImplementMethodsVisitor extends SpeciminStateVisitor {
     }
 
     String currentMethodName =
-        currentMethodSignature.substring(currentMethodSignature.lastIndexOf('.') + 1);
-
+        currentMethodSignature.substring(
+            currentMethodSignature.lastIndexOf('.', currentMethodSignature.indexOf('(')) + 1);
     for (ResolvedReferenceType implementation :
         getAllImplementations(new HashSet<>(resolvedMethod.declaringType().getAncestors()))) {
       try {
         for (MethodUsage potentialSuperMethod : implementation.getDeclaredMethods()) {
           String methodSignature = potentialSuperMethod.getQualifiedSignature();
           String potentialSuperMethodName =
-              methodSignature.substring(methodSignature.lastIndexOf('.') + 1);
+              methodSignature.substring(
+                  methodSignature.lastIndexOf('.', methodSignature.indexOf('(')) + 1);
           if (!currentMethodName.equals(potentialSuperMethodName)) {
             continue;
           }
           if (potentialSuperMethod.getDeclaration().isAbstract()) {
             // These classes are beyond our control. It's better to retain the implementations of
-            // all
-            // abstract methods to ensure the code remains compilable.
+            // all abstract methods to ensure the code remains compilable.
             if (JavaLangUtils.inJdkPackage(methodSignature)) {
               return true;
             }

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -129,13 +129,14 @@ public class MustImplementMethodsVisitor extends SpeciminStateVisitor {
     // The parent method is abstract, we should continue upwards
 
     ResolvedMethodDeclaration resolvedMethod;
+    String currentMethodSignature;
     try {
       resolvedMethod = method.resolve();
+      currentMethodSignature = resolvedMethod.getQualifiedSignature();
     } catch (UnsolvedSymbolException ex) {
       return false;
     }
 
-    String currentMethodSignature = resolvedMethod.getQualifiedSignature();
     String currentMethodName =
         currentMethodSignature.substring(currentMethodSignature.lastIndexOf('.') + 1);
 

--- a/src/main/java/org/checkerframework/specimin/SpeciminStateVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminStateVisitor.java
@@ -229,9 +229,10 @@ public abstract class SpeciminStateVisitor extends ModifierVisitor<Void> {
   }
 
   /**
-   * Determines if the given Node is a target/used method or class.
+   * Determines if the given Node is a target/used member or class.
    *
    * @param node The node to check
+   * @return true iff the given Node is a target/used member or type.
    */
   protected boolean isTargetOrUsed(Node node) {
     String qualifiedName;

--- a/src/test/java/org/checkerframework/specimin/Issue103Test.java
+++ b/src/test/java/org/checkerframework/specimin/Issue103Test.java
@@ -1,0 +1,19 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+/** This test checks if Specimin will preserve ancestors of types added in MustImplementMethodsVisitor. 
+ * It also checks to see if methods whose direct override is abstract, but original definition is JDK
+ * are preserved. Test code derived from a modified, minimized version of NullAway issue 103. 
+*/
+public class Issue103Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "issue103",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#foo()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/Issue103Test.java
+++ b/src/test/java/org/checkerframework/specimin/Issue103Test.java
@@ -1,13 +1,14 @@
 package org.checkerframework.specimin;
 
 import java.io.IOException;
-
 import org.junit.Test;
 
-/** This test checks if Specimin will preserve ancestors of types added in MustImplementMethodsVisitor. 
- * It also checks to see if methods whose direct override is abstract, but original definition is JDK
- * are preserved. Test code derived from a modified, minimized version of NullAway issue 103. 
-*/
+/**
+ * This test checks if Specimin will preserve ancestors of types added in
+ * MustImplementMethodsVisitor. It also checks to see if methods whose direct override is abstract,
+ * but original definition is JDK are preserved. Test code derived from a modified, minimized
+ * version of NullAway issue 103.
+ */
 public class Issue103Test {
   @Test
   public void runTest() throws IOException {

--- a/src/test/resources/issue103/expected/com/example/AbstractLinkedDeque.java
+++ b/src/test/resources/issue103/expected/com/example/AbstractLinkedDeque.java
@@ -1,0 +1,121 @@
+package com.example;
+
+import java.util.AbstractCollection;
+import java.util.Collection;
+
+public abstract class AbstractLinkedDeque<E> extends AbstractCollection<E> implements LinkedDeque<E> {
+
+    public boolean isEmpty() {
+        throw new Error();
+    }
+
+    public int size() {
+        throw new Error();
+    }
+
+    public void clear() {
+        throw new Error();
+    }
+
+    public abstract boolean contains(Object o);
+
+    public E peek() {
+        throw new Error();
+    }
+
+    public E peekFirst() {
+        throw new Error();
+    }
+
+    public E peekLast() {
+        throw new Error();
+    }
+
+    public E getFirst() {
+        throw new Error();
+    }
+
+    public E getLast() {
+        throw new Error();
+    }
+
+    public E element() {
+        throw new Error();
+    }
+
+    public boolean offer(E e) {
+        throw new Error();
+    }
+
+    public boolean offerFirst(E e) {
+        throw new Error();
+    }
+
+    public boolean offerLast(E e) {
+        throw new Error();
+    }
+
+    public boolean add(E e) {
+        throw new Error();
+    }
+
+    public void addFirst(E e) {
+        throw new Error();
+    }
+
+    public void addLast(E e) {
+        throw new Error();
+    }
+
+    public E poll() {
+        throw new Error();
+    }
+
+    public E pollFirst() {
+        throw new Error();
+    }
+
+    public E pollLast() {
+        throw new Error();
+    }
+
+    public E remove() {
+        throw new Error();
+    }
+
+    public E removeFirst() {
+        throw new Error();
+    }
+
+    public boolean removeFirstOccurrence(Object o) {
+        throw new Error();
+    }
+
+    public E removeLast() {
+        throw new Error();
+    }
+
+    public boolean removeLastOccurrence(Object o) {
+        throw new Error();
+    }
+
+    public boolean removeAll(Collection<?> c) {
+        throw new Error();
+    }
+
+    public void push(E e) {
+        throw new Error();
+    }
+
+    public E pop() {
+        throw new Error();
+    }
+
+    public PeekingIterator<E> iterator() {
+        throw new Error();
+    }
+
+    public PeekingIterator<E> descendingIterator() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/issue103/expected/com/example/AbstractLinkedDeque.java
+++ b/src/test/resources/issue103/expected/com/example/AbstractLinkedDeque.java
@@ -8,8 +8,6 @@ public abstract class AbstractLinkedDeque<E> extends AbstractCollection<E> imple
         throw new Error();
     }
 
-    public abstract boolean contains(Object o);
-
     public E peek() {
         throw new Error();
     }

--- a/src/test/resources/issue103/expected/com/example/AbstractLinkedDeque.java
+++ b/src/test/resources/issue103/expected/com/example/AbstractLinkedDeque.java
@@ -1,19 +1,10 @@
 package com.example;
 
 import java.util.AbstractCollection;
-import java.util.Collection;
 
 public abstract class AbstractLinkedDeque<E> extends AbstractCollection<E> implements LinkedDeque<E> {
 
-    public boolean isEmpty() {
-        throw new Error();
-    }
-
     public int size() {
-        throw new Error();
-    }
-
-    public void clear() {
         throw new Error();
     }
 
@@ -55,10 +46,6 @@ public abstract class AbstractLinkedDeque<E> extends AbstractCollection<E> imple
         throw new Error();
     }
 
-    public boolean add(E e) {
-        throw new Error();
-    }
-
     public void addFirst(E e) {
         throw new Error();
     }
@@ -96,10 +83,6 @@ public abstract class AbstractLinkedDeque<E> extends AbstractCollection<E> imple
     }
 
     public boolean removeLastOccurrence(Object o) {
-        throw new Error();
-    }
-
-    public boolean removeAll(Collection<?> c) {
         throw new Error();
     }
 

--- a/src/test/resources/issue103/expected/com/example/AccessOrderDeque.java
+++ b/src/test/resources/issue103/expected/com/example/AccessOrderDeque.java
@@ -7,8 +7,4 @@ public final class AccessOrderDeque<E> extends AbstractLinkedDeque<E> {
     public boolean contains(Object o) {
         throw new Error();
     }
-
-    public boolean remove(Object o) {
-        throw new Error();
-    }
 }

--- a/src/test/resources/issue103/expected/com/example/AccessOrderDeque.java
+++ b/src/test/resources/issue103/expected/com/example/AccessOrderDeque.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import java.util.Deque;
+
+public final class AccessOrderDeque<E> extends AbstractLinkedDeque<E> {
+
+    public boolean contains(Object o) {
+        throw new Error();
+    }
+
+    public boolean remove(Object o) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/issue103/expected/com/example/AccessOrderDeque.java
+++ b/src/test/resources/issue103/expected/com/example/AccessOrderDeque.java
@@ -3,8 +3,4 @@ package com.example;
 import java.util.Deque;
 
 public final class AccessOrderDeque<E> extends AbstractLinkedDeque<E> {
-
-    public boolean contains(Object o) {
-        throw new Error();
-    }
 }

--- a/src/test/resources/issue103/expected/com/example/LinkedDeque.java
+++ b/src/test/resources/issue103/expected/com/example/LinkedDeque.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import java.util.Deque;
+import java.util.Iterator;
+
+public interface LinkedDeque<E> extends Deque<E> {
+
+    interface PeekingIterator<E> extends Iterator<E> {
+    }
+}

--- a/src/test/resources/issue103/expected/com/example/Simple.java
+++ b/src/test/resources/issue103/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public class Simple<K> {
+
+    AccessOrderDeque<K> bar() {
+        throw new Error();
+    }
+
+    void foo() {
+        AccessOrderDeque<K> x = bar();
+    }
+}

--- a/src/test/resources/issue103/input/com/example/AbstractLinkedDeque.java
+++ b/src/test/resources/issue103/input/com/example/AbstractLinkedDeque.java
@@ -1,0 +1,121 @@
+package com.example;
+
+import java.util.AbstractCollection;
+import java.util.Collection;
+
+public abstract class AbstractLinkedDeque<E> extends AbstractCollection<E> implements LinkedDeque<E> {
+
+    public boolean isEmpty() {
+        throw new Error();
+    }
+
+    public int size() {
+        throw new Error();
+    }
+
+    public void clear() {
+        throw new Error();
+    }
+
+    public abstract boolean contains(Object o);
+
+    public E peek() {
+        throw new Error();
+    }
+
+    public E peekFirst() {
+        throw new Error();
+    }
+
+    public E peekLast() {
+        throw new Error();
+    }
+
+    public E getFirst() {
+        throw new Error();
+    }
+
+    public E getLast() {
+        throw new Error();
+    }
+
+    public E element() {
+        throw new Error();
+    }
+
+    public boolean offer(E e) {
+        throw new Error();
+    }
+
+    public boolean offerFirst(E e) {
+        throw new Error();
+    }
+
+    public boolean offerLast(E e) {
+        throw new Error();
+    }
+
+    public boolean add(E e) {
+        throw new Error();
+    }
+
+    public void addFirst(E e) {
+        throw new Error();
+    }
+
+    public void addLast(E e) {
+        throw new Error();
+    }
+
+    public E poll() {
+        throw new Error();
+    }
+
+    public E pollFirst() {
+        throw new Error();
+    }
+
+    public E pollLast() {
+        throw new Error();
+    }
+
+    public E remove() {
+        throw new Error();
+    }
+
+    public E removeFirst() {
+        throw new Error();
+    }
+
+    public boolean removeFirstOccurrence(Object o) {
+        throw new Error();
+    }
+
+    public E removeLast() {
+        throw new Error();
+    }
+
+    public boolean removeLastOccurrence(Object o) {
+        throw new Error();
+    }
+
+    public boolean removeAll(Collection<?> c) {
+        throw new Error();
+    }
+
+    public void push(E e) {
+        throw new Error();
+    }
+
+    public E pop() {
+        throw new Error();
+    }
+
+    public PeekingIterator<E> iterator() {
+        throw new Error();
+    }
+
+    public PeekingIterator<E> descendingIterator() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/issue103/input/com/example/AccessOrderDeque.java
+++ b/src/test/resources/issue103/input/com/example/AccessOrderDeque.java
@@ -1,0 +1,30 @@
+package com.example;
+
+import java.util.Deque;
+
+public final class AccessOrderDeque<E> extends AbstractLinkedDeque<E> {
+
+    public boolean contains(Object o) {
+        throw new Error();
+    }
+
+    public boolean remove(Object o) {
+        throw new Error();
+    }
+
+    public E getPrevious(E e) {
+        throw new Error();
+    }
+
+    public void setPrevious(E e, E prev) {
+        throw new Error();
+    }
+
+    public E getNext(E e) {
+        throw new Error();
+    }
+
+    public void setNext(E e, E next) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/issue103/input/com/example/LinkedDeque.java
+++ b/src/test/resources/issue103/input/com/example/LinkedDeque.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import java.util.Deque;
+import java.util.Iterator;
+
+public interface LinkedDeque<E> extends Deque<E> {
+
+    interface PeekingIterator<E> extends Iterator<E> {
+    }
+}

--- a/src/test/resources/issue103/input/com/example/Simple.java
+++ b/src/test/resources/issue103/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public class Simple<K> {
+    AccessOrderDeque<K> bar() {
+        throw new Error();
+    }
+
+    // Target method
+    void foo() {
+        AccessOrderDeque<K> x = bar();
+    }
+}


### PR DESCRIPTION
This PR addresses an issue I found in [NullAway issue #103](https://github.com/uber/NullAway/issues/103), where compile-time errors were caused by missing methods and types. The missing methods were caused by the following:

**1) Methods not preserved**

Foo extends (abstract) Bar extends [Some JDK interface]

If Bar contains an abstract method also present in the JDK interface, those implementations in Foo were removed while the abstract definition was maintained in Bar, causing compile-time errors. A check was added to ensure that all super abstract methods did not contain anything that needed to be preserved (i.e. when in Foo, instead of just checking Bar, we check Bar and the JDK interface).

**2. Classes not preserved**

If a non-target class needs its method implementations to be preserved, and some of its return/parameter types are solvable but were untracked so far by `usedTypeElements`, their ancestors were not preserved. For example, if a method visited by `MustImplementMethodsVisitor` is of type `PeekingIterator<E>` which extends `Iterator<E>`, the `extends Iterator<E>` portion is kept in the original definition but its import statement was removed, leading to compile-time errors. The new approach to this is, if a type element was not previously in `usedTypeElements`, all of its ancestors (interfaces and super classes) would also be marked for preservation.

A test case can be found in `Issue103Test`.

Thanks!