### PR TITLE
Deinterlace multithreaded logs

### DIFF
--- a/.github/workflows/check_compilable_percentage.yml
+++ b/.github/workflows/check_compilable_percentage.yml
@@ -98,19 +98,22 @@ jobs:
             $(pwd)/CI_repository_list.csv \
             $(pwd)/ASHE/CI_REPO_CLONE_SPACE \
             $(pwd)/ASHE/src/main/resources/config.properties
+      - name: De-Interleave Multithreaded Log
+        run: |
+          python3 ashe_scripts/de-interleave-ashe-log.py ASHE/logs/app.log
       - name: Translate results
         run: |
-          python3 ashe_scripts/specimin_get_run_results.py ASHE/logs/app.log
-          cat ASHE/logs/app.log
+          python3 ashe_scripts/specimin_get_run_results.py ASHE/logs/deinterleaved-log.txt
+          cat ASHE/logs/deinterleaved-log.log
       - name: Show only successful minimizations
         run: |
-          grep 'full_success' ASHE/logs/specimin_run_results.txt
+          grep 'full_success' ASHE/logs/specimin_run_results.txt | sort
       - name: Show only failed minimizations
         run: |
-          grep 'failed_minimization' ASHE/logs/specimin_run_results.txt
+          grep 'failed_minimization' ASHE/logs/specimin_run_results.txt | sort
       - name: Show only failed compilations
         run: |
-          grep 'failed_compilation' ASHE/logs/specimin_run_results.txt
+          grep 'failed_compilation' ASHE/logs/specimin_run_results.txt | sort
       - name: Parse accuracy percentage
         id: parse_accuracy_percentage
         run: |

--- a/.github/workflows/check_compilable_percentage.yml
+++ b/.github/workflows/check_compilable_percentage.yml
@@ -98,9 +98,6 @@ jobs:
             $(pwd)/CI_repository_list.csv \
             $(pwd)/ASHE/CI_REPO_CLONE_SPACE \
             $(pwd)/ASHE/src/main/resources/config.properties
-      - name: De-Interleave Multithreaded Log
-        run: |
-          python3 ashe_scripts/de-interleave-ashe-log.py ASHE/logs/app.log
       - name: Translate results
         run: |
           python3 ashe_scripts/specimin_get_run_results.py ASHE/logs/deinterleaved-log.txt

--- a/.github/workflows/check_compilable_percentage.yml
+++ b/.github/workflows/check_compilable_percentage.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Translate results
         run: |
           python3 ashe_scripts/specimin_get_run_results.py ASHE/logs/deinterleaved-log.txt
-          cat ASHE/logs/deinterleaved-log.log
+          cat ASHE/logs/deinterleaved-log.txt
       - name: Show only successful minimizations
         run: |
           grep 'full_success' ASHE/logs/specimin_run_results.txt | sort

--- a/ashe_scripts/de-interleave-ashe-log.py
+++ b/ashe_scripts/de-interleave-ashe-log.py
@@ -1,0 +1,41 @@
+#!/sbin/python
+from collections import defaultdict
+import re
+import os
+import sys
+
+def deinterleave(file_path: str):
+    thread_logs = defaultdict(list)
+    
+    with open(file_path, "r") as infile:
+        for line in infile:
+            #log format is like this:
+            #13:40:26.262 [ForkJoinPool-1-worker-9]
+            #\[ForkJoinPool-1-worker-\([0-9]\+\)]
+            pattern = re.compile(r"\[ForkJoinPool-1-worker-([0-9]+)]")
+            #pattern = re.compile(r"ForkJoinPool")
+            with open(file_path, "r") as infile:
+                for line in infile:
+                    match = pattern.search(line)
+                    if match:
+                        thread = match.group(1)
+                        thread_logs[thread].append(line.strip())
+                break
+
+    with open(output_file, "w") as outfile:
+        for thread_id, messages in thread_logs.items():
+            outfile.write(f"Logs for {thread_id}:\n")
+            for message in messages:
+                outfile.write(f"{thread_id}: {message}\n")
+            outfile.write("\n")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Usage: python3 specimin_repo_specifics.py <path_to_log_file.log>")
+        sys.exit(1)
+    log_file_path = sys.argv[1]
+    directory: str = os.path.dirname(log_file_path)
+    output_file = os.path.join(directory, 'deinterleaved-log.txt')
+    deinterleave(log_file_path)
+    print(f"De-interleaved log written to: {output_file}")

--- a/ashe_scripts/de-interleave-ashe-log.py
+++ b/ashe_scripts/de-interleave-ashe-log.py
@@ -13,13 +13,18 @@ def deinterleave(file_path: str):
             #13:40:26.262 [ForkJoinPool-1-worker-9]
             #\[ForkJoinPool-1-worker-\([0-9]\+\)]
             pattern = re.compile(r"\[ForkJoinPool-1-worker-([0-9]+)]")
