### PR TITLE
Fix ability to target constructors with arguments

### DIFF
--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -196,6 +196,8 @@ public class TargetMethodFinderVisitor extends SpeciminStateVisitor {
     String constructorMethodAsString = method.getDeclarationAsString(false, false, false);
     // the methodName will be something like this: "com.example.Car#Car()"
     String methodName = this.currentClassQualifiedName + "#" + constructorMethodAsString;
+    // remove spaces
+    methodName = methodName.replaceAll("\\s", "");
     if (this.targetMethodNames.contains(methodName)) {
       ResolvedConstructorDeclaration resolvedMethod = method.resolve();
       targetMethods.add(resolvedMethod.getQualifiedSignature());

--- a/src/test/java/org/checkerframework/specimin/CtorTargetTest.java
+++ b/src/test/java/org/checkerframework/specimin/CtorTargetTest.java
@@ -1,0 +1,15 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks that Specimin can successfully target a constructor. */
+public class CtorTargetTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "ctortarget",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#Simple(Foo, int)"});
+  }
+}

--- a/src/test/resources/ctortarget/expected/com/example/Foo.java
+++ b/src/test/resources/ctortarget/expected/com/example/Foo.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public class Foo {
+
+}

--- a/src/test/resources/ctortarget/expected/com/example/Simple.java
+++ b/src/test/resources/ctortarget/expected/com/example/Simple.java
@@ -1,0 +1,7 @@
+package com.example;
+
+class Simple {
+    private Simple(Foo foo, int x) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/ctortarget/input/com/example/Foo.java
+++ b/src/test/resources/ctortarget/input/com/example/Foo.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public class Foo {
+
+}

--- a/src/test/resources/ctortarget/input/com/example/Simple.java
+++ b/src/test/resources/ctortarget/input/com/example/Simple.java
@@ -1,0 +1,7 @@
+package com.example;
+
+class Simple {
+    private Simple(Foo foo, int x) {
+        throw new Error();
+    }
+}


### PR DESCRIPTION
Was broken by #325, I think. We should have had a test for this. Should fix the issue @theron-wang observed with na-323 and na-347, which both require a constructor with an argument to be targeted.