### PR TITLE
Use fully-qualified name for java.lang.Error()

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -32,7 +32,7 @@ public final class JavaLangUtils {
 
   /** Don't call this. */
   private JavaLangUtils() {
-    throw new Error("cannot be instantiated");
+    throw new java.lang.Error("cannot be instantiated");
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -32,7 +32,7 @@ public final class JavaLangUtils {
 
   /** Don't call this. */
   private JavaLangUtils() {
-    throw new java.lang.Error("cannot be instantiated");
+    throw new Error("cannot be instantiated");
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -44,7 +44,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /**
  * This visitor removes every member in the compilation unit that is not a member of its {@link
  * #targetMethods} set or {@link #usedMembers} set. It also deletes the bodies of all methods and
- * replaces them with "throw new Error();" or remove the initializers of fields (minimized if the
+ * replaces them with "throw new java.lang.Error();" or remove the initializers of fields (minimized if the
  * field is final) within the {@link #usedMembers} set.
  */
 public class PrunerVisitor extends SpeciminStateVisitor {
@@ -343,7 +343,7 @@ public class PrunerVisitor extends SpeciminStateVisitor {
     if (insideFunctionalInterface && usedMembers.contains(signature)) {
       if (methodDecl.getBody().isPresent()) {
         // avoid introducing unsolved symbols into the final output.
-        methodDecl.setBody(StaticJavaParser.parseBlock("{ throw new Error(); }"));
+        methodDecl.setBody(StaticJavaParser.parseBlock("{ throw new java.lang.Error(); }"));
       }
       return methodDecl;
     }
@@ -352,7 +352,7 @@ public class PrunerVisitor extends SpeciminStateVisitor {
       boolean isMethodInsideInterface = isInsideInterface(methodDecl);
       // do nothing if methodDecl is just a method signature in a class.
       if (methodDecl.getBody().isPresent() || isMethodInsideInterface) {
-        methodDecl.setBody(StaticJavaParser.parseBlock("{ throw new Error(); }"));
+        methodDecl.setBody(StaticJavaParser.parseBlock("{ throw new java.lang.Error(); }"));
         // static and default keywords can not be together.
         if (isMethodInsideInterface && !methodDecl.isStatic()) {
           methodDecl.setDefault(true);
@@ -394,7 +394,7 @@ public class PrunerVisitor extends SpeciminStateVisitor {
     // we need to preserve all constructors to retain compilability.
     if (usedMembers.contains(qualifiedSignature) || JavaParserUtil.isInEnum(constructorDecl)) {
       if (!needToPreserveSuperOrThisCall(constructorDecl.resolve())) {
-        constructorDecl.setBody(StaticJavaParser.parseBlock("{ throw new Error(); }"));
+        constructorDecl.setBody(StaticJavaParser.parseBlock("{ throw new java.lang.Error(); }"));
         return constructorDecl;
       }
 
@@ -411,7 +411,7 @@ public class PrunerVisitor extends SpeciminStateVisitor {
       }
 
       // not sure if we will ever get to this line. So this line is merely for the peace of mind.
-      constructorDecl.setBody(StaticJavaParser.parseBlock("{ throw new Error(); }"));
+      constructorDecl.setBody(StaticJavaParser.parseBlock("{ throw new java.lang.Error(); }"));
       return constructorDecl;
     }
 

--- a/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
@@ -260,7 +260,7 @@ public class UnsolvedMethod {
     if (isJustMethodSignature) {
       return signature.append(";").toString();
     } else {
-      return "\n    " + signature + " {\n        throw new Error();\n    }\n";
+      return "\n    " + signature + " {\n        throw new java.lang.Error();\n    }\n";
     }
   }
 }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -3227,7 +3227,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
           new BufferedWriter(new FileWriter(filePath.toFile(), StandardCharsets.UTF_8))) {
         writer.write(fileContent.toString());
       } catch (Exception e) {
-        throw new java.lang.Error(e.getMessage());
+        throw new Error(e.getMessage());
       }
     } catch (IOException e) {
       System.out.println("Error creating Java file: " + e.getMessage());

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -3227,7 +3227,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
           new BufferedWriter(new FileWriter(filePath.toFile(), StandardCharsets.UTF_8))) {
         writer.write(fileContent.toString());
       } catch (Exception e) {
-        throw new Error(e.getMessage());
+        throw new java.lang.Error(e.getMessage());
       }
     } catch (IOException e) {
       System.out.println("Error creating Java file: " + e.getMessage());

--- a/src/test/resources/ExceptionTypeInferenceImprecision/expected/org/fortest/UnsolvedType.java
+++ b/src/test/resources/ExceptionTypeInferenceImprecision/expected/org/fortest/UnsolvedType.java
@@ -3,6 +3,6 @@ package org.fortest;
 public class UnsolvedType extends java.lang.RuntimeException {
 
     public UnsolvedType(java.lang.String parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/HiddenSuperFieldAndUnsolvedLocal/expected/sample/pack/MyType.java
+++ b/src/test/resources/HiddenSuperFieldAndUnsolvedLocal/expected/sample/pack/MyType.java
@@ -3,6 +3,6 @@ package sample.pack;
 public class MyType {
 
     public MyType() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/ObjectCreationInsideAnonymousClass/expected/org/testing/Baz.java
+++ b/src/test/resources/ObjectCreationInsideAnonymousClass/expected/org/testing/Baz.java
@@ -3,10 +3,10 @@ package org.testing;
 public class Baz {
 
     public Baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void remove() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/ObjectCreationInsideAnonymousClass/expected/org/testing/Foo.java
+++ b/src/test/resources/ObjectCreationInsideAnonymousClass/expected/org/testing/Foo.java
@@ -3,10 +3,10 @@ package org.testing;
 public class Foo {
 
     public Foo(java.lang.String parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public RemoveReturnType remove() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/ThrowableImprecision/expected/org/fortest/UnsolvedType.java
+++ b/src/test/resources/ThrowableImprecision/expected/org/fortest/UnsolvedType.java
@@ -3,6 +3,6 @@ package org.fortest;
 public class UnsolvedType  {
 
     public static int getType() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/ThrowableImprecision/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/ThrowableImprecision/expected/org/testing/UnsolvedType.java
@@ -3,6 +3,6 @@ package org.testing;
 public class UnsolvedType extends java.lang.Throwable {
 
     public UnsolvedType() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/ThrowableType/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/ThrowableType/expected/org/testing/UnsolvedType.java
@@ -3,6 +3,6 @@ package org.testing;
 public class UnsolvedType extends java.lang.Throwable {
 
     public UnsolvedType() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/UsedMethodsInInnerClass/expected/com/example/Baz.java
+++ b/src/test/resources/UsedMethodsInInnerClass/expected/com/example/Baz.java
@@ -5,7 +5,7 @@ public class Baz {
     public static class BazFirstChild {
 
         public static void test() {
-            throw new Error();
+            throw new java.lang.Error();
         }
     }
 }

--- a/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
+++ b/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
@@ -7,58 +7,58 @@ import java.util.Collection;
 class WrappedSet<K, V> implements Set<V> {
 
     WrappedSet(K key, Set<V> delegate) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public int size() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public Iterator<V> iterator() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void clear() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean remove(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean removeAll(Collection<?> c) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean retainAll(Collection<?> c) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean addAll(Collection<? extends V> collection) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean contains(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean containsAll(Collection<?> c) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean add(V value) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public <T> T[] toArray(T[] type) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public Object[] toArray() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean isEmpty() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/abstractimpl/input/com/example/WrappedSet.java
+++ b/src/test/resources/abstractimpl/input/com/example/WrappedSet.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 class WrappedSet<K, V> implements Set<V> {
 
     WrappedSet(K key, Set<V> delegate) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     @Override

--- a/src/test/resources/anonclassscope/expected/com/example/Simple.java
+++ b/src/test/resources/anonclassscope/expected/com/example/Simple.java
@@ -17,6 +17,6 @@ public final class Simple {
     }
 
     private static void cast(Object value) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/anonymousclass/expected/com/nameless/SomeClass.java
+++ b/src/test/resources/anonymousclass/expected/com/nameless/SomeClass.java
@@ -3,9 +3,9 @@ package com.nameless;
 public class SomeClass {
 
     public SomeClass() {
-        throw new Error();
+        throw new java.lang.Error();
     }
     public int getLocalVar() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/booleanexpr/expected/com/example/Foo.java
+++ b/src/test/resources/booleanexpr/expected/com/example/Foo.java
@@ -7,26 +7,26 @@ public class Foo {
     public boolean isBaz;
 
     public boolean isBar() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public int qux() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public double razz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public int getX() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public long getLong() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public Long getBigLong() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/booleanreturn/expected/org/example/ElementUtils.java
+++ b/src/test/resources/booleanreturn/expected/org/example/ElementUtils.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class ElementUtils {
     public static boolean isEffectivelyFinal() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/booleanreturn/expected/org/example/Foo.java
+++ b/src/test/resources/booleanreturn/expected/org/example/Foo.java
@@ -5,6 +5,6 @@ public class Foo {
     public boolean good;
 
     public boolean isGood() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/callJavaParser/expected/com/github/javaparser/ast/CompilationUnit.java
+++ b/src/test/resources/callJavaParser/expected/com/github/javaparser/ast/CompilationUnit.java
@@ -2,6 +2,6 @@ package com.github.javaparser.ast;
 public class CompilationUnit {
 
     public CompilationUnit() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/constraintType/expected/org/example/Baz.java
+++ b/src/test/resources/constraintType/expected/org/example/Baz.java
@@ -3,6 +3,6 @@ package org.example;
 public class Baz {
 
     public String printValue() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/constructorchaining/expected/com/example/Foo.java
+++ b/src/test/resources/constructorchaining/expected/com/example/Foo.java
@@ -2,6 +2,6 @@ package com.example;
 
 public class Foo {
     public Foo(int x, Object f) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/constructorchaining2/expected/com/example/Foo.java
+++ b/src/test/resources/constructorchaining2/expected/com/example/Foo.java
@@ -2,6 +2,6 @@ package com.example;
 
 public class Foo {
     public Foo(int x, Object f) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/constructorrequirement/expected/com/example/Baz.java
+++ b/src/test/resources/constructorrequirement/expected/com/example/Baz.java
@@ -3,6 +3,6 @@ package com.example;
 public class Baz {
 
     public Baz(String args) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/ctorargument/expected/com/example/Simple.java
+++ b/src/test/resources/ctorargument/expected/com/example/Simple.java
@@ -17,6 +17,6 @@ public class Simple {
     }
 
     public void baz() throws VerifierConstraintViolatedException {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/ctorargument/expected/org/example/VerificationResult.java
+++ b/src/test/resources/ctorargument/expected/org/example/VerificationResult.java
@@ -7,6 +7,6 @@ public class VerificationResult {
     public static org.example.VerificationResult OK;
 
     public VerificationResult(org.example.OrgExampleVerificationResultVERIFIED_REJECTEDSyntheticType parameter0, java.lang.String parameter1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/ctorargument/expected/org/example/VerifierConstraintViolatedException.java
+++ b/src/test/resources/ctorargument/expected/org/example/VerifierConstraintViolatedException.java
@@ -3,6 +3,6 @@ package org.example;
 public class VerifierConstraintViolatedException extends Exception {
 
     public ExtendMessageReturnType extendMessage(java.lang.String parameter0, java.lang.String parameter1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/ctortarget/expected/com/example/Simple.java
+++ b/src/test/resources/ctortarget/expected/com/example/Simple.java
@@ -2,6 +2,6 @@ package com.example;
 
 class Simple {
     private Simple(Foo foo, int x) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/ctortarget/input/com/example/Simple.java
+++ b/src/test/resources/ctortarget/input/com/example/Simple.java
@@ -2,6 +2,6 @@ package com.example;
 
 class Simple {
     private Simple(Foo foo, int x) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/customexception/expected/com/example/CustomException.java
+++ b/src/test/resources/customexception/expected/com/example/CustomException.java
@@ -3,6 +3,6 @@ package com.example;
 public class CustomException extends Exception {
 
     public CustomException(String msg) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/differentparamtypes/expected/com/example/Simple.java
+++ b/src/test/resources/differentparamtypes/expected/com/example/Simple.java
@@ -9,6 +9,6 @@ class Simple {
     }
 
     void foo(List<?> baz) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/enumconstantarg/expected/com/example/Foo.java
+++ b/src/test/resources/enumconstantarg/expected/com/example/Foo.java
@@ -9,7 +9,7 @@ class Foo {
         PREFIX(Op.EQ);
 
         Mode(Op op) {
-            throw new Error();
+            throw new java.lang.Error();
         }
     }
 

--- a/src/test/resources/enumswitch/expected/com/example/Analysis.java
+++ b/src/test/resources/enumswitch/expected/com/example/Analysis.java
@@ -8,6 +8,6 @@ public interface Analysis {
     }
 
     default Direction getDirection() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/enumswitch/input/com/example/Analysis.java
+++ b/src/test/resources/enumswitch/input/com/example/Analysis.java
@@ -7,6 +7,6 @@ public interface Analysis {
     }
 
     default Direction getDirection() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/extendqualifiedpath/expected/com/example/Baz.java
+++ b/src/test/resources/extendqualifiedpath/expected/com/example/Baz.java
@@ -3,6 +3,6 @@ package com.example;
 public interface Baz<E> extends org.testing.Baz<E> {
 
     default void bar() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/extendssourcebutnottarget/expected/com/example/C.java
+++ b/src/test/resources/extendssourcebutnottarget/expected/com/example/C.java
@@ -2,6 +2,6 @@ package com.example;
 
 public class C {
     public void foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/extendswithtypevar/expected/com/example/AbstractMapEntry.java
+++ b/src/test/resources/extendswithtypevar/expected/com/example/AbstractMapEntry.java
@@ -3,10 +3,10 @@ package com.example;
 abstract class AbstractMapEntry<K, V> {
 
     public V setValue(V value) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public K getKey() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/extendswithtypevar/input/com/example/AbstractMapEntry.java
+++ b/src/test/resources/extendswithtypevar/input/com/example/AbstractMapEntry.java
@@ -8,7 +8,7 @@ import java.util.Map.Entry;
 abstract class AbstractMapEntry<K, V> implements Entry<K, V> {
 
     public V setValue(V value) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public K getKey() {
@@ -16,10 +16,10 @@ abstract class AbstractMapEntry<K, V> implements Entry<K, V> {
     }
 
     public boolean equals(Object object) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public int hashCode() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/fieldinenum/expected/com/example/Foo.java
+++ b/src/test/resources/fieldinenum/expected/com/example/Foo.java
@@ -9,7 +9,7 @@ class Foo {
         int bitRep;
 
         Status(int x) {
-            throw new Error();
+            throw new java.lang.Error();
         }
     }
 

--- a/src/test/resources/foreachiterable/expected/org/example/Baz.java
+++ b/src/test/resources/foreachiterable/expected/org/example/Baz.java
@@ -3,6 +3,6 @@ package org.example;
 public class Baz {
 
     public org.example.Foo[] getFoos() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/foreachlocal/expected/com/example/Foo.java
+++ b/src/test/resources/foreachlocal/expected/com/example/Foo.java
@@ -3,6 +3,6 @@ package com.example;
 public class Foo {
 
     public DoSomethingReturnType doSomething() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/generictypemethod/expected/com/example/Baz.java
+++ b/src/test/resources/generictypemethod/expected/com/example/Baz.java
@@ -3,6 +3,6 @@ package com.example;
 public class Baz<T> {
 
     public T baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/hiddenType/expected/com/github/javaparser/ast/body/GetTypeReturnType.java
+++ b/src/test/resources/hiddenType/expected/com/github/javaparser/ast/body/GetTypeReturnType.java
@@ -2,6 +2,6 @@ package com.github.javaparser.ast.body;
 public class GetTypeReturnType {
 
     public boolean isVoidType() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/hiddenType/expected/com/github/javaparser/ast/body/MethodDeclaration.java
+++ b/src/test/resources/hiddenType/expected/com/github/javaparser/ast/body/MethodDeclaration.java
@@ -2,6 +2,6 @@ package com.github.javaparser.ast.body;
 public class MethodDeclaration {
 
     public GetTypeReturnType getType() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/implicitinterfaceaccess/expected/org/testing/B.java
+++ b/src/test/resources/implicitinterfaceaccess/expected/org/testing/B.java
@@ -3,6 +3,6 @@ package org.testing;
 public interface B {
 
     public default int baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/implicitinterfaceaccessforinnerclass/expected/com/example/Simple.java
+++ b/src/test/resources/implicitinterfaceaccessforinnerclass/expected/com/example/Simple.java
@@ -5,7 +5,7 @@ import org.fortesting.Parent2;
 public class Simple {
 
     void foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     class InnerClass2 extends Parent2 {

--- a/src/test/resources/implicitinterfaceaccessforinnerclass/expected/org/fortesting/Parent2.java
+++ b/src/test/resources/implicitinterfaceaccessforinnerclass/expected/org/fortesting/Parent2.java
@@ -3,6 +3,6 @@ package org.fortesting;
 public class Parent2 {
 
     public Method1ReturnType method1() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/implicitinterfaceaccessmethodoverload/expected/com/example/Simple.java
+++ b/src/test/resources/implicitinterfaceaccessmethodoverload/expected/com/example/Simple.java
@@ -13,6 +13,6 @@ abstract class Simple implements B {
     }
 
     int foo(int x) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/implicitinterfaceaccessmethodoverload/expected/org/testing/B.java
+++ b/src/test/resources/implicitinterfaceaccessmethodoverload/expected/org/testing/B.java
@@ -3,6 +3,6 @@ package org.testing;
 public interface B {
 
     public default FooReturnType foo(int parameter0, java.lang.String parameter1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/implicitinterfaceaccesswithmanyinterfaces/expected/org/testing/D.java
+++ b/src/test/resources/implicitinterfaceaccesswithmanyinterfaces/expected/org/testing/D.java
@@ -3,6 +3,6 @@ package org.testing;
 public interface D {
 
     public default int baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/implicitsupercall/expected/org/testing/B.java
+++ b/src/test/resources/implicitsupercall/expected/org/testing/B.java
@@ -3,6 +3,6 @@ package org.testing;
 public class B {
 
     public int baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/importremovalstatic/expected/org/example/Preconditions.java
+++ b/src/test/resources/importremovalstatic/expected/org/example/Preconditions.java
@@ -3,6 +3,6 @@ package org.example;
 public class Preconditions {
 
     public static void checkArgument(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/inheritmethodexception/expected/com/example/Parent.java
+++ b/src/test/resources/inheritmethodexception/expected/com/example/Parent.java
@@ -3,6 +3,6 @@ package com.example;
 public class Parent {
 
     public void foo() throws UnknownException {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/inheritmethodexception/expected/com/example/Simple.java
+++ b/src/test/resources/inheritmethodexception/expected/com/example/Simple.java
@@ -3,6 +3,6 @@ package com.example;
 public class Simple extends Parent {
 
     public void foo() throws UnknownException {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/inheritmethodexception/input/com/example/Simple.java
+++ b/src/test/resources/inheritmethodexception/input/com/example/Simple.java
@@ -3,6 +3,6 @@ package com.example;
 public class Simple extends Parent {
     @Override
     public void foo() throws UnknownException {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/innerclasstypecorrect/expected/org/example/Outer.java
+++ b/src/test/resources/innerclasstypecorrect/expected/org/example/Outer.java
@@ -7,6 +7,6 @@ public class Outer {
     }
 
     public static org.example.Outer.Inner getInner() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/innerclassusage/expected/com/example/Baz.java
+++ b/src/test/resources/innerclassusage/expected/com/example/Baz.java
@@ -7,7 +7,7 @@ public class Baz {
         public static class NestedInnerBaz {
 
             public void test() {
-                throw new Error();
+                throw new java.lang.Error();
             }
         }
     }

--- a/src/test/resources/innerclassusage/input/com/example/Baz.java
+++ b/src/test/resources/innerclassusage/input/com/example/Baz.java
@@ -5,7 +5,7 @@ public class Baz {
     public static class InnerBaz {
 
         public void toBeRemovedToo() {
-            throw new Error();
+            throw new java.lang.Error();
         }
 
         public static class NestedInnerBaz {
@@ -14,7 +14,7 @@ public class Baz {
             }
 
             public void toBeRemoved() {
-                throw new Error();
+                throw new java.lang.Error();
             }
         }
     }

--- a/src/test/resources/interfacechain/expected/com/example/Foo.java
+++ b/src/test/resources/interfacechain/expected/com/example/Foo.java
@@ -6,7 +6,7 @@ public class Foo<E> {
     public Iterator<E> iterator() {
         return new AbstractLinkedIterator() {
             E computeNext() {
-                throw new Error();
+                throw new java.lang.Error();
             }
         };
     }
@@ -15,11 +15,11 @@ public class Foo<E> {
         abstract E computeNext();
 
         public E next() {
-            throw new Error();
+            throw new java.lang.Error();
         }
 
         public boolean hasNext() {
-            throw new Error();
+            throw new java.lang.Error();
         }
     }
 

--- a/src/test/resources/interfacechain/input/com/example/Foo.java
+++ b/src/test/resources/interfacechain/input/com/example/Foo.java
@@ -7,7 +7,7 @@ public class Foo<E> {
         return new AbstractLinkedIterator() {
             @Override
             E computeNext() {
-                throw new Error();
+                throw new java.lang.Error();
             }
         };
     }
@@ -17,12 +17,12 @@ public class Foo<E> {
 
         @Override
         public E next() {
-            throw new Error();
+            throw new java.lang.Error();
         }
 
         @Override
         public boolean hasNext() {
-            throw new Error();
+            throw new java.lang.Error();
         }
     }
 

--- a/src/test/resources/interfaceimplemented/expected/com/example/Baz.java
+++ b/src/test/resources/interfaceimplemented/expected/com/example/Baz.java
@@ -3,6 +3,6 @@ package com.example;
 public interface Baz {
 
     default void doSomething() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/interfacemethodwithunsolvedtype/expected/com/example/Baz.java
+++ b/src/test/resources/interfacemethodwithunsolvedtype/expected/com/example/Baz.java
@@ -5,6 +5,6 @@ import org.testing.UnsolvedType;
 public interface Baz<T> {
 
     default UnsolvedType doSomething(T value) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/interfaceusecomplex/expected/com/example/Baz.java
+++ b/src/test/resources/interfaceusecomplex/expected/com/example/Baz.java
@@ -2,6 +2,6 @@ package com.example;
 
 public interface Baz<E> {
     public default boolean containsAll(com.example.Baz<?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/interfacewithgenerictype/expected/com/example/Baz.java
+++ b/src/test/resources/interfacewithgenerictype/expected/com/example/Baz.java
@@ -3,10 +3,10 @@ package com.example;
 public interface Baz<T> {
 
     default void doSomething(T value) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     default void doSomething(int x) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/interfacewithunsolvedsymbols/expected/com/example/Baz.java
+++ b/src/test/resources/interfacewithunsolvedsymbols/expected/com/example/Baz.java
@@ -3,10 +3,10 @@ package com.example;
 public interface Baz<T> {
 
     default void doSomething(T value) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     default void doSomething(int x) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/issue103/expected/com/example/AbstractLinkedDeque.java
+++ b/src/test/resources/issue103/expected/com/example/AbstractLinkedDeque.java
@@ -5,98 +5,98 @@ import java.util.AbstractCollection;
 public abstract class AbstractLinkedDeque<E> extends AbstractCollection<E> implements LinkedDeque<E> {
 
     public int size() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E peek() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E peekFirst() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E peekLast() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E getFirst() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E getLast() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E element() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean offer(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean offerFirst(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean offerLast(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void addFirst(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void addLast(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E poll() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E pollFirst() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E pollLast() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E remove() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E removeFirst() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean removeFirstOccurrence(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E removeLast() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean removeLastOccurrence(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void push(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E pop() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public PeekingIterator<E> iterator() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public PeekingIterator<E> descendingIterator() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/issue103/expected/com/example/Simple.java
+++ b/src/test/resources/issue103/expected/com/example/Simple.java
@@ -3,7 +3,7 @@ package com.example;
 public class Simple<K> {
 
     AccessOrderDeque<K> bar() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     void foo() {

--- a/src/test/resources/issue103/input/com/example/AbstractLinkedDeque.java
+++ b/src/test/resources/issue103/input/com/example/AbstractLinkedDeque.java
@@ -6,116 +6,116 @@ import java.util.Collection;
 public abstract class AbstractLinkedDeque<E> extends AbstractCollection<E> implements LinkedDeque<E> {
 
     public boolean isEmpty() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public int size() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void clear() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public abstract boolean contains(Object o);
 
     public E peek() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E peekFirst() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E peekLast() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E getFirst() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E getLast() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E element() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean offer(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean offerFirst(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean offerLast(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean add(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void addFirst(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void addLast(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E poll() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E pollFirst() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E pollLast() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E remove() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E removeFirst() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean removeFirstOccurrence(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E removeLast() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean removeLastOccurrence(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean removeAll(Collection<?> c) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void push(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E pop() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public PeekingIterator<E> iterator() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public PeekingIterator<E> descendingIterator() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/issue103/input/com/example/AccessOrderDeque.java
+++ b/src/test/resources/issue103/input/com/example/AccessOrderDeque.java
@@ -5,26 +5,26 @@ import java.util.Deque;
 public final class AccessOrderDeque<E> extends AbstractLinkedDeque<E> {
 
     public boolean contains(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean remove(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E getPrevious(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void setPrevious(E e, E prev) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E getNext(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void setNext(E e, E next) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/issue103/input/com/example/Simple.java
+++ b/src/test/resources/issue103/input/com/example/Simple.java
@@ -2,7 +2,7 @@ package com.example;
 
 public class Simple<K> {
     AccessOrderDeque<K> bar() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     // Target method

--- a/src/test/resources/issue272/expected/com/example/Simple.java
+++ b/src/test/resources/issue272/expected/com/example/Simple.java
@@ -9,7 +9,7 @@ public class Simple {
         PRECONDITION(PreconditionAnnotation.class), POSTCONDITION(PostconditionAnnotation.class);
 
         Kind(Class<? extends Annotation> metaAnnotation) {
-            throw new Error();
+            throw new java.lang.Error();
         }
     }
 

--- a/src/test/resources/issue298/expected/com/example/AnnotationUtils.java
+++ b/src/test/resources/issue298/expected/com/example/AnnotationUtils.java
@@ -5,6 +5,6 @@ import javax.lang.model.element.AnnotationMirror;
 public class AnnotationUtils {
 
   public static boolean areSameByName(AnnotationMirror am, String aname) {
-    throw new Error();
+    throw new java.lang.Error();
   }
 }

--- a/src/test/resources/issue368/expected/com/example/A.java
+++ b/src/test/resources/issue368/expected/com/example/A.java
@@ -5,6 +5,6 @@ import java.net.InetAddress;
 public class A {
 
     public InetAddress test() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/iteratorexample/expected/com/example/Simple.java
+++ b/src/test/resources/iteratorexample/expected/com/example/Simple.java
@@ -3,7 +3,7 @@ package com.example;
 class Simple {
 
     public <K, V> Iterator<Map.Entry<K, V>> iterator() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     void bar() {

--- a/src/test/resources/jarfile/expected/an/old/library/Book.java
+++ b/src/test/resources/jarfile/expected/an/old/library/Book.java
@@ -3,10 +3,10 @@ package an.old.library;
 public class Book {
 
     public Book(int var1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public String getRates() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabifunction/expected/org/example/LambdaUser.java
+++ b/src/test/resources/lambdabifunction/expected/org/example/LambdaUser.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class LambdaUser {
     public UseReturnType use(java.util.function.BiFunction<?, ?, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabody/expected/com/example/sql/SqlNode.java
+++ b/src/test/resources/lambdabody/expected/com/example/sql/SqlNode.java
@@ -2,6 +2,6 @@ package com.example.sql;
 
 public class SqlNode {
     public SqlParserPos getParserPosition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabody/expected/com/example/util/Cast.java
+++ b/src/test/resources/lambdabody/expected/com/example/util/Cast.java
@@ -3,6 +3,6 @@ package com.example.util;
 public class Cast {
 
     public static <T extends Object> T castNonNull(T t) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabody/expected/com/example/util/Util.java
+++ b/src/test/resources/lambdabody/expected/com/example/util/Util.java
@@ -2,6 +2,6 @@ package com.example.util;
 
 public class Util {
     public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable, java.util.function.Function<? super F, ? extends T> function) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabody/input/com/example/sql/SqlNode.java
+++ b/src/test/resources/lambdabody/input/com/example/sql/SqlNode.java
@@ -2,6 +2,6 @@ package com.example.sql;
 
 public class SqlNode {
     public SqlParserPos getParserPosition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabody/input/com/example/util/Util.java
+++ b/src/test/resources/lambdabody/input/com/example/util/Util.java
@@ -3,6 +3,6 @@ package com.example.util;
 public class Util {
     public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable,
                                                java.util.function.Function<? super F, ? extends T> function) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/nullness/Nullness.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/nullness/Nullness.java
@@ -3,6 +3,6 @@ package com.example.nullness;
 public class Nullness {
 
     public static com.example.sql.SqlParserPos castNonNull(java.lang.Object parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/sql/SqlNode.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/sql/SqlNode.java
@@ -2,6 +2,6 @@ package com.example.sql;
 
 public class SqlNode {
     public SqlParserPos getParserPosition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/util/Util.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/util/Util.java
@@ -2,6 +2,6 @@ package com.example.util;
 
 public class Util {
     public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable, java.util.function.Function<? super F, ? extends T> function) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved/input/com/example/sql/SqlNode.java
+++ b/src/test/resources/lambdabodystaticunsolved/input/com/example/sql/SqlNode.java
@@ -2,6 +2,6 @@ package com.example.sql;
 
 public class SqlNode {
     public SqlParserPos getParserPosition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved/input/com/example/util/Util.java
+++ b/src/test/resources/lambdabodystaticunsolved/input/com/example/util/Util.java
@@ -3,6 +3,6 @@ package com.example.util;
 public class Util {
     public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable,
                                                java.util.function.Function<? super F, ? extends T> function) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved2/expected/com/example/nullness/Nullness.java
+++ b/src/test/resources/lambdabodystaticunsolved2/expected/com/example/nullness/Nullness.java
@@ -3,6 +3,6 @@ package com.example.nullness;
 public class Nullness {
 
     public static <SyntheticUnconstrainedType> SyntheticUnconstrainedType castNonNull(java.lang.Object parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved2/expected/com/example/sql/SqlNode.java
+++ b/src/test/resources/lambdabodystaticunsolved2/expected/com/example/sql/SqlNode.java
@@ -2,6 +2,6 @@ package com.example.sql;
 
 public class SqlNode {
     public SqlParserPos getParserPosition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved2/expected/com/example/util/Util.java
+++ b/src/test/resources/lambdabodystaticunsolved2/expected/com/example/util/Util.java
@@ -2,6 +2,6 @@ package com.example.util;
 
 public class Util {
     public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable, java.util.function.Function<? super F, ? extends T> function) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved2/input/com/example/sql/SqlNode.java
+++ b/src/test/resources/lambdabodystaticunsolved2/input/com/example/sql/SqlNode.java
@@ -2,6 +2,6 @@ package com.example.sql;
 
 public class SqlNode {
     public SqlParserPos getParserPosition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved2/input/com/example/util/Util.java
+++ b/src/test/resources/lambdabodystaticunsolved2/input/com/example/util/Util.java
@@ -3,6 +3,6 @@ package com.example.util;
 public class Util {
     public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable,
                                                java.util.function.Function<? super F, ? extends T> function) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdaconsumer/expected/org/example/LambdaUser.java
+++ b/src/test/resources/lambdaconsumer/expected/org/example/LambdaUser.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class LambdaUser {
     public UseReturnType use(java.util.function.Consumer<?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdafunction/expected/org/example/LambdaUser.java
+++ b/src/test/resources/lambdafunction/expected/org/example/LambdaUser.java
@@ -3,6 +3,6 @@ package org.example;
 public class LambdaUser {
 
     public UseReturnType use(java.util.function.Function<?, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdaparamwithtype/expected/org/example/FunctionalProgramming.java
+++ b/src/test/resources/lambdaparamwithtype/expected/org/example/FunctionalProgramming.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class FunctionalProgramming {
     public static OrgExampleFunctionalProgrammingMapReturnType map(java.util.function.Function<?, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdaparamwithtypevar/expected/org/example/FunctionalProgramming.java
+++ b/src/test/resources/lambdaparamwithtypevar/expected/org/example/FunctionalProgramming.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class FunctionalProgramming {
     public static OrgExampleFunctionalProgrammingMapReturnType map(java.util.function.Function<?, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdaparamwithtypevar/expected/org/example/MyList.java
+++ b/src/test/resources/lambdaparamwithtypevar/expected/org/example/MyList.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class MyList<T> {
     public ToArrayReturnType toArray() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdaquadfunction/expected/org/example/LambdaUser.java
+++ b/src/test/resources/lambdaquadfunction/expected/org/example/LambdaUser.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class LambdaUser {
     public UseReturnType use(SyntheticFunction4<?, ?, ?, ?, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdasupplier/expected/org/example/LambdaUser.java
+++ b/src/test/resources/lambdasupplier/expected/org/example/LambdaUser.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class LambdaUser {
     public UseReturnType use(java.util.function.Supplier<?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdatriconsumer/expected/org/example/LambdaUser.java
+++ b/src/test/resources/lambdatriconsumer/expected/org/example/LambdaUser.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class LambdaUser {
     public UseReturnType use(SyntheticConsumer3<?, ?, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdatrifunction/expected/org/example/LambdaUser.java
+++ b/src/test/resources/lambdatrifunction/expected/org/example/LambdaUser.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class LambdaUser {
     public UseReturnType use(SyntheticFunction3<?, ?, ?, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdatrifunction2/expected/org/example/LambdaUser.java
+++ b/src/test/resources/lambdatrifunction2/expected/org/example/LambdaUser.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class LambdaUser {
     public UseReturnType use(SyntheticFunction3<?, ?, ?, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/localvarinexception/expected/javalanguage/Method.java
+++ b/src/test/resources/localvarinexception/expected/javalanguage/Method.java
@@ -3,10 +3,10 @@ package javalanguage;
 public class Method {
 
     public Method() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public SolveReturnType solve() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/methodcalledbyfield/expected/org/math/Calculator.java
+++ b/src/test/resources/methodcalledbyfield/expected/org/math/Calculator.java
@@ -3,6 +3,6 @@ package org.math;
 public class Calculator {
 
     public int doMultiplication(int parameter0, int parameter1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/methodref/expected/com/example/Simple.java
+++ b/src/test/resources/methodref/expected/com/example/Simple.java
@@ -9,6 +9,6 @@ class Simple {
     }
 
     public static <F, T> List<T> transform(List<? extends F> list, java.util.function.Function<? super F, ? extends T> function) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/methodref/expected/com/example/SqlNode.java
+++ b/src/test/resources/methodref/expected/com/example/SqlNode.java
@@ -3,6 +3,6 @@ package com.example;
 public class SqlNode {
 
     public Integer getParserPosition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/methodref/input/com/example/Simple.java
+++ b/src/test/resources/methodref/input/com/example/Simple.java
@@ -13,6 +13,6 @@ class Simple {
     /** Transforms a list, applying a function to each element. */
     public static <F, T> List<T> transform(List<? extends F> list,
                                            java.util.function.Function<? super F, ? extends T> function) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/methodref/input/com/example/SqlNode.java
+++ b/src/test/resources/methodref/input/com/example/SqlNode.java
@@ -3,6 +3,6 @@ package com.example;
 public class SqlNode {
 
     public Integer getParserPosition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/methodref2/expected/com/example/MethodSignature.java
+++ b/src/test/resources/methodref2/expected/com/example/MethodSignature.java
@@ -3,6 +3,6 @@ package com.example;
 public class MethodSignature {
 
     public String toString() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/methodref2/expected/org/plumelib/util/CollectionsPlume.java
+++ b/src/test/resources/methodref2/expected/org/plumelib/util/CollectionsPlume.java
@@ -3,6 +3,6 @@ package org.plumelib.util;
 public class CollectionsPlume {
 
     public static OrgPlumelibUtilCollectionsPlumeMapListReturnType mapList(java.util.function.Supplier<?> parameter0, java.util.Set<?> parameter1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/methodreturnfullyqualifiedgeneric/expected/com/bar/Bar.java
+++ b/src/test/resources/methodreturnfullyqualifiedgeneric/expected/com/bar/Bar.java
@@ -3,6 +3,6 @@ package com.bar;
 public class Bar<T> {
 
     public static com.bar.Bar<com.example.InOtherPackage2> getOtherPackage2() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/methodreturngeneric/expected/com/bar/Bar.java
+++ b/src/test/resources/methodreturngeneric/expected/com/bar/Bar.java
@@ -3,14 +3,14 @@ package com.bar;
 public class Bar<T> {
 
     public static com.bar.Bar<com.foo.InOtherPackage> getOtherPackage() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static com.bar.Bar<com.example.InSamePackage> getSamePackage() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static com.bar.Bar<Integer> getJavaLang() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/mismatchtypeparameter/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/mismatchtypeparameter/expected/org/testing/UnsolvedType.java
@@ -3,6 +3,6 @@ package org.testing;
 public class UnsolvedType {
 
     public int getInt() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/mismatchtypeparameterhardcase/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/mismatchtypeparameterhardcase/expected/org/testing/UnsolvedType.java
@@ -3,10 +3,10 @@ package org.testing;
 public class UnsolvedType {
 
     public java.util.List<String> getList() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public int getInt() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/multilevelinheritance/expected/com/example/Baz.java
+++ b/src/test/resources/multilevelinheritance/expected/com/example/Baz.java
@@ -3,6 +3,6 @@ package com.example;
 public class Baz extends BazParent {
 
     public Baz(String s) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/multipleboundtypeparameter/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/multipleboundtypeparameter/expected/org/testing/UnsolvedType.java
@@ -3,6 +3,6 @@ package org.testing;
 public class UnsolvedType {
 
     public PrintReturnType print() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/multiplevariabledeclarators/expected/com/example/Simple.java
+++ b/src/test/resources/multiplevariabledeclarators/expected/com/example/Simple.java
@@ -16,6 +16,6 @@ class Simple {
     }
 
     Object baz(Object obj) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/navigablesetexample2/expected/com/example/Simple.java
+++ b/src/test/resources/navigablesetexample2/expected/com/example/Simple.java
@@ -18,7 +18,7 @@ public class Simple {
     static class UnmodifiableNavigableSet<E> extends UnmodifiableSortedSet<E> implements NavigableSet<E> {
 
         UnmodifiableNavigableSet(NavigableSet<E> s) {
-            throw new Error();
+            throw new java.lang.Error();
         }
     }
 }

--- a/src/test/resources/navigablesetexample2/input/com/example/Simple.java
+++ b/src/test/resources/navigablesetexample2/input/com/example/Simple.java
@@ -21,7 +21,7 @@ public class Simple {
     static class UnmodifiableNavigableSet<E> extends UnmodifiableSortedSet<E> implements NavigableSet<E> {
 
         UnmodifiableNavigableSet(NavigableSet<E> s) {
-            throw new Error();
+            throw new java.lang.Error();
         }
     }
 }

--- a/src/test/resources/navigablesetfieldexample/expected/com/example/Simple.java
+++ b/src/test/resources/navigablesetfieldexample/expected/com/example/Simple.java
@@ -16,7 +16,7 @@ public class Simple {
         private static class EmptyNavigableSet<E> extends UnmodifiableNavigableSet<E> {
 
             public EmptyNavigableSet() {
-                throw new Error();
+                throw new java.lang.Error();
             }
         }
 

--- a/src/test/resources/nestedcatchclause/expected/com/example/CustomException.java
+++ b/src/test/resources/nestedcatchclause/expected/com/example/CustomException.java
@@ -3,6 +3,6 @@ package com.example;
 public class CustomException extends Exception {
 
     public CustomException(String msg) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/nestedcatchclause/expected/com/example/Simple.java
+++ b/src/test/resources/nestedcatchclause/expected/com/example/Simple.java
@@ -15,6 +15,6 @@ public class Simple {
     }
 
     private void handleException(CustomException e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/nonprimaryusedmethod/expected/com/example/Baz.java
+++ b/src/test/resources/nonprimaryusedmethod/expected/com/example/Baz.java
@@ -6,6 +6,6 @@ class Baz {
 class NonPrimary {
 
     static void printMessage() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/nullarg/expected/org/example/Baz.java
+++ b/src/test/resources/nullarg/expected/org/example/Baz.java
@@ -3,6 +3,6 @@ package org.example;
 public class Baz {
 
     public QuxReturnType qux(java.lang.Object parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/onefilesimple/expected/com/example/Simple.java
+++ b/src/test/resources/onefilesimple/expected/com/example/Simple.java
@@ -8,6 +8,6 @@ class Simple {
     }
 
     Object baz(Object obj) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/otherpackagearray/expected/com/example/Simple.java
+++ b/src/test/resources/otherpackagearray/expected/com/example/Simple.java
@@ -8,6 +8,6 @@ class Simple {
     }
 
     void baz(Type[] types) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/otherpackagearray/expected/org/example/Method.java
+++ b/src/test/resources/otherpackagearray/expected/org/example/Method.java
@@ -3,6 +3,6 @@ package org.example;
 public class Method {
 
     public org.example.Type[] getTypes() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/otherpackagearray2/expected/com/example/Simple.java
+++ b/src/test/resources/otherpackagearray2/expected/com/example/Simple.java
@@ -8,6 +8,6 @@ class Simple {
     }
 
     private Simple(Type[] types) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/otherpackagearray2/expected/org/example/Method.java
+++ b/src/test/resources/otherpackagearray2/expected/org/example/Method.java
@@ -3,6 +3,6 @@ package org.example;
 public class Method {
 
     public org.example.Type[] getTypes() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/otherpackagearray3/expected/com/example/Simple.java
+++ b/src/test/resources/otherpackagearray3/expected/com/example/Simple.java
@@ -8,6 +8,6 @@ class Simple {
     }
 
     private Simple(Type[] types) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/otherpackagearray3/expected/org/example/Method.java
+++ b/src/test/resources/otherpackagearray3/expected/org/example/Method.java
@@ -3,6 +3,6 @@ package org.example;
 public class Method {
 
     public org.example.anotherpkg.Type[] getTypes() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/otherpackagelist/expected/com/example/Simple.java
+++ b/src/test/resources/otherpackagelist/expected/com/example/Simple.java
@@ -9,6 +9,6 @@ class Simple {
     }
 
     private Simple(List<? extends Type> types) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/otherpackagelist/expected/org/example/Method.java
+++ b/src/test/resources/otherpackagelist/expected/org/example/Method.java
@@ -3,6 +3,6 @@ package org.example;
 public class Method {
 
     public java.util.List<? extends org.example.anotherpkg.Type> getTypes() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/overloads/expected/org/example/MultipleMethods.java
+++ b/src/test/resources/overloads/expected/org/example/MultipleMethods.java
@@ -2,30 +2,30 @@ package org.example;
 
 public class MultipleMethods {
     public ExampleReturnType example() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public ExampleReturnType example(java.lang.String parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public ExampleReturnType example(int parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public ExampleReturnType example(java.lang.String parameter0, int parameter1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public ExampleReturnType example(int parameter0, java.lang.String parameter1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public ExampleReturnType example(int parameter0, int parameter1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public ExampleReturnType example(java.lang.String parameter0, java.lang.String parameter1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/overridedouble/expected/org/example/InstConstraintVisitor.java
+++ b/src/test/resources/overridedouble/expected/org/example/InstConstraintVisitor.java
@@ -3,6 +3,6 @@ package org.example;
 public class InstConstraintVisitor {
 
     public void setFrame(org.example.Frame parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/overridingmethod/expected/com/example/C.java
+++ b/src/test/resources/overridingmethod/expected/com/example/C.java
@@ -5,6 +5,6 @@ import org.testing.UnsolvedType;
 public class C {
 
     public void bar(int z, UnsolvedType m) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/overridingreturntypematching/expected/org/testing/SimpleParent.java
+++ b/src/test/resources/overridingreturntypematching/expected/org/testing/SimpleParent.java
@@ -3,6 +3,6 @@ package org.testing;
 public class SimpleParent {
 
     public void get() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/parameterwithannotations/expected/com/example/Simple.java
+++ b/src/test/resources/parameterwithannotations/expected/com/example/Simple.java
@@ -6,6 +6,6 @@ import org.testing.UnsolvedType;
 class Simple {
 
     void bar(byte @Nullable [] first, @Nullable UnsolvedType second) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/parameterwithannotations/input/com/example/Simple.java
+++ b/src/test/resources/parameterwithannotations/input/com/example/Simple.java
@@ -5,7 +5,7 @@ import org.testing.UnsolvedType;
 
 class Simple {
     void bar(byte @Nullable [] first, @Nullable UnsolvedType second) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     void foo() {

--- a/src/test/resources/preserveannotations/expected/com/example/Foo.java
+++ b/src/test/resources/preserveannotations/expected/com/example/Foo.java
@@ -6,6 +6,6 @@ class Foo {
 
     @Positive
     public static int baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/realsuperlub/expected/org/mygraphlib/Node.java
+++ b/src/test/resources/realsuperlub/expected/org/mygraphlib/Node.java
@@ -5,6 +5,6 @@ public class Node extends com.example.SyntheticTypeForChild {
     public org.mygraphlib.Node child;
 
     public org.mygraphlib.Node getChild() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/realsuperlub/expected/org/mygraphlib/NodeType1.java
+++ b/src/test/resources/realsuperlub/expected/org/mygraphlib/NodeType1.java
@@ -3,6 +3,6 @@ package org.mygraphlib;
 public class NodeType1 extends org.mygraphlib.Node {
 
     public NodeType1() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/removingcomments/expected/com/example/Simple.java
+++ b/src/test/resources/removingcomments/expected/com/example/Simple.java
@@ -3,7 +3,7 @@ package com.example;
 class Simple {
 
     static int returnTen() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     static void test() {

--- a/src/test/resources/sameclassname/expected/org/second/Calculator.java
+++ b/src/test/resources/sameclassname/expected/org/second/Calculator.java
@@ -2,6 +2,6 @@ package org.second;
 
 public class Calculator {
     public Calculator() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/staticandnonstaticuse/expected/org/example/Bar.java
+++ b/src/test/resources/staticandnonstaticuse/expected/org/example/Bar.java
@@ -3,6 +3,6 @@ package org.example;
 public class Bar {
 
     public Bar() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/staticandnonstaticuse/expected/org/example/Foo.java
+++ b/src/test/resources/staticandnonstaticuse/expected/org/example/Foo.java
@@ -3,10 +3,10 @@ package org.example;
 public class Foo {
 
     public Foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static OrgExampleFooSetThisReturnType setThis(org.example.Bar parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/staticimportmethod/expected/org/first/Foo.java
+++ b/src/test/resources/staticimportmethod/expected/org/first/Foo.java
@@ -3,6 +3,6 @@ package org.first;
 public class Foo {
 
     public static int count() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/staticmethod/expected/com/example/Foo.java
+++ b/src/test/resources/staticmethod/expected/com/example/Foo.java
@@ -3,6 +3,6 @@ package com.example;
 public class Foo {
 
     public static Foo[] getFoos() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/staticuseoferased/expected/com/example/Baz.java
+++ b/src/test/resources/staticuseoferased/expected/com/example/Baz.java
@@ -3,6 +3,6 @@ package com.example;
 public class Baz {
 
     public static ComExampleBazTestReturnType test() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/superclass/expected/com/example/Simple.java
+++ b/src/test/resources/superclass/expected/com/example/Simple.java
@@ -2,7 +2,7 @@ package com.example;
 
 class BigSimple {
     public void printMessage() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }
 

--- a/src/test/resources/superclasswithgenerictype/expected/com/example/Simple.java
+++ b/src/test/resources/superclasswithgenerictype/expected/com/example/Simple.java
@@ -5,6 +5,6 @@ import org.testing.Parent;
 class Simple<T> extends Parent<T> {
 
     public void bar() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/superclasswithgenerictype/input/com/example/Simple.java
+++ b/src/test/resources/superclasswithgenerictype/input/com/example/Simple.java
@@ -4,6 +4,6 @@ import org.testing.Parent;
 
 class Simple<T> extends Parent<T> {
     public void bar() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/superinterfaceextends/expected/com/example/PropertyFactoryManager.java
+++ b/src/test/resources/superinterfaceextends/expected/com/example/PropertyFactoryManager.java
@@ -9,6 +9,6 @@ public interface PropertyFactoryManager {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     default <V, P extends ReadableProperty<V>> PropertyFactory<V, ? extends P> getRequiredFactory(Class<P> propertyType, Class<V> valueType) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/superinterfaceextends/input/com/example/PropertyFactory.java
+++ b/src/test/resources/superinterfaceextends/input/com/example/PropertyFactory.java
@@ -3,6 +3,6 @@ package com.example;
 
 public interface PropertyFactory<V, P extends WritableProperty<V>> {
     default P create(String name, PropertyTypeInfo<V> valueClass, PropertyMetadata<V> metadata) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/superinterfaceextends/input/com/example/PropertyFactoryManager.java
+++ b/src/test/resources/superinterfaceextends/input/com/example/PropertyFactoryManager.java
@@ -10,6 +10,6 @@ public interface PropertyFactoryManager {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     default <V, P extends ReadableProperty<V>> PropertyFactory<V, ? extends P> getRequiredFactory(Class<P> propertyType, Class<V> valueType) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/supermethodwithunsolvedparameters/expected/com/example/Simple.java
+++ b/src/test/resources/supermethodwithunsolvedparameters/expected/com/example/Simple.java
@@ -10,6 +10,6 @@ class Simple extends SuperSimple {
     }
 
     public Unsolved baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/supermethodwithunsolvedparameters/expected/org/simple/SuperSimple.java
+++ b/src/test/resources/supermethodwithunsolvedparameters/expected/org/simple/SuperSimple.java
@@ -3,6 +3,6 @@ package org.simple;
 public class SuperSimple {
 
     public FooReturnType foo(org.example.Unsolved parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/supermethodwithunsolvedparameters/input/com/example/Simple.java
+++ b/src/test/resources/supermethodwithunsolvedparameters/input/com/example/Simple.java
@@ -9,6 +9,6 @@ class Simple extends SuperSimple {
     }
 
     public Unsolved baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticannotationtarget/expected/com/example/Simple.java
+++ b/src/test/resources/syntheticannotationtarget/expected/com/example/Simple.java
@@ -23,7 +23,7 @@ public class Simple<@TypeParam T> {
 
     @Constructor
     public Simple() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     @AnnotationDeclaration

--- a/src/test/resources/syntheticmethodrefs/expected/com/example/Bar.java
+++ b/src/test/resources/syntheticmethodrefs/expected/com/example/Bar.java
@@ -6,34 +6,34 @@ import java.util.List;
 public class Bar {
 
     public static void noParamVoid() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static String noParamNonVoid() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static void oneParamVoid(int x) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static Object oneParamNonVoid(Map<Object, String> x) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static void twoParamVoid(String x, boolean y) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static int twoParamNonVoid(Object x, Object y) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static void threeParamVoid(Object x, List<List<Object>> y, Object z) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static Object threeParamNonVoid(Object x, Object y, Object z) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticmethodrefs/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticmethodrefs/expected/com/example/Foo.java
@@ -3,34 +3,34 @@ package com.example;
 public class Foo {
 
     public static ComExampleFooMapListReturnType mapList(java.lang.Runnable parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static ComExampleFooMapList2ReturnType mapList2(java.util.function.Supplier<?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static ComExampleFooMapList3ReturnType mapList3(java.util.function.Consumer<Integer> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static ComExampleFooMapList4ReturnType mapList4(java.util.function.Function<java.util.Map<Object, String>, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static ComExampleFooMapList5ReturnType mapList5(java.util.function.BiConsumer<String, Boolean> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static ComExampleFooMapList6ReturnType mapList6(java.util.function.BiFunction<Object, Object, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static ComExampleFooMapList7ReturnType mapList7(SyntheticConsumer3<Object, java.util.List<java.util.List<Object>>, Object> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static ComExampleFooMapList8ReturnType mapList8(SyntheticFunction3<Object, Object, Object, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticobjectcreation/expected/org/can/not/be/real/Pen.java
+++ b/src/test/resources/syntheticobjectcreation/expected/org/can/not/be/real/Pen.java
@@ -2,6 +2,6 @@ package org.can.not.be.real;
 public class Pen {
 
     public Pen(org.still.not.real.Ink parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticobjectcreation/expected/org/not/a/real/pack/Writer.java
+++ b/src/test/resources/syntheticobjectcreation/expected/org/not/a/real/pack/Writer.java
@@ -2,6 +2,6 @@ package org.not.a.real.pack;
 public class Writer {
 
     public Writer(org.can.not.be.real.Pen parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticobjectcreation/expected/org/still/not/real/Ink.java
+++ b/src/test/resources/syntheticobjectcreation/expected/org/still/not/real/Ink.java
@@ -2,6 +2,6 @@ package org.still.not.real;
 public class Ink {
 
     public Ink(java.lang.String parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticparameters/expected/org/factory/AddYearsReturnType.java
+++ b/src/test/resources/syntheticparameters/expected/org/factory/AddYearsReturnType.java
@@ -2,6 +2,6 @@ package org.factory;
 public class AddYearsReturnType {
 
     public boolean getWarranty() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticparameters/expected/org/factory/Car.java
+++ b/src/test/resources/syntheticparameters/expected/org/factory/Car.java
@@ -2,6 +2,6 @@ package org.factory;
 public class Car {
 
     public AddYearsReturnType addYears(int parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticsuperconstructor/expected/org/factory/Vehicle.java
+++ b/src/test/resources/syntheticsuperconstructor/expected/org/factory/Vehicle.java
@@ -2,6 +2,6 @@ package org.factory;
 public class Vehicle {
 
     public Vehicle() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticsuperlub/expected/com/example/SyntheticTypeForPaws.java
+++ b/src/test/resources/syntheticsuperlub/expected/com/example/SyntheticTypeForPaws.java
@@ -2,6 +2,6 @@ package com.example;
 
 public class SyntheticTypeForPaws {
     public SetNumberReturnType setNumber(int parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticsuperlub/expected/org/wild/RegularPaws.java
+++ b/src/test/resources/syntheticsuperlub/expected/org/wild/RegularPaws.java
@@ -2,6 +2,6 @@ package org.wild;
 
 public class RegularPaws extends com.example.SyntheticTypeForPaws {
     public RegularPaws() {
-         throw new Error();
+         throw new java.lang.Error();
      }
 }

--- a/src/test/resources/syntheticsuperlub/expected/org/wild/WebbedPaws.java
+++ b/src/test/resources/syntheticsuperlub/expected/org/wild/WebbedPaws.java
@@ -2,6 +2,6 @@ package org.wild;
 
 public class WebbedPaws extends com.example.SyntheticTypeForPaws {
     public WebbedPaws() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/syntheticsupermethod/expected/org/factory/Vehicle.java
+++ b/src/test/resources/syntheticsupermethod/expected/org/factory/Vehicle.java
@@ -2,6 +2,6 @@ package org.factory;
 public class Vehicle {
 
     public int getWheels() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/targetField/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/targetField/expected/org/testing/UnsolvedType.java
@@ -3,6 +3,6 @@ package org.testing;
 public class UnsolvedType {
 
     public UnsolvedType(java.lang.String parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/thisclause/expected/com/example/Simple.java
+++ b/src/test/resources/thisclause/expected/com/example/Simple.java
@@ -7,6 +7,6 @@ public class Simple {
     }
 
     Simple(int a, int b) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/threelayerfunctioncall/expected/com/example/Simple.java
+++ b/src/test/resources/threelayerfunctioncall/expected/com/example/Simple.java
@@ -3,7 +3,7 @@ package com.example;
 class Simple {
 
     static int returnTen() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     static void test() {

--- a/src/test/resources/trywithresources/expected/org/example/OtherResource.java
+++ b/src/test/resources/trywithresources/expected/org/example/OtherResource.java
@@ -3,6 +3,6 @@ package org.example;
 public class OtherResource implements java.lang.AutoCloseable {
 
     public void close() throws java.lang.Exception {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/trywithresources/expected/org/example/Resource.java
+++ b/src/test/resources/trywithresources/expected/org/example/Resource.java
@@ -3,10 +3,10 @@ package org.example;
 public class Resource implements java.lang.AutoCloseable {
 
     public Resource() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void close() throws java.lang.Exception {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/trywithresources/expected/org/example/ThirdResource.java
+++ b/src/test/resources/trywithresources/expected/org/example/ThirdResource.java
@@ -3,6 +3,6 @@ package org.example;
 public class ThirdResource implements java.lang.AutoCloseable {
 
     public void close() throws java.lang.Exception {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/twofilesimple/expected/com/example/Baz.java
+++ b/src/test/resources/twofilesimple/expected/com/example/Baz.java
@@ -2,6 +2,6 @@ package com.example;
 
 public class Baz {
     public Baz(String s) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/typevariablecomplex/expected/com/example/Simple.java
+++ b/src/test/resources/typevariablecomplex/expected/com/example/Simple.java
@@ -15,6 +15,6 @@ class Simple<I extends Simple<I>.Dog> {
 class Animal {
 
     public void sound() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/typevariablecomplex/input/com/example/Simple.java
+++ b/src/test/resources/typevariablecomplex/input/com/example/Simple.java
@@ -7,7 +7,7 @@ class Simple<I extends Simple<I>.Dog> {
     }
     class Dog extends Animal {
         void walk() {
-            throw new Error();
+            throw new java.lang.Error();
         }
     }
 }

--- a/src/test/resources/typevariablemethodscope/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/typevariablemethodscope/expected/org/testing/UnsolvedType.java
@@ -3,6 +3,6 @@ package org.testing;
 public class UnsolvedType {
 
     public PrintReturnType print() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/typevarmatching/expected/org/testing/SimpleParent.java
+++ b/src/test/resources/typevarmatching/expected/org/testing/SimpleParent.java
@@ -3,6 +3,6 @@ package org.testing;
 public class SimpleParent<E, V> {
 
     public V get(E parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/typevarparameter/expected/com/example/Simple.java
+++ b/src/test/resources/typevarparameter/expected/com/example/Simple.java
@@ -5,7 +5,7 @@ public class Simple<T> {
     T field;
 
     void foo(T input) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     void bar() {

--- a/src/test/resources/typevarsimple/expected/org/example/ClassWithTypeParam.java
+++ b/src/test/resources/typevarsimple/expected/org/example/ClassWithTypeParam.java
@@ -2,6 +2,6 @@ package org.example;
 
 public class ClassWithTypeParam<T> {
     public T getT() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unaryexpr/expected/com/example/Foo.java
+++ b/src/test/resources/unaryexpr/expected/com/example/Foo.java
@@ -7,10 +7,10 @@ public class Foo {
     public long qux;
 
     public int baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public double razz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/uncatchthrow/expected/org/testing/MyException.java
+++ b/src/test/resources/uncatchthrow/expected/org/testing/MyException.java
@@ -3,6 +3,6 @@ package org.testing;
 public class MyException extends java.lang.RuntimeException {
 
     public MyException(java.lang.String parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/uniontype/expected/com/github/javaparser/resolution/UnsolvedSymbolException.java
+++ b/src/test/resources/uniontype/expected/com/github/javaparser/resolution/UnsolvedSymbolException.java
@@ -3,6 +3,6 @@ package com.github.javaparser.resolution;
 public class UnsolvedSymbolException extends Exception {
 
     public UnsolvedSymbolException() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/uniontype/expected/javalanguage/Method.java
+++ b/src/test/resources/uniontype/expected/javalanguage/Method.java
@@ -3,10 +3,10 @@ package javalanguage;
 public class Method {
 
     public Method() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public SolveReturnType solve() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unrelatedenum/expected/com/example/Simple.java
+++ b/src/test/resources/unrelatedenum/expected/com/example/Simple.java
@@ -8,6 +8,6 @@ class Simple {
     }
 
     Object baz(Object obj) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvableinterfacehardcase/expected/com/example/Baz.java
+++ b/src/test/resources/unsolvableinterfacehardcase/expected/com/example/Baz.java
@@ -3,6 +3,6 @@ package com.example;
 public class Baz<E> {
 
     public AddReturnType add(E parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvableinterfaceprettyhardcase/expected/com/example/Baz.java
+++ b/src/test/resources/unsolvableinterfaceprettyhardcase/expected/com/example/Baz.java
@@ -8,94 +8,94 @@ import java.util.ListIterator;
 public class Baz<E> implements List<E> {
 
     public int size() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean isEmpty() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean contains(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public Iterator<E> iterator() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public Object[] toArray() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public <T> T[] toArray(T[] a) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean add(E e) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean remove(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean containsAll(Collection<?> c) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean addAll(Collection<? extends E> c) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean addAll(int index, Collection<? extends E> c) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean removeAll(Collection<?> c) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public boolean retainAll(Collection<?> c) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void clear() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E get(int index) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E set(int index, E element) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public void add(int index, E element) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public E remove(int index) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public int indexOf(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public int lastIndexOf(Object o) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public ListIterator<E> listIterator() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public ListIterator<E> listIterator(int index) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public List<E> subList(int fromIndex, int toIndex) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedclassinsamepackage/expected/com/example/Baz.java
+++ b/src/test/resources/unsolvedclassinsamepackage/expected/com/example/Baz.java
@@ -3,6 +3,6 @@ package com.example;
 public class Baz {
 
     public Baz(java.lang.String parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedexception/expected/com/example/CustomException.java
+++ b/src/test/resources/unsolvedexception/expected/com/example/CustomException.java
@@ -3,6 +3,6 @@ package com.example;
 public class CustomException extends Exception {
 
     public CustomException(java.lang.String parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedfieldsinexistingclass/expected/org/testing/Unsolved.java
+++ b/src/test/resources/unsolvedfieldsinexistingclass/expected/org/testing/Unsolved.java
@@ -3,6 +3,6 @@ package org.testing;
 public class Unsolved {
 
     public GetValueReturnType getValue() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedmethodinexistingsuperclass/expected/com/example/Baz.java
+++ b/src/test/resources/unsolvedmethodinexistingsuperclass/expected/com/example/Baz.java
@@ -5,6 +5,6 @@ import org.testing.Unsolved;
 class Baz {
 
     public Unsolved foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedmethodinexistingsuperclass/input/com/example/Baz.java
+++ b/src/test/resources/unsolvedmethodinexistingsuperclass/input/com/example/Baz.java
@@ -5,6 +5,6 @@ import org.testing.Unsolved;
 class Baz {
 
     public Unsolved foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedmethodsinexistingclass/expected/com/example/Baz.java
+++ b/src/test/resources/unsolvedmethodsinexistingclass/expected/com/example/Baz.java
@@ -5,6 +5,6 @@ import org.testing.Unsolved;
 public class Baz {
 
     public Unsolved foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedmethodsinexistingclass/input/com/example/Baz.java
+++ b/src/test/resources/unsolvedmethodsinexistingclass/input/com/example/Baz.java
@@ -5,6 +5,6 @@ import org.testing.Unsolved;
 public class Baz {
 
     public Unsolved foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedmethodtypecorrect/expected/com/example/Simple.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/expected/com/example/Simple.java
@@ -10,6 +10,6 @@ class Simple {
     }
 
     void baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/Foo.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/Foo.java
@@ -3,10 +3,10 @@ package org.example;
 public class Foo {
 
     public Foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public org.example.LocalVariables getLocals() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/LocalVariables.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/LocalVariables.java
@@ -3,6 +3,6 @@ package org.example;
 public class LocalVariables {
 
     public SetReturnType set(int parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedmethodwitharrayparameter/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/unsolvedmethodwitharrayparameter/expected/org/testing/UnsolvedType.java
@@ -3,6 +3,6 @@ package org.testing;
 public class UnsolvedType {
 
     public static OrgTestingUnsolvedTypeProcessArrayReturnType processArray(int[][][] parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvednonstaticfield/expected/org/sampling/Baz.java
+++ b/src/test/resources/unsolvednonstaticfield/expected/org/sampling/Baz.java
@@ -5,6 +5,6 @@ public class Baz {
     public OrgSamplingBazCalSyntheticType cal;
 
     public Baz() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvednonstaticfield/expected/org/sampling/OrgSamplingBazCalSyntheticType.java
+++ b/src/test/resources/unsolvednonstaticfield/expected/org/sampling/OrgSamplingBazCalSyntheticType.java
@@ -3,6 +3,6 @@ package org.sampling;
 public class OrgSamplingBazCalSyntheticType {
 
     public DoAdditionReturnType doAddition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedoverrideannotation/expected/org/testing/Baz.java
+++ b/src/test/resources/unsolvedoverrideannotation/expected/org/testing/Baz.java
@@ -3,6 +3,6 @@ package org.testing;
 public class Baz {
 
  void bar() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedstaticmethod/expected/com/example/MyClass.java
+++ b/src/test/resources/unsolvedstaticmethod/expected/com/example/MyClass.java
@@ -3,6 +3,6 @@ package com.example;
 public class MyClass {
 
     public static ComExampleMyClassProcessReturnType process(int parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedstaticmethod/expected/org/testing/ThisClass.java
+++ b/src/test/resources/unsolvedstaticmethod/expected/org/testing/ThisClass.java
@@ -3,6 +3,6 @@ package org.testing;
 public class ThisClass {
 
     public static OrgTestingThisClassProcessReturnType process(java.lang.String parameter0, unreal.pack.AClass parameter1) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedstaticmethod/expected/unreal/pack/AClass.java
+++ b/src/test/resources/unsolvedstaticmethod/expected/unreal/pack/AClass.java
@@ -3,6 +3,6 @@ package unreal.pack;
 public class AClass {
 
     public AClass() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedstaticmethodfromexistingclass/expected/com/example/Baz.java
+++ b/src/test/resources/unsolvedstaticmethodfromexistingclass/expected/com/example/Baz.java
@@ -5,6 +5,6 @@ import org.testing.Unsolved;
 public class Baz {
 
     public static Unsolved foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedstaticmethodfromexistingclass/input/com/example/Baz.java
+++ b/src/test/resources/unsolvedstaticmethodfromexistingclass/input/com/example/Baz.java
@@ -5,6 +5,6 @@ import org.testing.Unsolved;
 public class Baz {
 
     public static Unsolved foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedstaticqualifiedfield/expected/org/sampling/OrgSamplingBazMyFieldSyntheticType.java
+++ b/src/test/resources/unsolvedstaticqualifiedfield/expected/org/sampling/OrgSamplingBazMyFieldSyntheticType.java
@@ -3,6 +3,6 @@ package org.sampling;
 public class OrgSamplingBazMyFieldSyntheticType {
 
     public DoAdditionReturnType doAddition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unsolvedstaticsimplefield/expected/org/sampling/OrgSamplingBazMyFieldSyntheticType.java
+++ b/src/test/resources/unsolvedstaticsimplefield/expected/org/sampling/OrgSamplingBazMyFieldSyntheticType.java
@@ -3,6 +3,6 @@ package org.sampling;
 public class OrgSamplingBazMyFieldSyntheticType {
 
     public DoAdditionReturnType doAddition() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unusedfuncinterfacemethod/expected/com/example/Bar.java
+++ b/src/test/resources/unusedfuncinterfacemethod/expected/com/example/Bar.java
@@ -3,6 +3,6 @@ package com.example;
 public class Bar {
 
     public static ComExampleBarUseReturnType use(SyntheticFunction4<?, ?, ?, ?, ?> parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unusedtypeparameterbound/expected/org/testing/Baz.java
+++ b/src/test/resources/unusedtypeparameterbound/expected/org/testing/Baz.java
@@ -3,6 +3,6 @@ package org.testing;
 public class Baz {
 
     public void bazMethod() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/vartype/expected/com/example/Simple.java
+++ b/src/test/resources/vartype/expected/com/example/Simple.java
@@ -10,6 +10,6 @@ class Simple {
     }
 
     Object baz(Calculator obj) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/vartype/expected/com/mathematic/Calculator.java
+++ b/src/test/resources/vartype/expected/com/mathematic/Calculator.java
@@ -3,6 +3,6 @@ package com.mathematic;
 public class Calculator {
 
     public Calculator() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/voidreturndouble/expected/com/example/MyFoo.java
+++ b/src/test/resources/voidreturndouble/expected/com/example/MyFoo.java
@@ -5,6 +5,6 @@ import org.example.Foo;
 public class MyFoo extends Foo {
 
     public MyFoo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/voidreturndouble/expected/org/example/Foo.java
+++ b/src/test/resources/voidreturndouble/expected/org/example/Foo.java
@@ -3,6 +3,6 @@ package org.example;
 public class Foo {
 
     public void methodGen(org.example.MethodGen parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/voidreturndouble/input/com/example/MyFoo.java
+++ b/src/test/resources/voidreturndouble/input/com/example/MyFoo.java
@@ -6,7 +6,7 @@ import org.example.MethodGen;
 public class MyFoo extends Foo {
 
     public MyFoo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     @Override

--- a/src/test/resources/whenthen/expected/org/example/OrgExampleTestUtilWhenReturnType.java
+++ b/src/test/resources/whenthen/expected/org/example/OrgExampleTestUtilWhenReturnType.java
@@ -3,10 +3,10 @@ package org.example;
 public class OrgExampleTestUtilWhenReturnType {
 
     public ThenReturnType then(java.lang.String parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public ThenReturnType then(java.lang.Object parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/whenthen/expected/org/example/TestUtil.java
+++ b/src/test/resources/whenthen/expected/org/example/TestUtil.java
@@ -3,14 +3,14 @@ package org.example;
 public class TestUtil {
 
     public static <SyntheticUnconstrainedType> SyntheticUnconstrainedType mock(int parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static OrgExampleTestUtilWhenReturnType when(int parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public static OrgExampleTestUtilWhenReturnType when(java.lang.String parameter0) {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/wildcardimport/expected/org/example/Foo.java
+++ b/src/test/resources/wildcardimport/expected/org/example/Foo.java
@@ -3,10 +3,10 @@ package org.example;
 public class Foo {
 
     public Foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public FooMethodReturnType fooMethod() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/wildcardimport2/expected/org/example/Foo.java
+++ b/src/test/resources/wildcardimport2/expected/org/example/Foo.java
@@ -3,10 +3,10 @@ package org.example;
 public class Foo {
 
     public Foo() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 
     public FooMethodReturnType fooMethod() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/wildcardimport3/expected/org/anotherexample/Foo.java
+++ b/src/test/resources/wildcardimport3/expected/org/anotherexample/Foo.java
@@ -2,6 +2,6 @@ package org.anotherexample;
 
 public class Foo {
     public void fooMethod() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }

--- a/src/test/resources/wildcardimport4/expected/com/example/Foo.java
+++ b/src/test/resources/wildcardimport4/expected/com/example/Foo.java
@@ -2,6 +2,6 @@ package com.example;
 
 public class Foo {
     void fooMethod() {
-        throw new Error();
+        throw new java.lang.Error();
     }
 }


### PR DESCRIPTION
...because it's possible that we're in a class where there's some other class named "Error" imported (I saw an example in the terminal emulator project that @M3CHR0M4NC3R pointed me to).