### PR TITLE
Remove unused `ElementType`s in `@Target`

### DIFF
--- a/src/main/java/org/checkerframework/specimin/AnnotationParameterTypesVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/AnnotationParameterTypesVisitor.java
@@ -3,6 +3,7 @@ package org.checkerframework.specimin;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.AnnotationMemberDeclaration;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.ArrayInitializerExpr;
@@ -113,6 +114,11 @@ public class AnnotationParameterTypesVisitor extends SpeciminStateVisitor {
 
   @Override
   public Visitable visit(MarkerAnnotationExpr anno, Void p) {
+    // Annotations on packages cause an exception in findClosestParentMemberOrClassLike
+    if (anno.hasParentNode() && anno.getParentNode().get() instanceof PackageDeclaration) {
+      return super.visit(anno, p);
+    }
+
     Node parent = JavaParserUtil.findClosestParentMemberOrClassLike(anno);
 
     if (isTargetOrUsed(parent)) {
@@ -123,6 +129,11 @@ public class AnnotationParameterTypesVisitor extends SpeciminStateVisitor {
 
   @Override
   public Visitable visit(SingleMemberAnnotationExpr anno, Void p) {
+    // Annotations on packages cause an exception in findClosestParentMemberOrClassLike
+    if (anno.hasParentNode() && anno.getParentNode().get() instanceof PackageDeclaration) {
+      return super.visit(anno, p);
+    }
+
     Node parent = JavaParserUtil.findClosestParentMemberOrClassLike(anno);
 
     if (isTargetOrUsed(parent)) {
@@ -133,6 +144,11 @@ public class AnnotationParameterTypesVisitor extends SpeciminStateVisitor {
 
   @Override
   public Visitable visit(NormalAnnotationExpr anno, Void p) {
+    // Annotations on packages cause an exception in findClosestParentMemberOrClassLike
+    if (anno.hasParentNode() && anno.getParentNode().get() instanceof PackageDeclaration) {
+      return super.visit(anno, p);
+    }
+
     Node parent = JavaParserUtil.findClosestParentMemberOrClassLike(anno);
 
     if (isTargetOrUsed(parent)) {

--- a/src/main/java/org/checkerframework/specimin/AnnotationTargetRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/AnnotationTargetRemoverVisitor.java
@@ -25,9 +25,12 @@ import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import java.lang.annotation.ElementType;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -129,6 +132,10 @@ public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
       newAnnotation.append("Target(");
 
       newAnnotation.append('{');
+
+      List<ElementType> sortedElementTypes = new ArrayList<>(elementTypes);
+      Collections.sort(sortedElementTypes, (a, b) -> a.name().compareTo(b.name()));
+
       Iterator<ElementType> iterator = elementTypes.iterator();
       while (iterator.hasNext()) {
         ElementType elementType = iterator.next();

--- a/src/main/java/org/checkerframework/specimin/AnnotationTargetRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/AnnotationTargetRemoverVisitor.java
@@ -1,0 +1,237 @@
+package org.checkerframework.specimin;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.ast.body.AnnotationMemberDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.EnumConstantDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.RecordDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.ArrayInitializerExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NormalAnnotationExpr;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.type.TypeParameter;
+import com.github.javaparser.ast.visitor.ModifierVisitor;
+import com.github.javaparser.ast.visitor.Visitable;
+import java.lang.annotation.ElementType;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Removes all unnecessary ElementType values from each annotation declaration, based on their
+ * usages. Run this visitor after PrunerVisitor to ensure all unnecessary ElementTypes are removed.
+ */
+public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
+  /** A Map of fully qualified annotation names to its ElementTypes. */
+  private final Map<String, Set<ElementType>> annotationToElementTypes = new HashMap<>();
+
+  /** A Map of fully qualified annotation names to their declarations. */
+  private final Map<String, AnnotationDeclaration> annotationToDeclaration = new HashMap<>();
+
+  /**
+   * Updates all annotation declaration {@code @Target} values to match their usages. Only removes
+   * {@code ElementType}s, doesn't add them. Call this method once after visiting all files.
+   */
+  public void removeExtraAnnotationTargets() {
+    for (Map.Entry<String, AnnotationDeclaration> pair : annotationToDeclaration.entrySet()) {
+      AnnotationExpr targetAnnotation = pair.getValue().getAnnotationByName("Target").orElse(null);
+
+      if (targetAnnotation == null) {
+        // This is most likely an existing definition. If there is no @Target annotation,
+        // we shouldn't add it
+        continue;
+      }
+
+      boolean useFullyQualified =
+          targetAnnotation.getNameAsString().equals("java.lang.annotation.Target");
+
+      // Only handle java.lang.annotation.Target
+      if (!targetAnnotation.resolve().getQualifiedName().equals("java.lang.annotation.Target")) {
+        continue;
+      }
+
+      Set<ElementType> actualElementTypes = annotationToElementTypes.get(pair.getKey());
+
+      if (actualElementTypes == null) {
+        // No usages of the annotation itself (see Issue272Test)
+        actualElementTypes = new HashSet<>();
+      }
+
+      Set<ElementType> elementTypes = new HashSet<>();
+      Set<ElementType> staticallyImportedElementTypes = new HashSet<>();
+      Expression memberValue;
+
+      // @Target(ElementType.___)
+      // @Target({ElementType.___, ElementType.___})
+      if (targetAnnotation.isSingleMemberAnnotationExpr()) {
+        SingleMemberAnnotationExpr asSingleMember = targetAnnotation.asSingleMemberAnnotationExpr();
+        memberValue = asSingleMember.getMemberValue();
+      }
+      // @Target(value = ElementType.___)
+      // @Target(value = {ElementType.___, ElementType.___})
+      else if (targetAnnotation.isNormalAnnotationExpr()) {
+        NormalAnnotationExpr asNormal = targetAnnotation.asNormalAnnotationExpr();
+        memberValue = asNormal.getPairs().get(0).getValue();
+      } else {
+        throw new RuntimeException("@Target annotation must contain an ElementType");
+      }
+
+      // If there's only one ElementType, we can't remove anything
+      // We should only be removing ElementTypes, not adding: we do not want to
+      // convert a non TYPE_USE annotation to a TYPE_USE annotation, for example
+      if (memberValue.isFieldAccessExpr() || memberValue.isNameExpr()) {
+        continue;
+      } else if (memberValue.isArrayInitializerExpr()) {
+        ArrayInitializerExpr arrayExpr = memberValue.asArrayInitializerExpr();
+        if (arrayExpr.getValues().size() <= 1) {
+          continue;
+        }
+        for (Expression value : arrayExpr.getValues()) {
+          if (value.isFieldAccessExpr()) {
+            FieldAccessExpr fieldAccessExpr = value.asFieldAccessExpr();
+            ElementType elementType = ElementType.valueOf(fieldAccessExpr.getNameAsString());
+            if (actualElementTypes.contains(elementType)) {
+              elementTypes.add(elementType);
+            }
+          } else if (value.isNameExpr()) {
+            // In case of static imports
+            NameExpr nameExpr = value.asNameExpr();
+            ElementType elementType = ElementType.valueOf(nameExpr.getNameAsString());
+            if (actualElementTypes.contains(elementType)) {
+              elementTypes.add(elementType);
+              staticallyImportedElementTypes.add(elementType);
+            }
+          }
+        }
+      }
+
+      StringBuilder newAnnotation = new StringBuilder();
+      newAnnotation.append("@");
+
+      if (useFullyQualified) {
+        newAnnotation.append("java.lang.annotation.");
+      }
+
+      newAnnotation.append("Target(");
+
+      newAnnotation.append('{');
+      Iterator<ElementType> iterator = elementTypes.iterator();
+      while (iterator.hasNext()) {
+        ElementType elementType = iterator.next();
+        if (!staticallyImportedElementTypes.contains(elementType)) {
+          if (useFullyQualified) {
+            newAnnotation.append("java.lang.annotation.");
+          }
+          newAnnotation.append("ElementType.");
+        }
+        newAnnotation.append(elementType.name());
+
+        if (iterator.hasNext()) {
+          newAnnotation.append(", ");
+        }
+      }
+
+      newAnnotation.append("})");
+      AnnotationExpr trimmed = StaticJavaParser.parseAnnotation(newAnnotation.toString());
+
+      targetAnnotation.remove();
+
+      pair.getValue().addAnnotation(trimmed);
+    }
+  }
+
+  @Override
+  public Visitable visit(AnnotationDeclaration decl, Void p) {
+    annotationToDeclaration.put(decl.getFullyQualifiedName().get(), decl);
+    return super.visit(decl, p);
+  }
+
+  @Override
+  public Visitable visit(MarkerAnnotationExpr anno, Void p) {
+    updateAnnotationElementTypes(anno);
+    return super.visit(anno, p);
+  }
+
+  @Override
+  public Visitable visit(NormalAnnotationExpr anno, Void p) {
+    updateAnnotationElementTypes(anno);
+    return super.visit(anno, p);
+  }
+
+  @Override
+  public Visitable visit(SingleMemberAnnotationExpr anno, Void p) {
+    updateAnnotationElementTypes(anno);
+    return super.visit(anno, p);
+  }
+
+  /**
+   * Helper method to update the ElementTypes for an annotation.
+   *
+   * @param anno The annotation to update element types for
+   */
+  private void updateAnnotationElementTypes(AnnotationExpr anno) {
+    Node parent = anno.getParentNode().orElse(null);
+
+    if (parent == null) {
+      return;
+    }
+
+    Set<ElementType> elementTypes = annotationToElementTypes.get(anno.resolve().getQualifiedName());
+    if (elementTypes == null) {
+      elementTypes = new HashSet<>();
+      annotationToElementTypes.put(anno.resolve().getQualifiedName(), elementTypes);
+    }
+
+    if (parent instanceof AnnotationDeclaration) {
+      elementTypes.add(ElementType.ANNOTATION_TYPE);
+      elementTypes.add(ElementType.TYPE);
+    } else if (parent instanceof ConstructorDeclaration) {
+      elementTypes.add(ElementType.CONSTRUCTOR);
+    } else if (parent instanceof FieldDeclaration || parent instanceof EnumConstantDeclaration) {
+      elementTypes.add(ElementType.FIELD);
+    } else if (parent instanceof VariableDeclarationExpr) {
+      elementTypes.add(ElementType.LOCAL_VARIABLE);
+    } else if (parent instanceof MethodDeclaration) {
+      elementTypes.add(ElementType.METHOD);
+
+      if (((MethodDeclaration) parent).getType().isVoidType()) {
+        // If it's void we don't need to add TYPE_USE
+        return;
+      }
+    } else if (parent instanceof AnnotationMemberDeclaration) {
+      elementTypes.add(ElementType.METHOD);
+    } else if (parent instanceof PackageDeclaration) {
+      elementTypes.add(ElementType.PACKAGE);
+      return;
+    } else if (parent instanceof Parameter) {
+      if (parent.getParentNode().isPresent()
+          && parent.getParentNode().get() instanceof RecordDeclaration) {
+        elementTypes.add(ElementType.RECORD_COMPONENT);
+      } else {
+        elementTypes.add(ElementType.PARAMETER);
+      }
+    } else if (parent instanceof TypeDeclaration) {
+      // TypeDeclaration is the parent class for class, interface, annotation, record declarations
+      // https://www.javadoc.io/doc/com.github.javaparser/javaparser-core/latest/com/github/javaparser/ast/body/TypeDeclaration.html
+      elementTypes.add(ElementType.TYPE);
+    } else if (parent instanceof TypeParameter) {
+      elementTypes.add(ElementType.TYPE_PARAMETER);
+    }
+
+    elementTypes.add(ElementType.TYPE_USE);
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/AnnotationTargetRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/AnnotationTargetRemoverVisitor.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -136,9 +135,8 @@ public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
       List<ElementType> sortedElementTypes = new ArrayList<>(elementTypes);
       Collections.sort(sortedElementTypes, (a, b) -> a.name().compareTo(b.name()));
 
-      Iterator<ElementType> iterator = elementTypes.iterator();
-      while (iterator.hasNext()) {
-        ElementType elementType = iterator.next();
+      for (int i = 0; i < sortedElementTypes.size(); i++) {
+        ElementType elementType = sortedElementTypes.get(i);
         if (!staticallyImportedElementTypes.contains(elementType)) {
           if (useFullyQualified) {
             newAnnotation.append("java.lang.annotation.");
@@ -147,7 +145,7 @@ public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
         }
         newAnnotation.append(elementType.name());
 
-        if (iterator.hasNext()) {
+        if (i < sortedElementTypes.size() - 1) {
           newAnnotation.append(", ");
         }
       }

--- a/src/main/java/org/checkerframework/specimin/AnnotationTargetRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/AnnotationTargetRemoverVisitor.java
@@ -44,13 +44,17 @@ public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
   /** A Map of fully qualified annotation names to their declarations. */
   private final Map<String, AnnotationDeclaration> annotationToDeclaration = new HashMap<>();
 
+  private static final String TARGET_PACKAGE = "java.lang.annotation";
+  private static final String TARGET_NAME = "Target";
+  private static final String FULLY_QUALIFIED_TARGET =  TARGET_PACKAGE + "." + TARGET_NAME;
+
   /**
    * Updates all annotation declaration {@code @Target} values to match their usages. Only removes
    * {@code ElementType}s, doesn't add them. Call this method once after visiting all files.
    */
   public void removeExtraAnnotationTargets() {
     for (Map.Entry<String, AnnotationDeclaration> pair : annotationToDeclaration.entrySet()) {
-      AnnotationExpr targetAnnotation = pair.getValue().getAnnotationByName("Target").orElse(null);
+      AnnotationExpr targetAnnotation = pair.getValue().getAnnotationByName(TARGET_NAME).orElse(null);
 
       if (targetAnnotation == null) {
         // This is most likely an existing definition. If there is no @Target annotation,
@@ -59,10 +63,10 @@ public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
       }
 
       boolean useFullyQualified =
-          targetAnnotation.getNameAsString().equals("java.lang.annotation.Target");
+          targetAnnotation.getNameAsString().equals(FULLY_QUALIFIED_TARGET);
 
       // Only handle java.lang.annotation.Target
-      if (!targetAnnotation.resolve().getQualifiedName().equals("java.lang.annotation.Target")) {
+      if (!targetAnnotation.resolve().getQualifiedName().equals(FULLY_QUALIFIED_TARGET)) {
         continue;
       }
 
@@ -125,10 +129,12 @@ public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
       newAnnotation.append("@");
 
       if (useFullyQualified) {
-        newAnnotation.append("java.lang.annotation.");
+        newAnnotation.append(TARGET_PACKAGE);
+        newAnnotation.append(".");
       }
 
-      newAnnotation.append("Target(");
+      newAnnotation.append(TARGET_NAME);
+      newAnnotation.append("(");
 
       newAnnotation.append('{');
 
@@ -139,7 +145,8 @@ public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
         ElementType elementType = sortedElementTypes.get(i);
         if (!staticallyImportedElementTypes.contains(elementType)) {
           if (useFullyQualified) {
-            newAnnotation.append("java.lang.annotation.");
+            newAnnotation.append(TARGET_PACKAGE);
+            newAnnotation.append(".");
           }
           newAnnotation.append("ElementType.");
         }

--- a/src/main/java/org/checkerframework/specimin/AnnotationTargetRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/AnnotationTargetRemoverVisitor.java
@@ -44,9 +44,14 @@ public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
   /** A Map of fully qualified annotation names to their declarations. */
   private final Map<String, AnnotationDeclaration> annotationToDeclaration = new HashMap<>();
 
+  /** Constant for the package of {@code @Target} ({@code java.lang.annotation}) */
   private static final String TARGET_PACKAGE = "java.lang.annotation";
+
+  /** Constant for {@code @Target}'s name (does not include the {@code @}) */
   private static final String TARGET_NAME = "Target";
-  private static final String FULLY_QUALIFIED_TARGET =  TARGET_PACKAGE + "." + TARGET_NAME;
+
+  /** Constant for {@code @Target}'s fully qualified name */
+  private static final String FULLY_QUALIFIED_TARGET = TARGET_PACKAGE + "." + TARGET_NAME;
 
   /**
    * Updates all annotation declaration {@code @Target} values to match their usages. Only removes
@@ -54,7 +59,8 @@ public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
    */
   public void removeExtraAnnotationTargets() {
     for (Map.Entry<String, AnnotationDeclaration> pair : annotationToDeclaration.entrySet()) {
-      AnnotationExpr targetAnnotation = pair.getValue().getAnnotationByName(TARGET_NAME).orElse(null);
+      AnnotationExpr targetAnnotation =
+          pair.getValue().getAnnotationByName(TARGET_NAME).orElse(null);
 
       if (targetAnnotation == null) {
         // This is most likely an existing definition. If there is no @Target annotation,
@@ -62,8 +68,7 @@ public class AnnotationTargetRemoverVisitor extends ModifierVisitor<Void> {
         continue;
       }
 
-      boolean useFullyQualified =
-          targetAnnotation.getNameAsString().equals(FULLY_QUALIFIED_TARGET);
+      boolean useFullyQualified = targetAnnotation.getNameAsString().equals(FULLY_QUALIFIED_TARGET);
 
       // Only handle java.lang.annotation.Target
       if (!targetAnnotation.resolve().getQualifiedName().equals(FULLY_QUALIFIED_TARGET)) {

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -512,6 +512,8 @@ public class SpeciminRunner {
       cu.accept(methodPruner, null);
     }
 
+    pruneAnnotationDeclarationTargets(parsedTargetFiles);
+
     // cache to avoid called Files.createDirectories repeatedly with the same arguments
     Set<Path> createdDirectories = new HashSet<>();
     Set<String> targetFilesAbsolutePaths = new HashSet<>();
@@ -657,6 +659,17 @@ public class SpeciminRunner {
       annotationParameterTypesVisitor.getClassesToAdd().clear();
     }
     return annotationParameterTypesVisitor;
+  }
+
+  /** Runs AnnotationTargetRemoverVisitor on the target files. Call after PrunerVisitor. */
+  private static void pruneAnnotationDeclarationTargets(
+      Map<String, CompilationUnit> parsedTargetFiles) {
+    AnnotationTargetRemoverVisitor targetPruner = new AnnotationTargetRemoverVisitor();
+    for (CompilationUnit cu : parsedTargetFiles.values()) {
+      cu.accept(targetPruner, null);
+    }
+
+    targetPruner.removeExtraAnnotationTargets();
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
@@ -476,6 +476,7 @@ public class UnsolvedClassOrInterface {
               + "\tjava.lang.annotation.ElementType.LOCAL_VARIABLE, \n"
               + "\tjava.lang.annotation.ElementType.ANNOTATION_TYPE,\n"
               + "\tjava.lang.annotation.ElementType.PACKAGE,\n"
+              + "\tjava.lang.annotation.ElementType.TYPE_PARAMETER,\n"
               + "\tjava.lang.annotation.ElementType.TYPE_USE \n"
               + "})");
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -2884,10 +2884,15 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
           return wildcardPkg;
         }
       }
-      // If none do, then default to the first wildcard import.
+      // If none do, then default to the first wildcard import that is not a JDK package.
       // TODO: log a warning about this once we have a logger
-      String wildcardPkg = wildcardImports.get(0);
-      return wildcardPkg;
+      for (String wildcardPkg : wildcardImports) {
+        if (!JavaLangUtils.inJdkPackage(wildcardPkg)) {
+          return wildcardPkg;
+        }
+      }
+      // If we're here, all wildcard imports are jdk imports; use current package instead
+      return currentPackage;
     }
   }
 

--- a/src/test/java/org/checkerframework/specimin/SyntheticAnnotationTargetTest.java
+++ b/src/test/java/org/checkerframework/specimin/SyntheticAnnotationTargetTest.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import org.junit.Test;
 
 /**
- * This test checks if synthetic annotations used in different locations will compile based
- * on @Target.
+ * This test checks if synthetic annotations used in different locations will contain
+ * the proper ElementTypes in their {@code @Target} annotations
  */
 public class SyntheticAnnotationTargetTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/SyntheticAnnotationTargetTest.java
+++ b/src/test/java/org/checkerframework/specimin/SyntheticAnnotationTargetTest.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import org.junit.Test;
 
 /**
- * This test checks if synthetic annotations used in different locations will contain
- * the proper ElementTypes in their {@code @Target} annotations
+ * This test checks if synthetic annotations used in different locations will contain the proper
+ * ElementTypes in their {@code @Target} annotations
  */
 public class SyntheticAnnotationTargetTest {
   @Test

--- a/src/test/resources/annoingenerictarget/expected/com/example/Simple.java
+++ b/src/test/resources/annoingenerictarget/expected/com/example/Simple.java
@@ -5,6 +5,7 @@ import org.checkerframework.checker.nullness.qual.*;
 import org.checkerframework.checker.initialization.qual.Initialized;
 
 class Simple {
+
     @Initialized
     @NonNull
     @UnknownKeyFor

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.initialization.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD })
 public @interface Initialized {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.initialization.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Initialized {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/initialization/qual/Initialized.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.initialization.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD })
 public @interface Initialized {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/KeyForBottom.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/KeyForBottom.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE })
 public @interface KeyForBottom {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD })
 public @interface NonNull {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.TYPE_USE })
 public @interface NonNull {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD })
 public @interface NonNull {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/Nullable.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/Nullable.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE })
 public @interface Nullable {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD })
 public @interface UnknownKeyFor {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD })
 public @interface UnknownKeyFor {
 }

--- a/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
+++ b/src/test/resources/annoingenerictarget/expected/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
@@ -1,5 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.TYPE_USE })
 public @interface UnknownKeyFor {
 }

--- a/src/test/resources/importanno/expected/com/example/Simple.java
+++ b/src/test/resources/importanno/expected/com/example/Simple.java
@@ -1,7 +1,6 @@
 package com.example;
 
 import org.checkerframework.checker.mustcall.qual.Owning;
-
 import java.net.Socket;
 
 public class Simple {

--- a/src/test/resources/importanno/expected/org/checkerframework/checker/mustcall/qual/Owning.java
+++ b/src/test/resources/importanno/expected/org/checkerframework/checker/mustcall/qual/Owning.java
@@ -6,6 +6,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD })
+@Target({ ElementType.FIELD })
 public @interface Owning {
 }

--- a/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
@@ -1,6 +1,5 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({})
 public @interface PostconditionAnnotation {
-
 }

--- a/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
@@ -1,6 +1,5 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({})
 public @interface PreconditionAnnotation {
-
 }

--- a/src/test/resources/issue272/expected/com/example/Simple.java
+++ b/src/test/resources/issue272/expected/com/example/Simple.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Annotation;
 public class Simple {
 
     public enum Kind {
+
         PRECONDITION(PreconditionAnnotation.class), POSTCONDITION(PostconditionAnnotation.class);
 
         Kind(Class<? extends Annotation> metaAnnotation) {

--- a/src/test/resources/parameterwithannotations/expected/org/checkerframework/checker/nullness/qual/Nullable.java
+++ b/src/test/resources/parameterwithannotations/expected/org/checkerframework/checker/nullness/qual/Nullable.java
@@ -12,9 +12,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @SubtypeOf({})
 @QualifierForLiterals({ LiteralKind.NULL })
 @DefaultFor(types = { Void.class })
+@Target({ ElementType.TYPE_USE })
 public @interface Nullable {
 }

--- a/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/GTENegativeOne.java
+++ b/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/GTENegativeOne.java
@@ -9,7 +9,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @SubtypeOf({ LowerBoundUnknown.class })
+@Target({})
 public @interface GTENegativeOne {
 }

--- a/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/GTENegativeOne.java
+++ b/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/GTENegativeOne.java
@@ -1,7 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;

--- a/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/LowerBoundUnknown.java
+++ b/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/LowerBoundUnknown.java
@@ -1,7 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;

--- a/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/LowerBoundUnknown.java
+++ b/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/LowerBoundUnknown.java
@@ -11,9 +11,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
 @InvisibleQualifier
+@Target({})
 public @interface LowerBoundUnknown {
 }

--- a/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/NonNegative.java
+++ b/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/NonNegative.java
@@ -9,7 +9,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @SubtypeOf({ GTENegativeOne.class })
+@Target({ ElementType.TYPE_USE })
 public @interface NonNegative {
 }

--- a/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/Positive.java
+++ b/src/test/resources/preserveannotations/expected/org/checkerframework/checker/index/qual/Positive.java
@@ -9,7 +9,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @SubtypeOf({ NonNegative.class })
+@Target({ ElementType.TYPE_USE })
 public @interface Positive {
 }

--- a/src/test/resources/syntheticannotations/expected/com/example/Anno.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Anno.java
@@ -1,6 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE })
 public @interface Anno {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Bar.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Bar.java
@@ -1,6 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Bar {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Bar.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Bar.java
@@ -1,6 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.METHOD })
 public @interface Bar {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Bar.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Bar.java
@@ -1,6 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Bar {
 
     public int value();

--- a/src/test/resources/syntheticannotations/expected/com/example/Baz.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Baz.java
@@ -1,6 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Baz {
 
     public String foo();

--- a/src/test/resources/syntheticannotations/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Foo.java
@@ -1,6 +1,6 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.TYPE_USE })
 public @interface Foo {
 
     public Deprecated x();

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/AnnotationDeclaration.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/AnnotationDeclaration.java
@@ -1,0 +1,5 @@
+package com.example;
+
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.TYPE_USE })
+public @interface AnnotationDeclaration {
+}

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/AnnotationDeclaration.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/AnnotationDeclaration.java
@@ -1,5 +1,5 @@
 package com.example;
 
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.TYPE_USE })
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.TYPE_USE })
 public @interface AnnotationDeclaration {
 }

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Constructor.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Constructor.java
@@ -1,0 +1,5 @@
+package com.example;
+
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.TYPE_USE })
+public @interface Constructor {
+}

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/EnumConstantDeclaration.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/EnumConstantDeclaration.java
@@ -1,0 +1,5 @@
+package com.example;
+
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.TYPE_USE })
+public @interface EnumConstantDeclaration {
+}

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Field.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Field.java
@@ -1,0 +1,5 @@
+package com.example;
+
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.TYPE_USE })
+public @interface Field {
+}

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Foo.java
@@ -1,5 +1,0 @@
-package com.example;
-
-@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_USE })
-public @interface Foo {
-}

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/LocalVariable.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/LocalVariable.java
@@ -1,0 +1,5 @@
+package com.example;
+
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.TYPE_USE })
+public @interface LocalVariable {
+}

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Method.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Method.java
@@ -1,0 +1,5 @@
+package com.example;
+
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.METHOD })
+public @interface Method {
+}

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Param.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Param.java
@@ -1,0 +1,5 @@
+package com.example;
+
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.TYPE_USE })
+public @interface Param {
+}

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Simple.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Simple.java
@@ -1,24 +1,39 @@
 package com.example;
 
