### PR TITLE
Re-add support for target fields

### DIFF
--- a/src/main/java/org/checkerframework/specimin/InheritancePreserveVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/InheritancePreserveVisitor.java
@@ -69,7 +69,7 @@ public class InheritancePreserveVisitor extends ModifierVisitor<Void> {
           for (Type bound : tp.getTypeBound()) {
             String boundDesc = bound.resolve().describe();
             if (visitedBounds.add(boundDesc)) {
-              TargetMethodFinderVisitor.updateUsedClassWithQualifiedClassName(
+              TargetMemberFinderVisitor.updateUsedClassWithQualifiedClassName(
                   boundDesc, addedClasses, new HashMap<>());
             }
           }
@@ -82,11 +82,11 @@ public class InheritancePreserveVisitor extends ModifierVisitor<Void> {
           // especially if the superclass is nested within the current class file, resulting in
           // infinite file visits. The TargetMethodFinderVisitor already addresses the updating job
           // in such cases. (Refer to the SuperClass test for an example.)
-          TargetMethodFinderVisitor.updateUsedClassWithQualifiedClassName(
+          TargetMemberFinderVisitor.updateUsedClassWithQualifiedClassName(
               extendedType.resolve().describe(), addedClasses, new HashMap<>());
           if (extendedType.getTypeArguments().isPresent()) {
             for (Type typeArgument : extendedType.getTypeArguments().get()) {
-              TargetMethodFinderVisitor.updateUsedClassWithQualifiedClassName(
+              TargetMemberFinderVisitor.updateUsedClassWithQualifiedClassName(
                   typeArgument.resolve().describe(), addedClasses, new HashMap<>());
             }
           }
@@ -105,11 +105,11 @@ public class InheritancePreserveVisitor extends ModifierVisitor<Void> {
             // in practice. TODO: fix this up
             continue;
           }
-          TargetMethodFinderVisitor.updateUsedClassWithQualifiedClassName(
+          TargetMemberFinderVisitor.updateUsedClassWithQualifiedClassName(
               interfacename, addedClasses, new HashMap<>());
           if (implementedType.getTypeArguments().isPresent()) {
             for (Type typeAgrument : implementedType.getTypeArguments().get()) {
-              TargetMethodFinderVisitor.updateUsedClassWithQualifiedClassName(
+              TargetMemberFinderVisitor.updateUsedClassWithQualifiedClassName(
                   typeAgrument.resolve().describe(), addedClasses, new HashMap<>());
             }
           }

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -354,8 +354,8 @@ public class SpeciminRunner {
     // what specifications they use, and the second phase takes that information
     // and removes all non-used code.
 
-    TargetMethodFinderVisitor finder =
-        new TargetMethodFinderVisitor(enumVisitor, nonPrimaryClassesToPrimaryClass);
+    TargetMemberFinderVisitor finder =
+        new TargetMemberFinderVisitor(enumVisitor, nonPrimaryClassesToPrimaryClass);
 
     for (CompilationUnit cu : parsedTargetFiles.values()) {
       cu.accept(finder, null);
@@ -365,8 +365,16 @@ public class SpeciminRunner {
     if (!unfoundMethods.isEmpty()) {
       throw new RuntimeException(
           "Specimin could not locate the following target methods in the target files:\n"
-              + unfoundMethodsTable(unfoundMethods));
+              + unfoundMembersTable(unfoundMethods, true));
     }
+
+    Map<String, Set<String>> unfoundFields = finder.getUnfoundFields();
+    if (!unfoundFields.isEmpty()) {
+      throw new RuntimeException(
+          "Specimin could not locate the following target methods in the target files:\n"
+              + unfoundMembersTable(unfoundFields, false));
+    }
+
     SolveMethodOverridingVisitor solveMethodOverridingVisitor =
         new SolveMethodOverridingVisitor(finder);
     for (CompilationUnit cu : parsedTargetFiles.values()) {
@@ -589,20 +597,24 @@ public class SpeciminRunner {
   }
 
   /**
-   * Helper method to create a human-readable table of the unfound methods and each method in the
+   * Helper method to create a human-readable table of the unfound members and each member in the
    * same class that was considered.
    *
-   * @param unfoundMethods the unfound methods and the methods that were considered
+   * @param unfoundMembers the unfound members and the members that were considered
+   * @param isMethod true if methods, false if fields
    * @return a human-readable string representation
    */
-  private static String unfoundMethodsTable(Map<String, Set<String>> unfoundMethods) {
+  private static String unfoundMembersTable(
+      Map<String, Set<String>> unfoundMembers, boolean isMethod) {
     StringBuilder sb = new StringBuilder();
-    for (String unfoundMethod : unfoundMethods.keySet()) {
+    for (String unfoundMember : unfoundMembers.keySet()) {
       sb.append("* ")
-          .append(unfoundMethod)
-          .append("\n  Considered these methods from the same class:\n");
-      for (String consideredMethod : unfoundMethods.get(unfoundMethod)) {
-        sb.append("    * ").append(consideredMethod).append("\n");
+          .append(unfoundMember)
+          .append("\n  Considered these ")
+          .append(isMethod ? "methods" : "fields")
+          .append(" from the same class:\n");
+      for (String consideredMember : unfoundMembers.get(unfoundMember)) {
+        sb.append("    * ").append(consideredMember).append("\n");
       }
     }
     return sb.toString();

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -371,7 +371,7 @@ public class SpeciminRunner {
     Map<String, Set<String>> unfoundFields = finder.getUnfoundFields();
     if (!unfoundFields.isEmpty()) {
       throw new RuntimeException(
-          "Specimin could not locate the following target methods in the target files:\n"
+          "Specimin could not locate the following target fields in the target files:\n"
               + unfoundMembersTable(unfoundFields, false));
     }
 

--- a/src/main/java/org/checkerframework/specimin/SpeciminStateVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminStateVisitor.java
@@ -82,7 +82,7 @@ public abstract class SpeciminStateVisitor extends ModifierVisitor<Void> {
    * The fully-qualified names of each field that is assigned by a target constructor. The
    * assignments to these fields will be preserved, so Specimin needs to avoid adding an initializer
    * for them if they are final (as it does for other, non-assigned-by-target final fields). Set by
-   * {@link TargetMethodFinderVisitor} but stored here so that it is easily available later when
+   * {@link TargetMemberFinderVisitor} but stored here so that it is easily available later when
    * pruning.
    */
   protected final Set<String> fieldsAssignedByTargetCtors;

--- a/src/test/java/org/checkerframework/specimin/Issue298Test.java
+++ b/src/test/java/org/checkerframework/specimin/Issue298Test.java
@@ -7,7 +7,7 @@ import org.junit.Test;
  * This test is a simplified version of the problem described by <a
  * href="https://github.com/njit-jerse/specimin/issues/298">...</a>. The test is somewhat limited -
  * it triggers part of the problem, but not all of it: in particular, the small test case doesn't
- * trigger the "resolved yet stuck method call" code in {@link TargetMethodFinderVisitor}, which is
+ * trigger the "resolved yet stuck method call" code in {@link TargetMemberFinderVisitor}, which is
  * part of the real bug.
  */
 public class Issue298Test {

--- a/src/test/java/org/checkerframework/specimin/TargetFieldTest.java
+++ b/src/test/java/org/checkerframework/specimin/TargetFieldTest.java
@@ -8,7 +8,7 @@ public class TargetFieldTest {
   @Test
   public void runTest() throws IOException {
     SpeciminTestExecutor.runTestWithoutJarPaths(
-        "targetfield",
+        "targetField",
         new String[] {"com/example/Simple.java"},
         new String[] {"com.example.Simple#unsolvedField"});
   }

--- a/src/test/java/org/checkerframework/specimin/TargetFieldTest.java
+++ b/src/test/java/org/checkerframework/specimin/TargetFieldTest.java
@@ -1,0 +1,15 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks if Specimin will preserve target fields. */
+public class TargetFieldTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "targetfield",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#unsolvedField"});
+  }
+}


### PR DESCRIPTION
While looking into na-705, I found that Specimin ignored target fields introduced in #247, possibly when we were refactoring. The original test case `TargetField` was also not included in the original PR, so I included the test for the CI. This PR doesn't fix the issue present in na-705, however.