### PR TITLE
Remove extra `ElementType`s in all synthetic annotations

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
@@ -471,18 +471,9 @@ public class UnsolvedClassOrInterface {
       sb.append(
           "@java.lang.annotation.Target({ \n"
               + "\tjava.lang.annotation.ElementType.TYPE, \n"
-              + "\tjava.lang.annotation.ElementType.FIELD, \n"
               + "\tjava.lang.annotation.ElementType.METHOD, \n"
-              + "\tjava.lang.annotation.ElementType.PARAMETER, \n"
-              + "\tjava.lang.annotation.ElementType.CONSTRUCTOR, \n"
-              + "\tjava.lang.annotation.ElementType.LOCAL_VARIABLE, \n"
-              + "\tjava.lang.annotation.ElementType.ANNOTATION_TYPE,\n"
-              + "\tjava.lang.annotation.ElementType.PACKAGE,\n"
               + "\tjava.lang.annotation.ElementType.TYPE_USE \n"
               + "})\n");
-      // We should retain these annotations in runtime (as it includes both CLASS and SOURCE)
-      // in case a type checker like NullAway requires it
-      sb.append("@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)\n");
     }
 
     sb.append("public ");

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
@@ -479,10 +479,10 @@ public class UnsolvedClassOrInterface {
               + "\tjava.lang.annotation.ElementType.ANNOTATION_TYPE,\n"
               + "\tjava.lang.annotation.ElementType.PACKAGE,\n"
               + "\tjava.lang.annotation.ElementType.TYPE_USE \n"
-              + "})");
+              + "})\n");
       // We should retain these annotations in runtime (as it includes both CLASS and SOURCE)
       // in case a type checker like NullAway requires it
-      sb.append("@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)");
+      sb.append("@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)\n");
     }
 
     sb.append("public ");

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
@@ -1,15 +1,17 @@
 package org.checkerframework.specimin;
 
-import com.google.common.base.Splitter;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
+
+import com.google.common.base.Splitter;
 
 /**
  * An UnsolvedClassOrInterface instance is a representation of a class or an interface that can not
@@ -478,6 +480,9 @@ public class UnsolvedClassOrInterface {
               + "\tjava.lang.annotation.ElementType.PACKAGE,\n"
               + "\tjava.lang.annotation.ElementType.TYPE_USE \n"
               + "})");
+      // We should retain these annotations in runtime (as it includes both CLASS and SOURCE)
+      // in case a type checker like NullAway requires it
+      sb.append("@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)");
     }
 
     sb.append("public ");

--- a/src/main/resources/preservation_status.json
+++ b/src/main/resources/preservation_status.json
@@ -27,7 +27,7 @@
   "na-323": "PASS",
   "na-347": "PASS",
   "na-389": "PASS",
-  "na-705": "FAIL",
+  "na-705": "PASS",
   "na-791a": "PASS",
   "na-791b": "FAIL"
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.initialization.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Initialized {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.initialization.qual;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface Initialized {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/KeyForBottom.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/KeyForBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.nullness.qual;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface KeyForBottom {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/KeyForBottom.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/KeyForBottom.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface KeyForBottom {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface NonNull {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.nullness.qual;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface NonNull {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/Nullable.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/Nullable.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Nullable {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/Nullable.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/Nullable.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.nullness.qual;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface Nullable {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.nullness.qual;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface UnknownKeyFor {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface UnknownKeyFor {
 }

--- a/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
@@ -1,7 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface PostconditionAnnotation {
 
 }

--- a/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
@@ -1,6 +1,7 @@
 package com.example;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface PostconditionAnnotation {
 
 }

--- a/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
@@ -1,6 +1,7 @@
 package com.example;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface PreconditionAnnotation {
 
 }

--- a/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
@@ -1,7 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface PreconditionAnnotation {
 
 }

--- a/src/test/resources/syntheticannotations/expected/com/example/Anno.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Anno.java
@@ -1,6 +1,7 @@
 package com.example;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface Anno {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Anno.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Anno.java
@@ -1,7 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Anno {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Bar.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Bar.java
@@ -1,6 +1,7 @@
 package com.example;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface Bar {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Bar.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Bar.java
@@ -1,7 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Bar {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Baz.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Baz.java
@@ -1,6 +1,7 @@
 package com.example;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface Baz {
 
     public String foo();

--- a/src/test/resources/syntheticannotations/expected/com/example/Baz.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Baz.java
@@ -1,7 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Baz {
 
     public String foo();

--- a/src/test/resources/syntheticannotations/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Foo.java
@@ -1,7 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Foo {
 
     public Deprecated x();

--- a/src/test/resources/syntheticannotations/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Foo.java
@@ -1,6 +1,7 @@
 package com.example;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface Foo {
 
     public Deprecated x();

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Foo.java
@@ -1,5 +1,6 @@
 package com.example;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 public @interface Foo {
 }

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Foo.java
@@ -1,6 +1,5 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Foo {
 }


### PR DESCRIPTION
This change allows na-705 to be reproducible. I discovered this one change was able to reproduce the error when running Specimin with `--jarPath path/to/checker-qual.jar`. ~~Since `@Retention(RetentionPolicy.RUNTIME)` is the most generous, it should work for all cases (i.e. `CLASS` and `SOURCE`).~~ (see comment below)