### PR TITLE
Fix a bug with the handling of type parameter bounds

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1239,9 +1239,6 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
     if (typeExpr.getParentNode().get() instanceof ClassOrInterfaceDeclaration) {
       return super.visit(typeExpr, p);
     }
-    if (!insideTargetMember && !insidePotentialUsedMember) {
-      return super.visit(typeExpr, p);
-    }
     resolveTypeExpr(typeExpr);
 
     return super.visit(typeExpr, p);
@@ -3845,7 +3842,7 @@ public class UnsolvedSymbolVisitor extends SpeciminStateVisitor {
       typeVarDecl = "";
       rest = javacType;
     }
-    
+
     // need to also remove annotations before parsing, because they aren't in the right
     // format. E.g., the string might look like this:
     // WeakReference<@org.checkerframework.checker.nullness.qual.Nullable,@org.checkerframework.checker.interning.qual.Interned String []>

--- a/src/test/java/org/checkerframework/specimin/UnusedTypeParameterBound2Test.java
+++ b/src/test/java/org/checkerframework/specimin/UnusedTypeParameterBound2Test.java
@@ -1,0 +1,19 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks if Specimin can remove unused bounds of type parameters in the declaration of a
+ * class. The only difference between this test and the other of the same name is that in this test,
+ * the classes used in the bounds are not in the input program.
+ */
+public class UnusedTypeParameterBound2Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unusedtypeparameterbound2",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(T)"});
+  }
+}

--- a/src/test/resources/unusedtypeparameterbound2/expected/com/example/Simple.java
+++ b/src/test/resources/unusedtypeparameterbound2/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.testing.Baz;
+import org.testing.Foo;
+
+class Simple<T extends Baz, V extends Foo> {
+
+    void bar(T bazObject) {
+        bazObject.bazMethod();
+    }
+}

--- a/src/test/resources/unusedtypeparameterbound2/expected/org/testing/Baz.java
+++ b/src/test/resources/unusedtypeparameterbound2/expected/org/testing/Baz.java
@@ -1,0 +1,8 @@
+package org.testing;
+
+public class Baz {
+
+    public void bazMethod() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/unusedtypeparameterbound2/expected/org/testing/Baz.java
+++ b/src/test/resources/unusedtypeparameterbound2/expected/org/testing/Baz.java
@@ -2,7 +2,7 @@ package org.testing;
 
 public class Baz {
 
-    public void bazMethod() {
+    public BazMethodReturnType bazMethod() {
         throw new java.lang.Error();
     }
 }

--- a/src/test/resources/unusedtypeparameterbound2/expected/org/testing/Foo.java
+++ b/src/test/resources/unusedtypeparameterbound2/expected/org/testing/Foo.java
@@ -1,0 +1,5 @@
+package org.testing;
+
+public class Foo {
+
+}

--- a/src/test/resources/unusedtypeparameterbound2/input/com/example/Simple.java
+++ b/src/test/resources/unusedtypeparameterbound2/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.testing.Baz;
+import org.testing.Foo;
+
+class Simple<T extends Baz, V extends Foo> {
+    void bar(T bazObject) {
+        bazObject.bazMethod();
+    }
+    Object baz(Object obj) {
+        return obj.toString();
+    }
+}


### PR DESCRIPTION
Discovered while investigating #402, though not sufficient to fix that one on its own.