+            fallbackPattern = re.compile(r"\[main]")
             #pattern = re.compile(r"ForkJoinPool")
+            thread = "main"
             with open(file_path, "r") as infile:
                 for line in infile:
                     match = pattern.search(line)
+                    fallbackMatch = fallbackPattern.search(line)
                     if match:
                         thread = match.group(1)
-                        thread_logs[thread].append(line.strip())
+                    if fallbackMatch:
+                        thread = "main"
+                    thread_logs[thread].append(line.strip())
                 break
 
     with open(output_file, "w") as outfile:

--- a/ashe_scripts/run_ashe_for_stats.py
+++ b/ashe_scripts/run_ashe_for_stats.py
@@ -40,12 +40,13 @@ def run(ashe_path: str, csv_path: str, clone_path: str, props_file_path: str):
     main_project_dir = os.path.abspath(os.path.join(current_dir, '..', '..'))
     stats_script = os.path.join(current_dir, 'specimin_statistics.py')
     rank_script = os.path.join(current_dir, 'specimin_exception_rank.py')
+    deinterleave_script = os.path.join(current_dir, 'de-interleave-ashe-log.py')
     print(f"Current directory path after normalising: {current_dir}")
     print(f"main project path: {main_project_dir}")
     print(f"Statistics script path: {stats_script}")
     print(f"Exception rank script path: {rank_script}")
     
-    __build_and_run_ashe(csv_path, clone_path, props_file_path, working_dir=ashe_path)
+    #__build_and_run_ashe(csv_path, clone_path, props_file_path, working_dir=ashe_path)
 
     current_dir = os.path.dirname(os.path.abspath(__file__))
     print(f"Current directory path: {current_dir}")
@@ -53,12 +54,17 @@ def run(ashe_path: str, csv_path: str, clone_path: str, props_file_path: str):
     main_project_dir = os.path.abspath(os.path.join(current_dir, '..', '..'))
     stats_script = os.path.join(current_dir, 'specimin_statistics.py')
     rank_script = os.path.join(current_dir, 'specimin_exception_rank.py')
+    deinterleave_script = os.path.join(current_dir, 'de-interleave-ashe-log.py')
     print(f"Current directory path after normalising: {current_dir}")
     print(f"main project path: {main_project_dir}")
     print(f"Statistics script path: {stats_script}")
     print(f"Exception rank script path: {rank_script}")
+    print(f"De Interleave script path: {deinterleave_script}")
     # run Specimin scripts
     log_path: str = os.path.join(ashe_path, "logs", "app.log")
+    print("Deinterleaving multithreaded script")
+    __run_command(f"python3 {deinterleave_script} {log_path}")
+    log_path = os.path.join(ashe_path, "logs", "deinterleaved-log.txt")
     print("Running statistics script...")
     __run_command(f"python3 {stats_script} {log_path}")
 

--- a/ashe_scripts/run_ashe_for_stats.py
+++ b/ashe_scripts/run_ashe_for_stats.py
@@ -46,7 +46,7 @@ def run(ashe_path: str, csv_path: str, clone_path: str, props_file_path: str):
     print(f"Statistics script path: {stats_script}")
     print(f"Exception rank script path: {rank_script}")
     
-    #__build_and_run_ashe(csv_path, clone_path, props_file_path, working_dir=ashe_path)
+    __build_and_run_ashe(csv_path, clone_path, props_file_path, working_dir=ashe_path)
 
     current_dir = os.path.dirname(os.path.abspath(__file__))
     print(f"Current directory path: {current_dir}")

--- a/ashe_scripts/run_ashe_for_stats.py
+++ b/ashe_scripts/run_ashe_for_stats.py
@@ -26,7 +26,7 @@ def run(ashe_path: str, csv_path: str, clone_path: str, props_file_path: str):
         props_file_path: absolute path to the directory containing the config.properties files for ASHE
     """
 
-    ashe_url: str = "https://github.com/jonathan-m-phillips/ASHE_Automated-Software-Hardening-for-Entrypoints"
+    ashe_url: str = "https://github.com/njit-jerse/ASHE_Automated-Software-Hardening-for-Entrypoints"
     # clone or update repository
     __git_clone_or_update(ashe_url, ashe_path)
 


### PR DESCRIPTION
When I multithreaded ASHE to speed up CI checks, I made the logs print out in a random order. This should filter it by thread and then sort the results alphabetically so it remains consistent regardless of how many threads the CI tests run on.
This should also let me figure out what failed during CI for #381.
If this PR passes CI don't merge it yet, I need to diff the results from this with my own results before that happens.