### PR TITLE
Remove unused imports

### DIFF
--- a/src/main/java/org/checkerframework/specimin/AnnotationParameterTypesVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/AnnotationParameterTypesVisitor.java
@@ -28,8 +28,7 @@ import java.util.Set;
  */
 public class AnnotationParameterTypesVisitor extends SpeciminStateVisitor {
   /**
-   * Constructs a new SolveMethodOverridingVisitor with the provided sets of target methods, used
-   * members, and used classes.
+   * Constructs a new AnnotationParameterTypesVisitor with the previous visitor
    *
    * @param previousVisitor the last visitor to run before this one
    */

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -55,6 +55,17 @@ public class JavaParserUtil {
   }
 
   /**
+   * This method checks if a string is capitalized
+   *
+   * @param string the string to be checked
+   * @return true if the string is capitalized
+   */
+  public static boolean isCapital(String string) {
+    Character first = string.charAt(0);
+    return Character.isUpperCase(first);
+  }
+
+  /**
    * Utility method to check if the given declaration is a local class declaration.
    *
    * @param decl a class, interface, or enum declaration

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -55,6 +55,21 @@ public class JavaParserUtil {
   }
 
   /**
+   * This method checks if a string has the form of a class path.
+   *
+   * @param potentialClassPath the string to be checked
+   * @return true if the string is a class path
+   */
+  public static boolean isAClassPath(String potentialClassPath) {
+    List<String> elements = Splitter.onPattern("\\.").splitToList(potentialClassPath);
+    int elementsCount = elements.size();
+    return elementsCount > 1
+        && isCapital(elements.get(elementsCount - 1))
+        // Classpaths cannot contain spaces!
+        && elements.stream().noneMatch(s -> s.contains(" "));
+  }
+
+  /**
    * This method checks if a string is capitalized
    *
    * @param string the string to be checked

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -500,6 +500,8 @@ public class SpeciminRunner {
       cu.accept(methodPruner, null);
     }
 
+    removeUnusedImports(parsedTargetFiles);
+
     // cache to avoid called Files.createDirectories repeatedly with the same arguments
     Set<Path> createdDirectories = new HashSet<>();
     Set<String> targetFilesAbsolutePaths = new HashSet<>();
@@ -645,6 +647,20 @@ public class SpeciminRunner {
       annotationParameterTypesVisitor.getClassesToAdd().clear();
     }
     return annotationParameterTypesVisitor;
+  }
+
+  /**
+   * Removes all unused imports in each output file through {@code UnusedImportRemoverVisitor}.
+   *
+   * @param parsedTargetFiles the files to remove unused imports
+   */
+  private static void removeUnusedImports(Map<String, CompilationUnit> parsedTargetFiles) {
+    UnusedImportRemoverVisitor unusedImportRemover = new UnusedImportRemoverVisitor();
+
+    for (CompilationUnit cu : parsedTargetFiles.values()) {
+      cu.accept(unusedImportRemover, null);
+      unusedImportRemover.removeUnusedImports();
+    }
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/TargetMemberFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMemberFinderVisitor.java
@@ -514,7 +514,7 @@ public class TargetMemberFinderVisitor extends SpeciminStateVisitor {
               // a call to a fully-qualified static method) or the scope is a simple name.
               // In the simple name case, append the current package to the front, since
               // if it had been imported we wouldn't be in this situation.
-              if (UnsolvedSymbolVisitor.isAClassPath(scopeAsString)) {
+              if (JavaParserUtil.isAClassPath(scopeAsString)) {
                 resolvedYetStuckMethodCall.add(scopeAsString + "." + call.getNameAsString());
                 usedTypeElements.add(scopeAsString);
               } else {
@@ -869,7 +869,7 @@ public class TargetMemberFinderVisitor extends SpeciminStateVisitor {
 
     String potentialOuterClass =
         qualifiedClassName.substring(0, qualifiedClassName.lastIndexOf("."));
-    if (UnsolvedSymbolVisitor.isAClassPath(potentialOuterClass)) {
+    if (JavaParserUtil.isAClassPath(potentialOuterClass)) {
       updateUsedClassWithQualifiedClassName(
           potentialOuterClass, usedTypeElement, nonPrimaryClassesToPrimaryClass);
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedAnnotationRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedAnnotationRemoverVisitor.java
@@ -114,7 +114,7 @@ public class UnsolvedAnnotationRemoverVisitor extends ModifierVisitor<Void> {
       isResolved = false;
     }
 
-    if (!UnsolvedSymbolVisitor.isAClassPath(annotationName)) {
+    if (!JavaParserUtil.isAClassPath(annotationName)) {
       if (!classToFullClassName.containsKey(annotationName)) {
         // An annotation not imported and from the java.lang package is not our concern.
         if (!JavaLangUtils.isJavaLangName(annotationName)) {

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
@@ -324,7 +324,7 @@ public class UnsolvedClassOrInterface {
           || "java.lang.annotation.Annotation".equals(extendsName)) {
         setIsAnAnnotationToTrue();
       } else {
-        if (!UnsolvedSymbolVisitor.isAClassPath(extendsName)) {
+        if (!JavaParserUtil.isAClassPath(extendsName)) {
           extendsName = visitor.getPackageFromClassName(extendsName) + "." + extendsName;
         }
         extend(extendsName);

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1086,7 +1086,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
     } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
       // for a qualified name field access such as org.sample.MyClass.field, org.sample will also be
       // considered FieldAccessExpr.
-      if (isAClassPath(node.getScope().toString())) {
+      if (JavaParserUtil.isAClassPath(node.getScope().toString())) {
         gotException();
       }
     }
@@ -1101,7 +1101,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
       if (scope.isTypeExpr()) {
         Type scopeAsType = scope.asTypeExpr().getType();
         String scopeAsTypeFQN = scopeAsType.asString();
-        if (!isAClassPath(scopeAsTypeFQN) && scopeAsType.isClassOrInterfaceType()) {
+        if (!JavaParserUtil.isAClassPath(scopeAsTypeFQN) && scopeAsType.isClassOrInterfaceType()) {
           scopeAsTypeFQN =
               getQualifiedNameForClassOrInterfaceType(scopeAsType.asClassOrInterfaceType());
         }
@@ -1416,7 +1416,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
 
     UnsolvedClassOrInterface unsolvedAnnotation;
 
-    if (isAClassPath(anno.getNameAsString())) {
+    if (JavaParserUtil.isAClassPath(anno.getNameAsString())) {
       @SuppressWarnings("signature") // Already guaranteed to be a FQN here
       @FullyQualifiedName String qualifiedTypeName = anno.getNameAsString();
       unsolvedAnnotation = getSimpleSyntheticClassFromFullyQualifiedName(qualifiedTypeName);
@@ -1463,7 +1463,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
 
     UnsolvedClassOrInterface unsolvedAnnotation;
 
-    if (isAClassPath(anno.getNameAsString())) {
+    if (JavaParserUtil.isAClassPath(anno.getNameAsString())) {
       @SuppressWarnings("signature") // Already guaranteed to be a FQN here
       @FullyQualifiedName String qualifiedTypeName = anno.getNameAsString();
       unsolvedAnnotation = getSimpleSyntheticClassFromFullyQualifiedName(qualifiedTypeName);
@@ -1520,7 +1520,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
 
     UnsolvedClassOrInterface unsolvedAnnotation;
 
-    if (isAClassPath(anno.getNameAsString())) {
+    if (JavaParserUtil.isAClassPath(anno.getNameAsString())) {
       @SuppressWarnings("signature") // Already guaranteed to be a FQN here
       @FullyQualifiedName String qualifiedTypeName = anno.getNameAsString();
       unsolvedAnnotation = getSimpleSyntheticClassFromFullyQualifiedName(qualifiedTypeName);
@@ -1712,7 +1712,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
     }
 
     String packageName, className;
-    if (isAClassPath(typeRawName)) {
+    if (JavaParserUtil.isAClassPath(typeRawName)) {
       // Two cases: this could be either an Outer.Inner pair or it could
       // be a fully-qualified name. If it's an Outer.Inner pair, we identify
       // that via the heuristic that there are only two elements if we split on
@@ -3075,21 +3075,6 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
   }
 
   /**
-   * This method checks if a string has the form of a class path.
-   *
-   * @param potentialClassPath the string to be checked
-   * @return true if the string is a class path
-   */
-  public static boolean isAClassPath(String potentialClassPath) {
-    List<String> elements = Splitter.onPattern("\\.").splitToList(potentialClassPath);
-    int elementsCount = elements.size();
-    return elementsCount > 1
-        && JavaParserUtil.isCapital(elements.get(elementsCount - 1))
-        // Classpaths cannot contain spaces!
-        && elements.stream().noneMatch(s -> s.contains(" "));
-  }
-
-  /**
    * Given the name of a class in the @FullyQualifiedName, this method will create a synthetic class
    * for that class
    *
@@ -3098,9 +3083,9 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
    */
   public static UnsolvedClassOrInterface getSimpleSyntheticClassFromFullyQualifiedName(
       @FullyQualifiedName String fullyName) {
-    if (!isAClassPath(fullyName)) {
+    if (!JavaParserUtil.isAClassPath(fullyName)) {
       throw new RuntimeException(
-          "Check with isAClassPath first before using"
+          "Check with JavaParserUtil.isAClassPath first before using"
               + " getSimpleSyntheticClassFromFullyQualifiedName. Non-classpath-like name: "
               + fullyName);
     }
@@ -3202,7 +3187,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
         return false;
       }
       String callerToString = callerExpression.get().toString();
-      return isAClassPath(callerToString);
+      return JavaParserUtil.isAClassPath(callerToString);
     }
   }
 
@@ -3217,7 +3202,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
    */
   public boolean isAQualifiedFieldSignature(String field) {
     String caller = field.substring(0, field.lastIndexOf("."));
-    return isAClassPath(caller);
+    return JavaParserUtil.isAClassPath(caller);
   }
 
   /**
@@ -3645,7 +3630,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
         fullyQualifiedName.append("? extends ");
         lookupTypeArgumentFQN(fullyQualifiedName, asWildcardType.getExtendedType().get());
       }
-    } else if (isAClassPath(erased)) {
+    } else if (JavaParserUtil.isAClassPath(erased)) {
       // If it's already a fully qualified name, don't do anything
       fullyQualifiedName.append(typeArgument.asString());
     } else {

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1219,7 +1219,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
     // like com.example.Dog dog, JavaParser considers its package components (com and com.example)
     // as types, too. This issue happens even when the source file of the Dog class is present in
     // the codebase.
-    if (!isCapital(typeExpr.getName().asString())) {
+    if (!JavaParserUtil.isCapital(typeExpr.getName().asString())) {
       return super.visit(typeExpr, p);
     }
     // type belonging to a class declaration will be handled by the visit method for
@@ -1717,7 +1717,8 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
       // be a fully-qualified name. If it's an Outer.Inner pair, we identify
       // that via the heuristic that there are only two elements if we split on
       // the dot and that the whole string is capital
-      if (typeRawName.indexOf('.') == typeRawName.lastIndexOf('.') && isCapital(typeRawName)) {
+      if (typeRawName.indexOf('.') == typeRawName.lastIndexOf('.')
+          && JavaParserUtil.isCapital(typeRawName)) {
         className = typeRawName;
         packageName = getPackageFromClassName(typeRawName.substring(0, typeRawName.indexOf('.')));
       } else {
@@ -2529,7 +2530,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
       if (splitType.size() > 2) {
         // if the above conditions are met, this type is probably already in the qualified form.
         return typeAsString;
-      } else if (isCapital(typeAsString)) {
+      } else if (JavaParserUtil.isCapital(typeAsString)) {
         // Heuristic: if the type name has two dot-separated components and
         // the first one is capitalized, then it's probably an inner class.
         // Return the outer class' package.
@@ -2911,7 +2912,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
     //    name might be "java.util" and the class name might be "Map.Entry".
     String outerClassName = null, innerClassName = null;
     // First case, looking for "Map.Entry" pattern
-    if (isCapital(qualifiedName)
+    if (JavaParserUtil.isCapital(qualifiedName)
         &&
         // This test checks that it has only one .
         qualifiedName.indexOf('.') == qualifiedName.lastIndexOf('.')) {
@@ -3074,17 +3075,6 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
   }
 
   /**
-   * This method checks if a string is capitalized
-   *
-   * @param string the string to be checked
-   * @return true if the string is capitalized
-   */
-  public static boolean isCapital(String string) {
-    Character first = string.charAt(0);
-    return Character.isUpperCase(first);
-  }
-
-  /**
    * This method checks if a string has the form of a class path.
    *
    * @param potentialClassPath the string to be checked
@@ -3094,7 +3084,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
     List<String> elements = Splitter.onPattern("\\.").splitToList(potentialClassPath);
     int elementsCount = elements.size();
     return elementsCount > 1
-        && isCapital(elements.get(elementsCount - 1))
+        && JavaParserUtil.isCapital(elements.get(elementsCount - 1))
         // Classpaths cannot contain spaces!
         && elements.stream().noneMatch(s -> s.contains(" "));
   }

--- a/src/main/java/org/checkerframework/specimin/UnusedImportRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnusedImportRemoverVisitor.java
@@ -277,14 +277,14 @@ public class UnusedImportRemoverVisitor extends ModifierVisitor<Void> {
     usedImports.add(fullyQualified);
     usedImports.add(wildcard);
   }
-  
+
   /**
-   * Helper method to convert a fully qualified class/member name into a wildcard
-   * e.g. {@code java.lang.Math.sqrt} --> {@code java.lang.Math.*}
-   * 
+   * Helper method to convert a fully qualified class/member name into a wildcard e.g.
+   * {@code java.lang.Math.sqrt} --> {@code java.lang.Math.*}
+   *
    * @param fullyQualified The fully qualified name
-   * 
-   * @return {@code fullyQualified} with the text after the last dot replaced with an asterisk ({@code *})
+   * @return {@code fullyQualified} with the text after the last dot replaced with an
+   * asterisk ({@code *})
    */
   private static String getWildcardFromClassOrMemberName(String fullyQualified) {
     return fullyQualified.substring(0, fullyQualified.lastIndexOf('.')) + ".*";

--- a/src/main/java/org/checkerframework/specimin/UnusedImportRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnusedImportRemoverVisitor.java
@@ -3,9 +3,13 @@ package org.checkerframework.specimin;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NormalAnnotationExpr;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
@@ -138,5 +142,36 @@ public class UnusedImportRemoverVisitor extends ModifierVisitor<Void> {
     }
 
     return super.visit(expr, arg);
+  }
+
+  @Override
+  public Visitable visit(MarkerAnnotationExpr anno, Void arg) {
+    handleAnnotation(anno);
+
+    return super.visit(anno, arg);
+  }
+
+  @Override
+  public Visitable visit(NormalAnnotationExpr anno, Void arg) {
+    handleAnnotation(anno);
+
+    return super.visit(anno, arg);
+  }
+
+  @Override
+  public Visitable visit(SingleMemberAnnotationExpr anno, Void arg) {
+    handleAnnotation(anno);
+
+    return super.visit(anno, arg);
+  }
+
+  /** Helper method to resolve all annotation expressions and add them to usedImports. */
+  private void handleAnnotation(AnnotationExpr anno) {
+    String fullyQualified = JavaParserUtil.erase(anno.resolve().getQualifiedName());
+    String wildcard = fullyQualified.substring(0, fullyQualified.lastIndexOf('.')) + ".*";
+
+    // Check for java.lang.annotation.Target and java.lang.annotation.*
+    usedImports.add(fullyQualified);
+    usedImports.add(wildcard);
   }
 }

--- a/src/main/java/org/checkerframework/specimin/UnusedImportRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnusedImportRemoverVisitor.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
+import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
@@ -99,7 +100,15 @@ public class UnusedImportRemoverVisitor extends ModifierVisitor<Void> {
       return super.visit(expr, arg);
     }
 
-    ResolvedValueDeclaration resolved = expr.resolve();
+    ResolvedValueDeclaration resolved;
+    try {
+      resolved = expr.resolve();
+    } catch (UnsolvedSymbolException ex) {
+      // In testing, an UnsolvedSymbolException occurs when an invalid type is passed into
+      // NameExpr (for example, ArrayTypeTest passes in Arrays here, when it should really be a
+      // ClassOrInterfaceType)
+      return super.visit(expr, arg);
+    }
     // Handle statically imported fields
     // import static java.lang.Math.PI;
     // double x = PI;

--- a/src/main/java/org/checkerframework/specimin/UnusedImportRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnusedImportRemoverVisitor.java
@@ -1,0 +1,104 @@
+package org.checkerframework.specimin;
+
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.visitor.ModifierVisitor;
+import com.github.javaparser.ast.visitor.Visitable;
+import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Removes all unused import statements from a compilation unit. This visitor should be used after
+ * pruning.
+ */
+public class UnusedImportRemoverVisitor extends ModifierVisitor<Void> {
+  /**
+   * A Map of fully qualified type/member names, or a wildcard import, to the actual import
+   * declaration itself
+   */
+  private final Map<String, ImportDeclaration> typeNamesToImports = new HashMap<>();
+
+  /** A set of all fully qualified type/member names in the current compilation unit */
+  private final Set<String> usedImports = new HashSet<>();
+
+  /**
+   * Removes unused imports from the current compilation unit and resets the state to be used with
+   * another compilation unit.
+   */
+  public void removeUnusedImports() {
+    for (Map.Entry<String, ImportDeclaration> entry : typeNamesToImports.entrySet()) {
+      if (!usedImports.contains(entry.getKey())) {
+        entry.getValue().remove();
+      }
+    }
+
+    typeNamesToImports.clear();
+    usedImports.clear();
+  }
+
+  @Override
+  public Node visit(ImportDeclaration decl, Void arg) {
+    String importName = decl.getNameAsString();
+
+    // ImportDeclaration does not contain the asterick by default; we need to add it
+    if (decl.isAsterisk()) {
+      importName += ".*";
+    }
+
+    typeNamesToImports.put(importName, decl);
+    return super.visit(decl, arg);
+  }
+
+  @Override
+  public Visitable visit(ClassOrInterfaceType type, Void arg) {
+    String fullyQualified = JavaParserUtil.erase(type.resolve().describe());
+    String wildcard = fullyQualified.substring(0, fullyQualified.lastIndexOf('.')) + ".*";
+
+    // Check for java.util.List and java.util.*
+    usedImports.add(fullyQualified);
+    usedImports.add(wildcard);
+    return super.visit(type, arg);
+  }
+
+  @Override
+  public Visitable visit(NameExpr expr, Void arg) {
+    ResolvedValueDeclaration resolved = expr.resolve();
+    // Handle statically imported fields
+    // import static java.lang.Math.PI;
+    // double x = PI;
+    //            ^^
+    if (resolved.isField()) {
+      ResolvedFieldDeclaration asField = resolved.asField();
+      String declaringType = JavaParserUtil.erase(asField.declaringType().getQualifiedName());
+      // Check for both cases: java.lang.Math.PI and java.lang.Math.*
+      usedImports.add(declaringType + "." + asField.getName());
+      usedImports.add(declaringType + ".*");
+    }
+    return super.visit(expr, arg);
+  }
+
+  @Override
+  public Visitable visit(MethodCallExpr expr, Void arg) {
+    ResolvedMethodDeclaration resolved = expr.resolve();
+
+    // Only static methods can be statically imported
+    if (resolved.isStatic()) {
+      // Handle statically imported methods
+      // import static java.lang.Math.sqrt;
+      // sqrt(1);
+      // Check for both cases: java.lang.Math.sqrt and java.lang.Math.*
+      usedImports.add(JavaParserUtil.erase(resolved.getQualifiedName()));
+      usedImports.add(JavaParserUtil.erase(resolved.declaringType().getQualifiedName()) + ".*");
+    }
+
+    return super.visit(expr, arg);
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/UnusedImportRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnusedImportRemoverVisitor.java
@@ -15,6 +15,7 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
+import com.github.javaparser.resolution.declarations.ResolvedEnumConstantDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
@@ -169,6 +170,13 @@ public class UnusedImportRemoverVisitor extends ModifierVisitor<Void> {
       String declaringType = JavaParserUtil.erase(asField.declaringType().getQualifiedName());
       // Check for both cases: java.lang.Math.PI and java.lang.Math.*
       usedImports.add(declaringType + "." + asField.getName());
+      usedImports.add(declaringType + ".*");
+    } else if (resolved.isEnumConstant()) {
+      ResolvedEnumConstantDeclaration asEnumConstant = resolved.asEnumConstant();
+      String declaringType = JavaParserUtil.erase(asEnumConstant.getType().describe());
+      // com.example.Enum, com.example.Enum.VALUE, com.example.Enum.*
+      usedImports.add(declaringType);
+      usedImports.add(declaringType + "." + asEnumConstant.getName());
       usedImports.add(declaringType + ".*");
     }
     return super.visit(expr, arg);

--- a/src/test/java/org/checkerframework/specimin/JavaParserUtilIsAClassPathTest.java
+++ b/src/test/java/org/checkerframework/specimin/JavaParserUtilIsAClassPathTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-/** This class unit tests static methods in UnsolvedSymbolVisitor. */
-public class UnsovledSymbolVisitorStaticTest {
+/** This class unit tests the isAClassPath method in JavaParserUtil. */
+public class JavaParserUtilIsAClassPathTest {
 
   private static final String LONG_CHAIN =
       "BigQueryIO.read(BillingEvent::parseFromRecord)\n"
@@ -42,20 +42,20 @@ public class UnsovledSymbolVisitorStaticTest {
 
   @Test
   public void testIsAClassPath() {
-    assertTrue(UnsolvedSymbolVisitor.isAClassPath("org.checkerframework.javacutil.ElementUtils"));
+    assertTrue(JavaParserUtil.isAClassPath("org.checkerframework.javacutil.ElementUtils"));
 
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath("org"));
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath("ElementUtils"));
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath("ElementUtils.foo()"));
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath("org.ElementUtils.foo()"));
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath("MapElements.into(TypeDescriptors.strings())"));
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath(LONG_CHAIN));
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath("TextIO.write()"));
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath("TextIO.<BillingEvent>writeCustomType()"));
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath(ENDS_WITH_DOT_CLASS));
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath(ANOTHER_LONG_CHAIN));
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath(ANOTHER_LONG_CHAIN_2));
+    assertFalse(JavaParserUtil.isAClassPath("org"));
+    assertFalse(JavaParserUtil.isAClassPath("ElementUtils"));
+    assertFalse(JavaParserUtil.isAClassPath("ElementUtils.foo()"));
+    assertFalse(JavaParserUtil.isAClassPath("org.ElementUtils.foo()"));
+    assertFalse(JavaParserUtil.isAClassPath("MapElements.into(TypeDescriptors.strings())"));
+    assertFalse(JavaParserUtil.isAClassPath(LONG_CHAIN));
+    assertFalse(JavaParserUtil.isAClassPath("TextIO.write()"));
+    assertFalse(JavaParserUtil.isAClassPath("TextIO.<BillingEvent>writeCustomType()"));
+    assertFalse(JavaParserUtil.isAClassPath(ENDS_WITH_DOT_CLASS));
+    assertFalse(JavaParserUtil.isAClassPath(ANOTHER_LONG_CHAIN));
+    assertFalse(JavaParserUtil.isAClassPath(ANOTHER_LONG_CHAIN_2));
     // This is the one that caused https://github.com/kelloggm/specimin/issues/94
-    assertFalse(UnsolvedSymbolVisitor.isAClassPath(ANOTHER_LONG_CHAIN_3));
+    assertFalse(JavaParserUtil.isAClassPath(ANOTHER_LONG_CHAIN_3));
   }
 }

--- a/src/test/java/org/checkerframework/specimin/UnusedImportsTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnusedImportsTest.java
@@ -1,0 +1,15 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks if Specimin can properly remove unused imports. */
+public class UnusedImportsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unusedimports",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#shouldNotBeRemoved()"});
+  }
+}

--- a/src/test/resources/abstractimpl/expected/com/example/Simple.java
+++ b/src/test/resources/abstractimpl/expected/com/example/Simple.java
@@ -3,8 +3,6 @@ package com.example;
 import java.util.Set;
 import java.util.Collection;
 
-import com.example.WrappedSet;
-
 public class Simple<K, V> {
     Collection<V> bar(K key, Collection<V> collection) {
         return new WrappedSet(key, (Set<V>) collection);

--- a/src/test/resources/issue103/expected/com/example/AccessOrderDeque.java
+++ b/src/test/resources/issue103/expected/com/example/AccessOrderDeque.java
@@ -1,6 +1,4 @@
 package com.example;
 
-import java.util.Deque;
-
 public final class AccessOrderDeque<E> extends AbstractLinkedDeque<E> {
 }

--- a/src/test/resources/preserveannotations/expected/com/example/Foo.java
+++ b/src/test/resources/preserveannotations/expected/com/example/Foo.java
@@ -1,6 +1,5 @@
 package com.example;
 
-import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
 
 class Foo {

--- a/src/test/resources/unsolvedmethodtypecorrect/expected/com/example/Simple.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/expected/com/example/Simple.java
@@ -1,6 +1,5 @@
 package com.example;
 
-import org.example.LocalVariables;
 import org.example.Foo;
 
 class Simple {

--- a/src/test/resources/unsolvedstaticmethod/expected/com/example/Simple.java
+++ b/src/test/resources/unsolvedstaticmethod/expected/com/example/Simple.java
@@ -1,6 +1,5 @@
 package com.example;
 
-import com.example.MyClass;
 import unreal.pack.AClass;
 
 class Simple {

--- a/src/test/resources/unusedimports/expected/com/example/ManyImports.java
+++ b/src/test/resources/unusedimports/expected/com/example/ManyImports.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public class ManyImports {
+}

--- a/src/test/resources/unusedimports/expected/com/example/Simple.java
+++ b/src/test/resources/unusedimports/expected/com/example/Simple.java
@@ -1,0 +1,17 @@
+package com.example;
+
+import java.util.List;
+import java.io.*;
+import static java.util.Map.*;
+import static java.lang.Math.sqrt;
+import static java.lang.Math.PI;
+
+public class Simple {
+
+    public ManyImports shouldNotBeRemoved() {
+        List<Entry<Object, Object>> x;
+        sqrt(PI);
+        File file;
+        return null;
+    }
+}

--- a/src/test/resources/unusedimports/input/com/example/ManyImports.java
+++ b/src/test/resources/unusedimports/input/com/example/ManyImports.java
@@ -1,0 +1,15 @@
+package com.example;
+
+import java.util.List;
+import java.io.*;
+import static java.util.Map.*;
+import static java.lang.Math.sqrt;
+import static java.lang.Math.PI;
+
+public class ManyImports {
+    public void shouldBeRemoved() {
+        List<Entry<Object, Object>> x;
+        sqrt(PI);
+        File file;
+    }
+}

--- a/src/test/resources/unusedimports/input/com/example/Simple.java
+++ b/src/test/resources/unusedimports/input/com/example/Simple.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import java.util.List;
+import java.io.*;
+import static java.util.Map.*;
+import static java.lang.Math.sqrt;
+import static java.lang.Math.PI;
+
+public class Simple {
+    public ManyImports shouldNotBeRemoved() {
+        List<Entry<Object, Object>> x;
+        sqrt(PI);
+        File file;
+        return null;
+    }
+}

--- a/src/test/resources/voidreturndouble/expected/com/example/MyFoo.java
+++ b/src/test/resources/voidreturndouble/expected/com/example/MyFoo.java
@@ -1,7 +1,6 @@
 package com.example;
 
 import org.example.Foo;
-import org.example.MethodGen;
 
 public class MyFoo extends Foo {
 

--- a/src/test/resources/whenthen/expected/com/example/Simple.java
+++ b/src/test/resources/whenthen/expected/com/example/Simple.java
@@ -3,8 +3,6 @@ package com.example;
 import static org.example.TestUtil.when;
 import static org.example.TestUtil.mock;
 
-import com.example.Banana;
-
 class Simple {
 
     void bar() {


### PR DESCRIPTION
Removes unused imports in all output files.

Take, for example, `ManyImports` in the included test case.
Previously:

```java
package com.example;

import java.util.List;
import java.io.*;
import static java.util.Map.*;
import static java.lang.Math.sqrt;
import static java.lang.Math.PI;

public class ManyImports {
}
```

Now:

```java
package com.example;

public class ManyImports {
}
```

Even if the import type is a used type element, it should still be removed if the current, minimized file does not contain any instances.