### PR TITLE
include `java/` files in output if they are targeted

### DIFF
--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -461,10 +461,20 @@ public class SpeciminRunner {
 
     // cache to avoid called Files.createDirectories repeatedly with the same arguments
     Set<Path> createdDirectories = new HashSet<>();
+    Set<String> targetFilesAbsolutePaths = new HashSet<>();
+
+    for (String target : targetFiles) {
+      File targetFile = new File(target);
+      // Convert to absolute path for comparison
+      targetFilesAbsolutePaths.add(targetFile.getAbsolutePath());
+    }
 
     for (Entry<String, CompilationUnit> target : parsedTargetFiles.entrySet()) {
-      // ignore classes from the Java package.
-      if (target.getKey().startsWith("java/")) {
+      // ignore classes from the Java package, unless we are targeting a JDK file.
+      // However, all related java/ files should not be included (as in used, but not targeted)
+      String absolutePath = new File(target.getKey()).getAbsolutePath();
+      if (!targetFilesAbsolutePaths.contains(absolutePath)
+          && (target.getKey().startsWith("java/") || target.getKey().startsWith("java\\"))) {
         continue;
       }
       // If a compilation output's entire body has been removed and the related class is not used by

--- a/src/main/resources/preservation_status.json
+++ b/src/main/resources/preservation_status.json
@@ -20,7 +20,7 @@
   "jdk-8319461": "PASS",
   "jdk-8288590": "PASS",
   "na-89": "FAIL",
-  "na-97": "FAIL",
+  "na-97": "PASS",
   "na-102": "PASS",
   "na-103": "PASS",
   "na-176": "FAIL",


### PR DESCRIPTION
In na-97, where we target a `java/` file, the targeted file (`java/util/atomic/concurrent/Striped64.java`, I believe) was being excluded from the output because of these lines in `SpeciminRunner`:

```java
if (target.getKey().startsWith("java/")) {
    continue;
}
```

The reason it worked on Windows was probably because Windows uses backslashes, and it didn't work on Unix because of the forward slash comparison here. I changed it so that the target file is preserved in the output no matter what, even if it starts with `java/` (or `java\`). This should make na-97 work on both OSes.

I didn't include a test case for this, since NullAway bugs are now in the evaluation script, but if you'd like, I could add one. Thanks!