### PR TITLE
Fix crash when a type parameter in a field declaration has an array type

### DIFF
--- a/src/main/java/org/checkerframework/specimin/TargetMemberFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMemberFinderVisitor.java
@@ -920,7 +920,11 @@ public class TargetMemberFinderVisitor extends SpeciminStateVisitor {
         }
         continue;
       }
-      // TODO: also handle arrays
+      if (typePara.isArray()) {
+        ResolvedType componentType = typePara.asArrayType().getComponentType();
+        updateUsedClassBasedOnType(componentType);
+        continue;
+      }
       updateUsedClassWithQualifiedClassName(
           typePara.asReferenceType().getQualifiedName(),
           usedTypeElements,

--- a/src/main/java/org/checkerframework/specimin/TargetMemberFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMemberFinderVisitor.java
@@ -878,7 +878,7 @@ public class TargetMemberFinderVisitor extends SpeciminStateVisitor {
   }
 
   /**
-   * Updates the list of used classes based on the resolved type of a used element, where a element
+   * Updates the list of used classes based on the resolved type of a used element, where an element
    * can be a method, a field, a variable, or a parameter. Also updates the set of used classes
    * based on component types, wildcard bounds, etc., as needed: any type that is used in the type
    * will be included.
@@ -920,6 +920,7 @@ public class TargetMemberFinderVisitor extends SpeciminStateVisitor {
         }
         continue;
       }
+      // TODO: also handle arrays
       updateUsedClassWithQualifiedClassName(
           typePara.asReferenceType().getQualifiedName(),
           usedTypeElements,

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -3830,6 +3830,41 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
       typeVarDecl = "";
       rest = javacType;
     }
+    
+    // need to also remove annotations before parsing, because they aren't in the right
+    // format. E.g., the string might look like this:
+    // WeakReference<@org.checkerframework.checker.nullness.qual.Nullable,@org.checkerframework.checker.interning.qual.Interned String []>
+    int indexOfAt = rest.indexOf('@');
+    while (indexOfAt != -1) {
+      // need to find the next comma or space, disregarding
+      // any that don't occur when parens are balanced
+      int idx = indexOfAt;
+      int endIdx = -1;
+      int parens = 0;
+      while (endIdx == -1) {
+        idx += 1;
+        char atIdx = rest.charAt(idx);
+        switch (atIdx) {
+          case '(':
+            parens++;
+            break;
+          case ')':
+            parens--;
+            break;
+          case ',':
+          case ' ':
+            if (parens == 0) {
+              endIdx = idx;
+            }
+            break;
+          default:
+            // do nothing
+        }
+      }
+      rest = rest.substring(0, indexOfAt) + rest.substring(endIdx + 1);
+      indexOfAt = rest.indexOf('@');
+    }
+
     Visitable parsedJavac = StaticJavaParser.parseType(rest);
     parsedJavac =
         parsedJavac.accept(

--- a/src/test/java/org/checkerframework/specimin/ArrayTypeParamTest.java
+++ b/src/test/java/org/checkerframework/specimin/ArrayTypeParamTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that Specimin doesn't crash when an array is used as a type parameter. Based on
+ * a crash we found when we ran on plume-util.
+ */
+public class ArrayTypeParamTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "arraytypeparam",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Object[])"});
+  }
+}

--- a/src/test/resources/arraytypeparam/expected/com/example/Simple.java
+++ b/src/test/resources/arraytypeparam/expected/com/example/Simple.java
@@ -7,6 +7,6 @@ class Simple {
     List<Object[]> toHoldTheArgs;
 
     void bar(Object[] args) {
-        toHoldTheArgs = List.of(args);
+        toHoldTheArgs = List.<Object[]>of(args);
     }
 }

--- a/src/test/resources/arraytypeparam/expected/com/example/Simple.java
+++ b/src/test/resources/arraytypeparam/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.List;
+
+class Simple {
+
+    List<Object[]> toHoldTheArgs;
+
+    void bar(Object[] args) {
+        toHoldTheArgs = List.of(args);
+    }
+}

--- a/src/test/resources/arraytypeparam/input/com/example/Simple.java
+++ b/src/test/resources/arraytypeparam/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.List;
+
+class Simple {
+
+    List<Object[]> toHoldTheArgs;
+
+    // Target method.
+    void bar(Object[] args) {
+        toHoldTheArgs = List.of(args);
+    }
+}

--- a/src/test/resources/arraytypeparam/input/com/example/Simple.java
+++ b/src/test/resources/arraytypeparam/input/com/example/Simple.java
@@ -8,6 +8,6 @@ class Simple {
 
     // Target method.
     void bar(Object[] args) {
-        toHoldTheArgs = List.of(args);
+        toHoldTheArgs = List.<Object[]>of(args);
     }
 }


### PR DESCRIPTION
This caused some crashes in PlumeUtil's `Intern.java`, so I'll need to update the % of passing methods.