### PR TITLE
Functional interfaces should not include a method if it's not used

### DIFF
--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -335,6 +335,14 @@ public class PrunerVisitor extends SpeciminStateVisitor {
       return super.visit(methodDecl, p);
     }
 
+    if (insideFunctionalInterface && usedMembers.contains(signature)) {
+      if (methodDecl.getBody().isPresent()) {
+        // avoid introducing unsolved symbols into the final output.
+        methodDecl.setBody(StaticJavaParser.parseBlock("{ throw new Error(); }"));
+      }
+      return methodDecl;
+    }
+
     if (usedMembers.contains(signature) || isAResolvedYetStuckMethod(methodDecl)) {
       boolean isMethodInsideInterface = isInsideInterface(methodDecl);
       // do nothing if methodDecl is just a method signature in a class.
@@ -344,14 +352,6 @@ public class PrunerVisitor extends SpeciminStateVisitor {
         if (isMethodInsideInterface && !methodDecl.isStatic()) {
           methodDecl.setDefault(true);
         }
-      }
-      return methodDecl;
-    }
-
-    if (insideFunctionalInterface && usedMembers.contains(signature)) {
-      if (methodDecl.getBody().isPresent()) {
-        // avoid introducing unsolved symbols into the final output.
-        methodDecl.setBody(StaticJavaParser.parseBlock("{ throw new Error(); }"));
       }
       return methodDecl;
     }

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -348,7 +348,7 @@ public class PrunerVisitor extends SpeciminStateVisitor {
       return methodDecl;
     }
 
-    if (insideFunctionalInterface) {
+    if (insideFunctionalInterface && usedMembers.contains(signature)) {
       if (methodDecl.getBody().isPresent()) {
         // avoid introducing unsolved symbols into the final output.
         methodDecl.setBody(StaticJavaParser.parseBlock("{ throw new Error(); }"));

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.UnionType;
 import com.github.javaparser.ast.visitor.Visitable;
+import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedEnumConstantDeclaration;
@@ -470,6 +471,18 @@ public class TargetMethodFinderVisitor extends SpeciminStateVisitor {
         Expression arg = call.getArgument(i);
         if (arg.isLambdaExpr()) {
           updateUsedClassBasedOnType(decl.getParam(i).getType());
+          // We should mark the abstract method for preservation as well
+          if (decl.getParam(i).getType().isReferenceType()) {
+            ResolvedReferenceType functionalInterface =
+                decl.getParam(i).getType().asReferenceType();
+            for (MethodUsage method : functionalInterface.getDeclaredMethods()) {
+              if (method.getDeclaration().isAbstract()) {
+                preserveMethodDecl(method.getDeclaration());
+                // Only one abstract method per functional interface
+                break;
+              }
+            }
+          }
         }
       }
     }

--- a/src/test/java/org/checkerframework/specimin/UnusedFuncInterfaceMethodTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnusedFuncInterfaceMethodTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that if a functional interface has an unused method, it is removed, and if a
+ * synthetic functional interface method is generated, it is preserved.
+ */
+public class UnusedFuncInterfaceMethodTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unusedfuncinterfacemethod",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#foo()"});
+  }
+}

--- a/src/test/resources/unusedfuncinterfacemethod/expected/com/example/Bar.java
+++ b/src/test/resources/unusedfuncinterfacemethod/expected/com/example/Bar.java
@@ -1,0 +1,8 @@
+package com.example;
+
+public class Bar {
+
+    public static ComExampleBarUseReturnType use(SyntheticFunction4<?, ?, ?, ?, ?> parameter0) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/unusedfuncinterfacemethod/expected/com/example/ComExampleBarUseReturnType.java
+++ b/src/test/resources/unusedfuncinterfacemethod/expected/com/example/ComExampleBarUseReturnType.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public class ComExampleBarUseReturnType {
+}

--- a/src/test/resources/unusedfuncinterfacemethod/expected/com/example/FuncInterfaceUnused.java
+++ b/src/test/resources/unusedfuncinterfacemethod/expected/com/example/FuncInterfaceUnused.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public interface FuncInterfaceUnused {
+}

--- a/src/test/resources/unusedfuncinterfacemethod/expected/com/example/Simple.java
+++ b/src/test/resources/unusedfuncinterfacemethod/expected/com/example/Simple.java
@@ -1,0 +1,8 @@
+package com.example;
+
+public class Simple implements FuncInterfaceUnused {
+
+    public void foo() {
+        Bar.use((a, b, c, d) -> 0);
+    }
+}

--- a/src/test/resources/unusedfuncinterfacemethod/expected/com/example/SyntheticFunction4.java
+++ b/src/test/resources/unusedfuncinterfacemethod/expected/com/example/SyntheticFunction4.java
@@ -1,0 +1,6 @@
+package com.example;
+
+public interface SyntheticFunction4<T, T1, T2, T3, T4> {
+
+    public T4 apply(T parameter0, T1 parameter1, T2 parameter2, T3 parameter3);
+}

--- a/src/test/resources/unusedfuncinterfacemethod/input/com/example/FuncInterfaceUnused.java
+++ b/src/test/resources/unusedfuncinterfacemethod/input/com/example/FuncInterfaceUnused.java
@@ -1,0 +1,6 @@
+package com.example;
+
+@FunctionalInterface
+public interface FuncInterfaceUnused {
+    void shouldBeRemoved();
+}

--- a/src/test/resources/unusedfuncinterfacemethod/input/com/example/Simple.java
+++ b/src/test/resources/unusedfuncinterfacemethod/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+public class Simple implements FuncInterfaceUnused {
+    public void foo() {
+        Bar.use((a, b, c, d) -> 0);
+    }
+
+    public void shouldBeRemoved() {
+
+    }
+}


### PR DESCRIPTION
This PR fixes an issue present with na-791a where, even though a functional interface's method is not used, it is still being included in the output, causing compilation errors. Since the `@FunctionalInterface` annotation is removed, we should treat all interfaces equally.