-@Foo
-public class Simple<@Foo T> {
-    @Foo
+import java.lang.annotation.Target;
+import java.util.*;
+import static java.lang.annotation.ElementType.*;
+
+@Type
+public class Simple<@TypeParam T> {
+
+    @Method
     @AnnoDecl
-    public <@Foo U> void baz(@Foo U u) {
-        Simple<@Foo String> simple = new Simple<>();
-        @Foo
+    public <@TypeParam U> void baz(@Param U u) {
+        @LocalVariable
+        Simple<@TypeParam String> simple = new Simple<>();
+        @LocalVariable
         int x = simple.field;
+        EnumTest e = EnumTest.A;
+        List<String> y;
     }
 
-    @Foo
+    @Field
     public int field;
 
-    @Foo
+    @Constructor
     public Simple() {
         throw new Error();
     }
 
-    @Foo
+    @AnnotationDeclaration
+    @Target({ METHOD })
     private @interface AnnoDecl {
+    }
+
+    enum EnumTest {
+
+        @EnumConstantDeclaration
+        A
     }
 }

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Type.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Type.java
@@ -1,0 +1,5 @@
+package com.example;
+
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.TYPE_USE })
+public @interface Type {
+}

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/TypeParam.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/TypeParam.java
@@ -1,0 +1,5 @@
+package com.example;
+
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_PARAMETER, java.lang.annotation.ElementType.TYPE_USE })
+public @interface TypeParam {
+}

