### PR TITLE
Call the correct generic "solve a type" method in UnsolvedSymbolVisitor when using the NA modularity model

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1008,13 +1008,8 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
             (ClassOrInterfaceDeclaration) JavaParserUtil.getEnclosingClassLike(node);
         for (FieldDeclaration field : thisClass.getFields()) {
           for (VariableDeclarator variable : field.getVariables()) {
-            if (variable.getType().isClassOrInterfaceType()) {
-              solveSymbolsForClassOrInterfaceType(
-                  variable.getType().asClassOrInterfaceType(), false);
-            } else {
-              throw new RuntimeException(
-                  "fields can also have this type: " + variable.getType().getClass());
-            }
+            Type type = variable.getType();
+            resolveTypeExpr(type);
           }
         }
       }

--- a/src/main/resources/preservation_status.json
+++ b/src/main/resources/preservation_status.json
@@ -24,7 +24,7 @@
   "na-102": "PASS",
   "na-103": "PASS",
   "na-176": "PASS",
-  "na-323": "FAIL",
+  "na-323": "PASS",
   "na-347": "PASS",
   "na-389": "PASS",
   "na-705": "FAIL",

--- a/src/test/resources/nullaway-ctors/expected/com/example/Simple.java
+++ b/src/test/resources/nullaway-ctors/expected/com/example/Simple.java
@@ -5,6 +5,8 @@ class Simple {
 
     private Foo bar;
 
+    private int x;
+
     public Simple() {
     }
 }

--- a/src/test/resources/nullaway-ctors/input/com/example/Simple.java
+++ b/src/test/resources/nullaway-ctors/input/com/example/Simple.java
@@ -5,6 +5,8 @@ class Simple {
 
     private Foo bar;
 
+    private int x;
+
     public Simple() {
         // No initialization of a field can change NullAway's output,
         // so the NullAway modularity model needs to preserve all fields


### PR DESCRIPTION
This fixes NA-347 (with the modularity model changes in specimin-evaluation#9)