--- a/src/test/resources/syntheticannotationtarget/input/com/example/Simple.java
+++ b/src/test/resources/syntheticannotationtarget/input/com/example/Simple.java
@@ -1,22 +1,37 @@
 package com.example;
 
-@Foo
-public class Simple<@Foo T> {
-    @Foo
+import java.lang.annotation.Target;
+import java.util.*;
+
+import static java.lang.annotation.ElementType.*;
+
+@Type
+public class Simple<@TypeParam T> {
+    @Method
     @AnnoDecl
-    public <@Foo U> void baz(@Foo U u) {
-        Simple<@Foo String> simple = new Simple<>();
-        @Foo int x = simple.field;
+    public <@TypeParam U> void baz(@Param U u) {
+        @LocalVariable
+        Simple<@TypeParam String> simple = new Simple<>();
+        @LocalVariable int x = simple.field;
+        EnumTest e = EnumTest.A;
+        List<String> y;
     }
 
-    @Foo
+    @Field
     public int field;
 
-    @Foo
+    @Constructor
     public Simple() { }
 
-    @Foo
+    @AnnotationDeclaration
+    // METHOD should be the only one that remains
+    @Target({METHOD, FIELD, TYPE_USE})
     private @interface AnnoDecl {
 
+    }
+
+    enum EnumTest {
+        @EnumConstantDeclaration
+        A
     }
 }


### PR DESCRIPTION
Removes unused `ElementType`s in `@Target` annotations. The current approach is to only remove `ElementType`s, not add them, so we don't accidentally make a non `TYPE_USE` annotation into a `TYPE_USE` annotation, for example.

I also addressed two small bugs I encountered:
- When all the wildcard import are JDK imports, synthetic classes should be generated in the current package instead of the first wildcard import package
- Don't throw an exception when an annotation is applied on a package declaration

Instead of creating a new test case for this, I just modified one of the existing ones (`SyntheticAnnotationTargetTest`), since it's purpose already seemed to fit this PR.

Thanks!