### PR TITLE
Bug fixes

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -39,7 +39,6 @@ import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.Resolvable;
-import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.AssociableToAST;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
@@ -96,19 +95,12 @@ public class JavaParserUtil {
   }
 
   /**
-   * Set this TypeSolver instance to be used by the JavaParserFacade, so we don't have to find it
-   * through reflection in JavaParserSymbolSolver. This field is initialized once in SpeciminRunner.
-   * Note that by the time you evaluate the value of this field, it should already be non-null.
-   */
-  private static @MonotonicNonNull TypeSolver typeSolver = null;
-
-  /**
-   * Set this MemoryTypeSolver instance to be used by {@link #getResolvablePlaceholderType}, since
-   * {@code TypeSolver} does not expose child type solvers. This field is initialized once in
+   * Set this SpeciminTypeSolvers instance to be used by this class, so we don't have to find type
+   * solvers through reflection in JavaParserSymbolSolver. This field is initialized once in
    * SpeciminRunner. Note that by the time you evaluate the value of this field, it should already
    * be non-null.
    */
-  private static @MonotonicNonNull MemoryTypeSolver memoryTypeSolver = null;
+  private static @MonotonicNonNull SpeciminTypeSolvers typeSolvers = null;
 
   /**
    * Keeps track of the placeholder types that have been generated and registered with the type
@@ -117,16 +109,13 @@ public class JavaParserUtil {
   private static final Set<String> generatedResolvedPlaceholderTypes = new HashSet<>();
 
   /**
-   * Set the TypeSolver instances to be used.
+   * Set the SpeciminTypeSolvers instance to be used.
    *
-   * @param typeSolver the TypeSolver instance to set
-   * @param memoryTypeSolver the MemoryTypeSolver instance to set
+   * @param typeSolvers The SpeciminTypeSolvers instance holding all type solvers.
    */
-  @EnsuresNonNull("JavaParserUtil.typeSolver")
-  @EnsuresNonNull("JavaParserUtil.memoryTypeSolver")
-  public static void setTypeSolvers(TypeSolver typeSolver, MemoryTypeSolver memoryTypeSolver) {
-    JavaParserUtil.typeSolver = typeSolver;
-    JavaParserUtil.memoryTypeSolver = memoryTypeSolver;
+  @EnsuresNonNull("JavaParserUtil.typeSolvers")
+  public static void setTypeSolvers(SpeciminTypeSolvers typeSolvers) {
+    JavaParserUtil.typeSolvers = typeSolvers;
 
     // If we reset memoryTypeSolver, we should clear our cache since these old types
     // are not registered with the new MemoryTypeSolver. This is mainly an issue with
@@ -140,25 +129,12 @@ public class JavaParserUtil {
    *
    * @return The type solver
    */
-  public static TypeSolver getTypeSolver() {
-    if (typeSolver == null) {
+  public static SpeciminTypeSolvers getTypeSolvers() {
+    if (typeSolvers == null) {
       throw new RuntimeException(
-          "TypeSolver is not set. Make sure to call setTypeSolvers() in SpeciminRunner.");
+          "typeSolvers is not set. Make sure to call setTypeSolvers() in SpeciminRunner.");
     }
-    return typeSolver;
-  }
-
-  /**
-   * Gets the memory type solver, and ensures it is non-null.
-   *
-   * @return The type solver
-   */
-  public static MemoryTypeSolver getMemoryTypeSolver() {
-    if (memoryTypeSolver == null) {
-      throw new RuntimeException(
-          "MemoryTypeSolver is not set. Make sure to call setTypeSolvers() in SpeciminRunner.");
-    }
-    return memoryTypeSolver;
+    return typeSolvers;
   }
 
   /**
@@ -1040,7 +1016,7 @@ public class JavaParserUtil {
     // Add to java.lang so we don't need to worry about imports; this is a bit hacky but it works
     CompilationUnit dummy =
         StaticJavaParser.parse("package java.lang; public class " + typeName + " {}");
-    getMemoryTypeSolver().addType("java.lang." + typeName, dummy);
+    getTypeSolvers().getMemoryTypeSolver().addType("java.lang." + typeName, dummy);
 
     generatedResolvedPlaceholderTypes.add(typeName);
     return StaticJavaParser.parseClassOrInterfaceType(typeName);
@@ -1995,7 +1971,7 @@ public class JavaParserUtil {
     }
 
     Class<? extends Node> nodeClass = detachedNode.getClass();
-    return attached.findFirst(nodeClass, n -> n.equals(detachedNode)).get();
+    return attached.findFirst(nodeClass, n -> n.equals(detachedNode)).orElse(null);
   }
 
   /**
@@ -2016,6 +1992,30 @@ public class JavaParserUtil {
       case "boolean" -> "false";
       default -> "null";
     };
+  }
+
+  /**
+   * Given a list of parameter types, return a super(...) call with the default values of those
+   * types.
+   *
+   * @param paramTypes The parameter types
+   * @return The super(...) call; i.e., super(0, null);
+   */
+  public static String getDefaultSuperConstructorCall(List<String> paramTypes) {
+    StringBuilder sb = new StringBuilder();
+
+    sb.append("super(");
+
+    for (String paramType : paramTypes) {
+      sb.append(getInitializerRHS(paramType));
+      sb.append(", ");
+    }
+
+    // remove the trailing ", "
+    sb.delete(sb.length() - 2, sb.length());
+
+    sb.append(");");
+    return sb.toString();
   }
 
   /**
@@ -2216,7 +2216,7 @@ public class JavaParserUtil {
       try {
         // Must use JavaParserFacade instead of .resolve() here, since we need to get the
         // type parameters map: https://github.com/javaparser/javaparser/issues/2135
-        JavaParserFacade parserFacade = JavaParserFacade.get(getTypeSolver());
+        JavaParserFacade parserFacade = JavaParserFacade.get(getTypeSolvers().getTypeSolver());
         methodUsage = parserFacade.solveMethodAsUsage(methodCallParent);
         method = methodUsage.getDeclaration();
 
@@ -2595,7 +2595,7 @@ public class JavaParserUtil {
       }
 
       try {
-        combined.add(getTypeSolver().solveType(fqn));
+        combined.add(getTypeSolvers().getTypeSolver().solveType(fqn));
       } catch (UnsolvedSymbolException e) {
         // Type param, likely
       }

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithExtends;
 import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
@@ -1200,10 +1201,10 @@ public class JavaParserUtil {
    * @param withArgs The node representing a method call, constructor call, or enum constant
    *     declaration with arguments
    * @param fqnsToCompilationUnits The map of fully qualified names to their compilation units
-   * @return A list of matching {@link CallableDeclaration} instances, or an empty list if none are
+   * @return A list of matching {@link NodeWithParameters} instances, or an empty list if none are
    *     found
    */
-  public static List<? extends CallableDeclaration<?>> tryResolveNodeWithUnresolvableArguments(
+  public static List<? extends NodeWithParameters<?>> tryResolveNodeWithUnresolvableArguments(
       NodeWithArguments<?> withArgs, Map<String, CompilationUnit> fqnsToCompilationUnits) {
     if (withArgs instanceof MethodCallExpr parentMethodCall) {
       return tryResolveMethodCallWithUnresolvableArguments(
@@ -1232,10 +1233,10 @@ public class JavaParserUtil {
    * @param fqnsToCompilationUnits The map of fully qualified names to their compilation units
    * @return A resolvable callable if it can be found, null otherwise
    */
-  public static @Nullable CallableDeclaration<?>
+  public static @Nullable NodeWithParameters<?>
       tryFindSingleCallableForNodeWithUnresolvableArguments(
           NodeWithArguments<?> node, Map<String, CompilationUnit> fqnsToCompilationUnits) {
-    List<? extends CallableDeclaration<?>> callables =
+    List<? extends NodeWithParameters<?>> callables =
         tryResolveNodeWithUnresolvableArguments(node, fqnsToCompilationUnits);
     if (callables.isEmpty()) {
       return null;
@@ -1257,12 +1258,12 @@ public class JavaParserUtil {
 
     // If there is only one callable where the rest of the parameters match and a few others that
     // are null, return this maybe best match
-    CallableDeclaration<?> maybeBestMatch = null;
+    NodeWithParameters<?> maybeBestMatch = null;
     // If there are multiple callables, find the best match, i.e., FQNs = FQNs and simple names =
     // simple names
     // If there is one that matches exactly, return it; others that match it directly are simply
     // overrides
-    for (CallableDeclaration<?> callable : callables) {
+    for (NodeWithParameters<?> callable : callables) {
       boolean isAMatch = true;
       int nulls = 0;
       for (int i = 0; i < callable.getParameters().size(); i++) {
@@ -1309,13 +1310,15 @@ public class JavaParserUtil {
   /**
    * Given a constructor call, returns all possible constructors that match the arity and known
    * types of the arguments. This returns an empty list if no matching constructors were found or if
-   * the declaring type could not be solved.
+   * the declaring type could not be solved. Most list elements will be of type
+   * ConstructorDeclaration, but may be a RecordDeclaration if the constructor call is a potential
+   * match for a record's canonical constructor.
    *
    * @param constructorCall The constructor call expression
    * @param fqnToCompilationUnits The map of type FQNs to their compilation units
    * @return All possible constructor declarations
    */
-  private static List<ConstructorDeclaration> tryResolveConstructorCallWithUnresolvableArguments(
+  private static List<NodeWithParameters<?>> tryResolveConstructorCallWithUnresolvableArguments(
       ObjectCreationExpr constructorCall, Map<String, CompilationUnit> fqnToCompilationUnits) {
     List<@Nullable ResolvedType> parameterTypes =
         getArgumentTypesAsResolved(constructorCall.getArguments());
@@ -1334,10 +1337,19 @@ public class JavaParserUtil {
       return List.of();
     }
 
-    List<ConstructorDeclaration> candidates = new ArrayList<>();
+    List<NodeWithParameters<?>> candidates = new ArrayList<>();
+    if (enclosingClass.isRecordDeclaration()) {
+      if (isNodeWithParametersACandidate(enclosingClass.asRecordDeclaration(), parameterTypes)) {
+        candidates.add(enclosingClass.asRecordDeclaration());
+      }
+    }
+
+    List<ConstructorDeclaration> constructors = new ArrayList<>();
 
     addAllMatchingCallablesToList(
-        enclosingClass, parameterTypes, candidates, null, ConstructorDeclaration.class);
+        enclosingClass, parameterTypes, constructors, null, ConstructorDeclaration.class);
+
+    candidates.addAll(constructors);
 
     return candidates;
   }
@@ -1494,15 +1506,19 @@ public class JavaParserUtil {
     }
 
     if (enclosingAnonymousClass != null) {
-      addAllMatchingCallablesToListImpl(
+      for (MethodDeclaration method :
           enclosingAnonymousClass.getAnonymousClassBody().get().stream()
-              .filter(BodyDeclaration::isCallableDeclaration)
-              .map(c -> (CallableDeclaration<?>) c)
-              .toList(),
-          parameterTypes,
-          candidates,
-          methodCall.getNameAsString(),
-          MethodDeclaration.class);
+              .filter(BodyDeclaration::isMethodDeclaration)
+              .map(BodyDeclaration::asMethodDeclaration)
+              .toList()) {
+        if (!method.getNameAsString().equals(methodCall.getNameAsString())) {
+          continue;
+        }
+
+        if (isNodeWithParametersACandidate(method, parameterTypes)) {
+          candidates.add(method);
+        }
+      }
     }
 
     return candidates;
@@ -1640,95 +1656,86 @@ public class JavaParserUtil {
       List<T> result,
       @Nullable String methodName,
       Class<T> callableType) {
-    List<? extends CallableDeclaration<?>> callables;
+    List<? extends NodeWithParameters<?>> callables;
     if (callableType == ConstructorDeclaration.class) {
       callables = typeDecl.getConstructors();
     } else if (callableType == MethodDeclaration.class) {
-      callables = typeDecl.getMethods();
+      callables =
+          typeDecl.getMethods().stream()
+              .filter(m -> m.getNameAsString().equals(methodName))
+              .collect(Collectors.toList());
     } else {
       // Impossible: see
       // https://www.javadoc.io/doc/com.github.javaparser/javaparser-core/latest/com/github/javaparser/ast/body/CallableDeclaration.html
       throw new IllegalArgumentException("Impossible CallableDeclaration type.");
     }
 
-    addAllMatchingCallablesToListImpl(callables, parameterTypes, result, methodName, callableType);
+    for (NodeWithParameters<?> nodeWithParameters : callables) {
+      if (isNodeWithParametersACandidate(nodeWithParameters, parameterTypes)) {
+        result.add(callableType.cast(nodeWithParameters));
+      }
+    }
   }
 
   /**
-   * Actual logic for {@link #addAllMatchingCallablesToList}.
+   * Helper function for {@link #addAllMatchingCallablesToList(TypeDeclaration, List, List, String,
+   * Class)}. Determines whether a given NodeWithParameters is a potential candidate for a given set
+   * of parameter types. That list of parameter types should either contain ResolvedTypes or nulls,
+   * depending on whether that type was originally resolvable or not.
    *
-   * @param callables The list of callables to check against
-   * @param parameterTypes The resolved parameter types. Fully qualified names if resolvable, simple
-   *     names if not, and null if no type could be found at all.
-   * @param result The list to append to
-   * @param methodName The method name, if the callable is a method (it is ignored otherwise)
-   * @param callableType The type of callable (i.e., ConstructorDeclaration or MethodDeclaration)
+   * @param candidate The potential candidate to check
+   * @param requiredParamTypes The required parameter types
+   * @return True if it is a candidate, false otherwise
    */
-  private static <T extends CallableDeclaration<?>> void addAllMatchingCallablesToListImpl(
-      List<? extends CallableDeclaration<?>> callables,
-      List<@Nullable ResolvedType> parameterTypes,
-      List<T> result,
-      @Nullable String methodName,
-      Class<T> callableType) {
-    for (CallableDeclaration<?> callable : callables) {
-      if (callable.getParameters().size() != parameterTypes.size()) {
-        continue;
-      }
-      if (callableType == MethodDeclaration.class
-          && !callable.getNameAsString().equals(methodName)) {
-        continue;
-      }
+  private static boolean isNodeWithParametersACandidate(
+      NodeWithParameters<?> candidate, List<@Nullable ResolvedType> requiredParamTypes) {
+    if (candidate.getParameters().size() != requiredParamTypes.size()) {
+      return false;
+    }
 
-      boolean isAMatch = true;
+    for (int i = 0; i < candidate.getParameters().size(); i++) {
+      ResolvedType typeInCall = requiredParamTypes.get(i);
 
-      for (int i = 0; i < callable.getParameters().size(); i++) {
-        ResolvedType typeInCall = parameterTypes.get(i);
+      ResolvedParameterDeclaration resolvedParam = Resolver.resolve(candidate.getParameter(i));
+      boolean isParamTypeUnsolved = resolvedParam == null;
 
-        ResolvedParameterDeclaration resolvedParam = Resolver.resolve(callable.getParameter(i));
-        boolean isParamTypeUnsolved = resolvedParam == null;
+      if (resolvedParam != null) {
+        ResolvedType resolvedParameterType = null;
+        try {
+          resolvedParameterType = resolvedParam.getType();
+        } catch (UnsolvedSymbolException ex) {
+          isParamTypeUnsolved = true;
+          // getType() may throw an UnsolvedSymbolException
+        }
 
-        if (resolvedParam != null) {
-          ResolvedType resolvedParameterType = null;
-          try {
-            resolvedParameterType = resolvedParam.getType();
-          } catch (UnsolvedSymbolException ex) {
-            isParamTypeUnsolved = true;
-            // getType() may throw an UnsolvedSymbolException
-          }
+        if (typeInCall == null || isParamTypeUnsolved || resolvedParameterType == null) {
+          continue;
+        }
 
-          if (typeInCall == null || isParamTypeUnsolved || resolvedParameterType == null) {
+        if (!resolvedParameterType.isAssignableBy(typeInCall)) {
+          // If either is a type variable and the other is a reference type, it is likely valid
+          // Note that isAssignableBy will return false in those cases
+          if (typeInCall.isTypeVariable() && resolvedParameterType.isReference()) {
             continue;
           }
-
-          if (!resolvedParameterType.isAssignableBy(typeInCall)) {
-            // If either is a type variable and the other is a reference type, it is likely valid
-            // Note that isAssignableBy will return false in those cases
-            if (typeInCall.isTypeVariable() && resolvedParameterType.isReference()) {
-              continue;
-            }
-            if (resolvedParameterType.isTypeVariable() && typeInCall.isReference()) {
-              continue;
-            }
-            // JavaParser can't handle constraint types well. This isn't perfect (i.e., doesn't
-            // properly match bounds), but it should work for most cases.
-            if (typeInCall.isConstraint() && resolvedParameterType.isReference()) {
-              continue;
-            }
-            isAMatch = false;
-            break;
+          if (resolvedParameterType.isTypeVariable() && typeInCall.isReference()) {
+            continue;
           }
-        }
-
-        if (isParamTypeUnsolved && typeInCall != null) {
-          isAMatch = false;
-          break;
+          // JavaParser can't handle constraint types well. This isn't perfect (i.e., doesn't
+          // properly match bounds), but it should work for most cases.
+          if (typeInCall.isConstraint() && resolvedParameterType.isReference()) {
+            continue;
+          }
+          return false;
         }
       }
 
-      if (isAMatch) {
-        result.add(callableType.cast(callable));
+      if (isParamTypeUnsolved && typeInCall != null) {
+        return false;
       }
     }
+
+    return true;
   }
 
   /**
@@ -1971,7 +1978,11 @@ public class JavaParserUtil {
     }
 
     Class<? extends Node> nodeClass = detachedNode.getClass();
-    return attached.findFirst(nodeClass, n -> n.equals(detachedNode)).orElse(null);
+    return attached
+        .findFirst(
+            nodeClass,
+            n -> n.equals(detachedNode) && n.getParentNode().equals(detachedNode.getParentNode()))
+        .orElse(null);
   }
 
   /**
@@ -1995,16 +2006,18 @@ public class JavaParserUtil {
   }
 
   /**
-   * Given a list of parameter types, return a super(...) call with the default values of those
+   * Given a list of parameter types, return a super/this(...) call with the default values of those
    * types.
    *
-   * @param paramTypes The parameter types
-   * @return The super(...) call; i.e., super(0, null);
+   * @param paramTypes The parameter types*
+   * @param isThis If true, then {@code this}; else, {@code super}
+   * @return The super/this(...) call; i.e., super(0, null); or this(0, null);
    */
-  public static String getDefaultSuperConstructorCall(List<String> paramTypes) {
+  public static String getDefaultConstructorCall(List<String> paramTypes, boolean isThis) {
     StringBuilder sb = new StringBuilder();
 
-    sb.append("super(");
+    sb.append(isThis ? "this" : "super");
+    sb.append("(");
 
     for (String paramType : paramTypes) {
       sb.append(getInitializerRHS(paramType));

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithExtends;
 import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
+import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -1978,10 +1979,23 @@ public class JavaParserUtil {
     }
 
     Class<? extends Node> nodeClass = detachedNode.getClass();
+    Node detachedParent = detachedNode.getParentNode().get();
+    NodeWithName<?> detachedParentWithName =
+        detachedParent instanceof NodeWithName<?> ? (NodeWithName<?>) detachedParent : null;
+
     return attached
         .findFirst(
             nodeClass,
-            n -> n.equals(detachedNode) && n.getParentNode().equals(detachedNode.getParentNode()))
+            // These simple heuristics don't guarantee that a similar but incorrect node is not
+            // selected, but they make it very rare.
+            n ->
+                n.getParentNode().isPresent()
+                    && n.getParentNode().get().getClass() == detachedParent.getClass()
+                    && (detachedParentWithName == null
+                        || detachedParentWithName
+                            .getNameAsString()
+                            .equals(((NodeWithName<?>) n.getParentNode().get()).getNameAsString()))
+                    && n.equals(detachedNode))
         .orElse(null);
   }
 

--- a/src/main/java/org/checkerframework/specimin/Resolver.java
+++ b/src/main/java/org/checkerframework/specimin/Resolver.java
@@ -1,20 +1,29 @@
 package org.checkerframework.specimin;
 
+import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.resolution.MethodAmbiguityException;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -196,11 +205,19 @@ public class Resolver {
       if (result != null) {
         return result;
       }
+
+      if (expr.isMethodCallExpr()) {
+        result = handleUnresolvableRecordMember(expr.asMethodCallExpr());
+
+        if (result != null) {
+          return result;
+        }
+      }
     }
 
     // Handle cases where a method/constructor call cannot be resolved because of unresolvable
     // arguments, but its definition exists
-    CallableDeclaration<?> potentiallyResolvableCallable =
+    NodeWithParameters<?> potentiallyResolvableCallable =
         unsolvable instanceof NodeWithArguments<?> withArgs
             ? JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
                 withArgs, fqnToCompilationUnits)
@@ -249,17 +266,83 @@ public class Resolver {
           "fqnToCompilationUnits must be set before calling handleMethodAmbiguityException");
     }
     if (!ex.toString().contains("ReflectionMethodDeclaration")) {
-      if (node instanceof MethodCallExpr methodCallExpr) {
-        CallableDeclaration<?> potentialMethod =
-            JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
-                methodCallExpr, fqnToCompilationUnits);
-
-        if (potentialMethod != null) {
-          return potentialMethod.asMethodDeclaration().resolve();
-        }
+      if (node instanceof MethodCallExpr methodCallExpr
+          && JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
+                  methodCallExpr, fqnToCompilationUnits)
+              instanceof MethodDeclaration methodDecl) {
+        return methodDecl.resolve();
       }
 
       throw ex;
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolves record members because JavaParser can't.
+   *
+   * @param methodCallExpr The method call expression
+   * @return The parameter representing the record member, or null if not found
+   */
+  private static @Nullable ResolvedMethodDeclaration handleUnresolvableRecordMember(
+      MethodCallExpr methodCallExpr) {
+    if (fqnToCompilationUnits == null) {
+      throw new UnsupportedOperationException(
+          "fqnToCompilationUnits must be set before calling handleUnsupportedOperationException");
+    }
+
+    if (methodCallExpr.getArguments().isNonEmpty()) {
+      return null;
+    }
+
+    // JavaParser bug: cannot resolve MethodCallExpr if it represents a record member
+
+    // We have to use our own implementation, ResolvedRecordMemberDeclaration, since JavaParser
+    // throws an IllegalStateException anytime we try to resolve the original parameter.
+    if (methodCallExpr.getArguments().isEmpty()) {
+      if (methodCallExpr.hasScope()) {
+        ResolvedType scopeType = calculateResolvedType(methodCallExpr.getScope().get());
+
+        if (scopeType == null
+            || !scopeType.isReferenceType()
+            || scopeType.asReferenceType().getTypeDeclaration().isEmpty()
+            || !scopeType.asReferenceType().getTypeDeclaration().get().isRecord()) {
+          return null;
+        }
+
+        TypeDeclaration<?> typeDecl =
+            JavaParserUtil.getTypeFromQualifiedName(scopeType.describe(), fqnToCompilationUnits);
+
+        if (typeDecl != null) {
+          for (Parameter param : typeDecl.asRecordDeclaration().getParameters()) {
+            if (param.getNameAsString().equals(methodCallExpr.getNameAsString())) {
+              return new ResolvedRecordMemberDeclaration(param);
+            }
+          }
+        }
+      } else {
+        TypeDeclaration<?> encapsulating =
+            JavaParserUtil.getEnclosingClassLikeOptional(methodCallExpr);
+
+        while (encapsulating != null) {
+          if (encapsulating.isRecordDeclaration()) {
+            for (Parameter param : encapsulating.asRecordDeclaration().getParameters()) {
+              if (param.getNameAsString().equals(methodCallExpr.getNameAsString())) {
+                return new ResolvedRecordMemberDeclaration(param);
+              }
+            }
+          }
+
+          if (encapsulating.getParentNode().isEmpty()) {
+            return null;
+          }
+
+          // Check all outer classes
+          encapsulating =
+              JavaParserUtil.getEnclosingClassLikeOptional(encapsulating.getParentNode().get());
+        }
+      }
     }
 
     return null;
@@ -311,5 +394,86 @@ public class Resolver {
       }
     }
     throw ex;
+  }
+
+  /**
+   * Custom class to hold a record member declaration, since JavaParser cannot handle this case.
+   *
+   * @param parameter The wrapped parameter.
+   */
+  private record ResolvedRecordMemberDeclaration(Parameter parameter)
+      implements ResolvedMethodDeclaration {
+    @Override
+    public ResolvedType getReturnType() {
+      return Resolver.resolveGuaranteeNonNull(parameter.getType());
+    }
+
+    @Override
+    public boolean isAbstract() {
+      return false;
+    }
+
+    @Override
+    public boolean isDefaultMethod() {
+      return false;
+    }
+
+    @Override
+    public boolean isStatic() {
+      return false;
+    }
+
+    @Override
+    public String toDescriptor() {
+      return "";
+    }
+
+    @Override
+    public ResolvedReferenceTypeDeclaration declaringType() {
+      return (ResolvedReferenceTypeDeclaration)
+          resolveGuaranteeNonNull((Resolvable<?>) JavaParserUtil.getEnclosingClassLike(parameter));
+    }
+
+    @Override
+    public int getNumberOfParams() {
+      return 0;
+    }
+
+    @Override
+    public ResolvedParameterDeclaration getParam(int i) {
+      throw new IndexOutOfBoundsException(
+          "There are no parameters in a record member declaration.");
+    }
+
+    @Override
+    public int getNumberOfSpecifiedExceptions() {
+      return 0;
+    }
+
+    @Override
+    public ResolvedType getSpecifiedException(int index) {
+      throw new IndexOutOfBoundsException(
+          "There are no exceptions in a record member declaration.");
+    }
+
+    @Override
+    public AccessSpecifier accessSpecifier() {
+      return AccessSpecifier.PUBLIC;
+    }
+
+    @Override
+    public String getName() {
+      return parameter.getNameAsString();
+    }
+
+    @Override
+    public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
+      return List.of();
+    }
+
+    @Override
+    public Optional<Node> toAst() {
+      return Optional.of(parameter);
+    }
   }
 }

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -26,6 +26,7 @@ import com.github.javaparser.ast.type.UnknownType;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -317,6 +318,14 @@ public class Slicer {
     List<TypeDeclaration<?>> typesCopy = new ArrayList<>(cu.getTypes());
     for (TypeDeclaration<?> typeDecl : typesCopy) {
       removeNonSliceNodes(typeDecl);
+
+      if (typeDecl.getFullyQualifiedName().isPresent()) {
+        Object resolved = Resolver.resolveGuaranteeNonNull((Resolvable<?>) typeDecl);
+
+        if (resolved instanceof ResolvedReferenceTypeDeclaration resolvedDecl) {
+          typeSolvers.overrideCache(typeDecl.getFullyQualifiedName().get(), resolvedDecl);
+        }
+      }
     }
   }
 
@@ -435,9 +444,6 @@ public class Slicer {
             ConstructorDeclaration decl =
                 classOrInterfaceDecl.addConstructor(Modifier.Keyword.PUBLIC);
             decl.setBody(new BlockStmt(new NodeList<>(StaticJavaParser.parseStatement(superCall))));
-            if (classOrInterfaceDecl.getFullyQualifiedName().isPresent()) {
-              typeSolvers.clearCache(classOrInterfaceDecl.getFullyQualifiedName().get());
-            }
           }
         }
       } else if (node instanceof RecordDeclaration recordDecl) {

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -400,7 +400,7 @@ public class Slicer {
                   constructorNode.getParameters().stream()
                       .map(p -> p.getType().toString())
                       .toList();
-            } else {
+            } else if (attached != null) {
               parameterTypes =
                   constructor.formalParameterTypes().stream().map(ResolvedType::describe).toList();
             }

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -2,9 +2,12 @@ package org.checkerframework.specimin;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
@@ -19,8 +22,11 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.ast.type.UnknownType;
 import com.github.javaparser.resolution.Resolvable;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,6 +35,7 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.specimin.unsolved.UnsolvedGenerationResult;
@@ -37,8 +44,8 @@ import org.checkerframework.specimin.unsolved.UnsolvedSymbolGenerator;
 
 /**
  * Slices a program, given an initial worklist and a type rule dependency map. This class cannot be
- * instantiated; instead, use {@link #slice(TypeRuleDependencyMap, Deque, UnsolvedSymbolGenerator)}
- * to use this class.
+ * instantiated; instead, use {@link #slice(TypeRuleDependencyMap, Deque, UnsolvedSymbolGenerator,
+ * Map, SpeciminTypeSolvers)} to use this class.
  */
 public class Slicer {
   /**
@@ -75,20 +82,32 @@ public class Slicer {
   /** The type rule dependency map. */
   private final TypeRuleDependencyMap typeRuleDependencyMap;
 
+  /** A map of FQNs to compilation units. */
+  private final Map<String, CompilationUnit> fqnToCompilationUnits;
+
+  /** The collection of type solvers used by Specimin. */
+  private final SpeciminTypeSolvers typeSolvers;
+
   /**
    * Creates a new instance of {@link Slicer}.
    *
    * @param typeRuleDependencyMap The type rule dependency map to use in the slice.
    * @param worklist The worklist to use, already populated with target members and their bodies.
    * @param unsolvedSymbolGenerator The unsolved symbol generator to use.
+   * @param fqnToCompilationUnits The map of FQNs to compilation units.
+   * @param typeSolvers The collection of type solvers to use.
    */
   private Slicer(
       TypeRuleDependencyMap typeRuleDependencyMap,
       Deque<Node> worklist,
-      UnsolvedSymbolGenerator unsolvedSymbolGenerator) {
+      UnsolvedSymbolGenerator unsolvedSymbolGenerator,
+      Map<String, CompilationUnit> fqnToCompilationUnits,
+      SpeciminTypeSolvers typeSolvers) {
     this.typeRuleDependencyMap = typeRuleDependencyMap;
     this.worklist = worklist;
     this.unsolvedSymbolGenerator = unsolvedSymbolGenerator;
+    this.fqnToCompilationUnits = fqnToCompilationUnits;
+    this.typeSolvers = typeSolvers;
   }
 
   /**
@@ -99,13 +118,23 @@ public class Slicer {
    * @param typeRuleDependencyMap The type rule dependency map to use in the slice.
    * @param worklist The worklist to use, already populated with target members and their bodies.
    * @param unsolvedSymbolGenerator The unsolved symbol generator to use.
+   * @param fqnToCompilationUnits The map of FQNs to compilation units.
+   * @param typeSolvers The collection of type solvers to use.
    * @return A {@link SliceResult} representing the output of the slice.
    */
   public static SliceResult slice(
       TypeRuleDependencyMap typeRuleDependencyMap,
       Deque<Node> worklist,
-      UnsolvedSymbolGenerator unsolvedSymbolGenerator) {
-    Slicer slicer = new Slicer(typeRuleDependencyMap, worklist, unsolvedSymbolGenerator);
+      UnsolvedSymbolGenerator unsolvedSymbolGenerator,
+      Map<String, CompilationUnit> fqnToCompilationUnits,
+      SpeciminTypeSolvers typeSolvers) {
+    Slicer slicer =
+        new Slicer(
+            typeRuleDependencyMap,
+            worklist,
+            unsolvedSymbolGenerator,
+            fqnToCompilationUnits,
+            typeSolvers);
 
     slicer.buildSlice();
 
@@ -150,7 +179,7 @@ public class Slicer {
     if (!generatedSymbolSlice.isEmpty()) {
       // Step 2: Add more information to generated symbols based on context
       for (Node element : postProcessingWorklist) {
-        UnsolvedGenerationResult result = unsolvedSymbolGenerator.addInformation(element);
+        UnsolvedGenerationResult result = unsolvedSymbolGenerator.addInformation(element, slice);
         generatedSymbolSlice.addAll(result.toAdd());
         result.toRemove().forEach(generatedSymbolSlice::remove);
       }
@@ -338,6 +367,76 @@ public class Slicer {
         if (!isSet) {
           fieldDeclarator.setInitializer(
               JavaParserUtil.getInitializerRHS(fieldDeclarator.getType().toString()));
+        }
+      }
+
+      // If we find a class whose superclass whose constructors all have parameters, we need to
+      // 1) either generate a constructor that calls super(...) OR
+      // 2) replace a constructor in the slice with a body that calls super(...)
+
+      else if (node instanceof ClassOrInterfaceDeclaration classOrInterfaceDecl
+          && !classOrInterfaceDecl.isInterface()
+          && classOrInterfaceDecl.getExtendedTypes().size() == 1) {
+        ResolvedType superClass = Resolver.resolve(classOrInterfaceDecl.getExtendedTypes(0));
+
+        if (superClass instanceof ResolvedReferenceType superClassResolved
+            && superClassResolved.getTypeDeclaration().isPresent()) {
+          List<String> parameterTypes = null;
+
+          for (ResolvedConstructorDeclaration constructor :
+              superClassResolved.getTypeDeclaration().get().getConstructors()) {
+            if (parameterTypes != null
+                && parameterTypes.size() <= constructor.getNumberOfParams()) {
+              continue;
+            }
+
+            Node attached = JavaParserUtil.tryFindAttachedNode(constructor, fqnToCompilationUnits);
+
+            if (attached instanceof ConstructorDeclaration constructorNode) {
+              if (!slice.contains(constructorNode)) {
+                continue;
+              }
+              parameterTypes =
+                  constructorNode.getParameters().stream()
+                      .map(p -> p.getType().toString())
+                      .toList();
+            } else {
+              parameterTypes =
+                  constructor.formalParameterTypes().stream().map(ResolvedType::describe).toList();
+            }
+          }
+
+          if (parameterTypes == null || parameterTypes.isEmpty()) {
+            return;
+          }
+
+          String superCall = JavaParserUtil.getDefaultSuperConstructorCall(parameterTypes);
+
+          boolean foundConstructor = false;
+          for (ConstructorDeclaration constructorDeclaration :
+              classOrInterfaceDecl.getConstructors()) {
+            if (!slice.contains(constructorDeclaration)) {
+              continue;
+            }
+
+            foundConstructor = true;
+            if (slice.contains(constructorDeclaration.getBody())) {
+              continue;
+            }
+
+            constructorDeclaration.setBody(
+                new BlockStmt(new NodeList<>(StaticJavaParser.parseStatement(superCall))));
+            // No need to add body to slice because all children have already been handled
+          }
+
+          if (!foundConstructor) {
+            ConstructorDeclaration decl =
+                classOrInterfaceDecl.addConstructor(Modifier.Keyword.PUBLIC);
+            decl.setBody(new BlockStmt(new NodeList<>(StaticJavaParser.parseStatement(superCall))));
+            if (classOrInterfaceDecl.getFullyQualifiedName().isPresent()) {
+              typeSolvers.clearCache(classOrInterfaceDecl.getFullyQualifiedName().get());
+            }
+          }
         }
       }
     }

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -10,6 +10,8 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AssignExpr;
@@ -284,7 +286,7 @@ public class Slicer {
       throw new RuntimeException("Unexpected null value in resolve() call");
     }
 
-    List<Node> toAddToWorklist = typeRuleDependencyMap.getRelevantElements(resolved);
+    List<Node> toAddToWorklist = typeRuleDependencyMap.getRelevantElements(resolved, unresolved);
     worklist.addAll(toAddToWorklist);
 
     // Since resolved declarations may reference another file, we need to add that compilation
@@ -410,7 +412,7 @@ public class Slicer {
             return;
           }
 
-          String superCall = JavaParserUtil.getDefaultSuperConstructorCall(parameterTypes);
+          String superCall = JavaParserUtil.getDefaultConstructorCall(parameterTypes, false);
 
           boolean foundConstructor = false;
           for (ConstructorDeclaration constructorDeclaration :
@@ -437,6 +439,20 @@ public class Slicer {
               typeSolvers.clearCache(classOrInterfaceDecl.getFullyQualifiedName().get());
             }
           }
+        }
+      } else if (node instanceof RecordDeclaration recordDecl) {
+        String thisInvocationStmt =
+            JavaParserUtil.getDefaultConstructorCall(
+                recordDecl.getParameters().stream().map(Parameter::getTypeAsString).toList(), true);
+
+        for (ConstructorDeclaration decl : recordDecl.getConstructors()) {
+          if (!slice.contains(decl)) {
+            continue;
+          }
+
+          // Record non-canonical constructors must call the canonical
+          decl.setBody(
+              new BlockStmt(new NodeList<>(StaticJavaParser.parseStatement(thisInvocationStmt))));
         }
       }
     }

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -10,9 +10,7 @@ import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
 import com.github.javaparser.utils.SourceRoot;
 import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.FormatterException;
@@ -232,7 +230,8 @@ public class SpeciminRunner {
       validateRoot(root, targetMethodNames, targetFieldNames);
     }
 
-    ParserConfiguration config = updateStaticSolver(root, jarPaths);
+    SpeciminTypeSolvers typeSolver = initializeSolvers(root, jarPaths);
+    ParserConfiguration config = updateStaticSolver(typeSolver);
     decompileJarFiles(root, jarPaths, createdClass);
 
     SourceRoot sourceRoot = new SourceRoot(Path.of(root));
@@ -303,7 +302,9 @@ public class SpeciminRunner {
         Slicer.slice(
             new StandardTypeRuleDependencyMap(fqnToCompilationUnits),
             worklist,
-            unsolvedSymbolGenerator);
+            unsolvedSymbolGenerator,
+            fqnToCompilationUnits,
+            typeSolver);
 
     // cache to avoid called Files.createDirectories repeatedly with the same
     // arguments
@@ -674,27 +675,29 @@ public class SpeciminRunner {
   }
 
   /**
-   * Update the static solver for JavaParser.
+   * Sets up the type solvers for this run of Specimin, and returns it once initialized.
    *
    * @param root the root directory of the files to parse.
    * @param jarPaths the list of jar files to be used as input.
+   * @return The type solvers
    * @throws IOException if something went wrong.
    */
-  private static ParserConfiguration updateStaticSolver(String root, List<String> jarPaths)
+  private static SpeciminTypeSolvers initializeSolvers(String root, List<String> jarPaths)
       throws IOException {
-    MemoryTypeSolver mem = new MemoryTypeSolver();
+    SpeciminTypeSolvers typeSolver = new SpeciminTypeSolvers(root, jarPaths);
 
-    // Set up the parser's symbol solver, so that we can resolve definitions.
-    CombinedTypeSolver typeSolver =
-        new CombinedTypeSolver(new JdkTypeSolver(), new JavaParserTypeSolver(new File(root)), mem);
+    JavaParserUtil.setTypeSolvers(typeSolver);
 
-    for (String path : jarPaths) {
-      typeSolver.add(new JarTypeSolver(path));
-    }
+    return typeSolver;
+  }
 
-    JavaParserUtil.setTypeSolvers(typeSolver, mem);
-
-    JavaSymbolSolver symbolSolver = new JavaSymbolSolver(typeSolver);
+  /**
+   * Update the static solver for JavaParser.
+   *
+   * @param typeSolver the type solver
+   */
+  private static ParserConfiguration updateStaticSolver(SpeciminTypeSolvers typeSolver) {
+    JavaSymbolSolver symbolSolver = new JavaSymbolSolver(typeSolver.getTypeSolver());
 
     ParserConfiguration config =
         new ParserConfiguration()

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -356,23 +356,7 @@ public class SpeciminRunner {
       Set<Path> createdDirectories,
       Formatter formatter)
       throws IOException {
-    Set<String> usedPackages = new HashSet<>();
-    for (CompilationUnit cu : sliceResult.solvedSlice()) {
-      if (cu.getPackageDeclaration().isEmpty()) {
-        usedPackages.add("");
-        continue;
-      }
-      usedPackages.add(cu.getPackageDeclaration().get().getNameAsString());
-    }
-
-    for (String className : enumeratorResult.classNamesToFileContent().keySet()) {
-      int lastDot = className.lastIndexOf('.');
-      if (lastDot < 0) {
-        usedPackages.add("");
-      } else {
-        usedPackages.add(className.substring(0, lastDot));
-      }
-    }
+    Set<String> usedPackagesAndClasses = getUsedPackagesAndClasses(sliceResult, enumeratorResult);
 
     for (CompilationUnit original : sliceResult.solvedSlice()) {
       if (isEmptyCompilationUnit(original)) {
@@ -436,7 +420,7 @@ public class SpeciminRunner {
         writer.print(
             formatter.formatSourceAndFixImports(
                 getCompilationUnitWithUnusedWildcardImportsRemoved(
-                        getCompilationUnitWithCommentsTrimmed(cu), usedPackages)
+                        getCompilationUnitWithCommentsTrimmed(cu), usedPackagesAndClasses)
                     .toString()));
       } catch (IOException | FormatterException e) {
         System.out.println("failed to write output file " + targetOutputPath);
@@ -470,6 +454,39 @@ public class SpeciminRunner {
         System.out.println("with error: " + e);
       }
     }
+  }
+
+  private static Set<String> getUsedPackagesAndClasses(
+      SliceResult sliceResult, UnsolvedSymbolEnumeratorResult enumeratorResult) {
+    Set<String> usedPackagesAndClasses = new HashSet<>();
+    for (CompilationUnit cu : sliceResult.solvedSlice()) {
+      if (cu.getPackageDeclaration().isEmpty()) {
+        usedPackagesAndClasses.add("");
+        continue;
+      }
+      usedPackagesAndClasses.add(cu.getPackageDeclaration().get().getNameAsString());
+
+      for (TypeDeclaration<?> typeDecl : cu.findAll(TypeDeclaration.class)) {
+        String fqn = typeDecl.getFullyQualifiedName().orElse(null);
+
+        if (fqn == null) {
+          continue;
+        }
+
+        usedPackagesAndClasses.add(fqn);
+      }
+    }
+
+    for (String className : enumeratorResult.classNamesToFileContent().keySet()) {
+      int lastDot = className.lastIndexOf('.');
+      if (lastDot < 0) {
+        usedPackagesAndClasses.add("");
+      } else {
+        usedPackagesAndClasses.add(className.substring(0, lastDot));
+        usedPackagesAndClasses.add(className);
+      }
+    }
+    return usedPackagesAndClasses;
   }
 
   /**
@@ -576,22 +593,22 @@ public class SpeciminRunner {
    * Removes all wildcard imports that are not used in the given set of package names.
    *
    * @param cu The CompilationUnit to process.
-   * @param usedPackages A set of package names that are used in the code.
+   * @param usedPackagesAndClasses A set of package and class names that are used in the code.
    * @return The modified CompilationUnit with unused wildcard imports removed.
    */
   private static CompilationUnit getCompilationUnitWithUnusedWildcardImportsRemoved(
-      CompilationUnit cu, Set<String> usedPackages) {
+      CompilationUnit cu, Set<String> usedPackagesAndClasses) {
     for (ImportDeclaration decl : List.copyOf(cu.getImports())) {
       if (!decl.isAsterisk()) {
         continue;
       }
-      String packageName = decl.getNameAsString();
+      String qualifier = decl.getNameAsString();
 
-      if (JavaLangUtils.inJdkPackage(packageName)) {
+      if (JavaLangUtils.inJdkPackage(qualifier)) {
         continue;
       }
 
-      if (!usedPackages.contains(packageName)) {
+      if (!usedPackagesAndClasses.contains(qualifier)) {
         decl.remove();
       }
     }

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -457,6 +457,13 @@ public class SpeciminRunner {
     }
   }
 
+  /**
+   * Gets the packages and classes used in the given slice and unsolved symbol enumeration.
+   *
+   * @param sliceResult The slice
+   * @param enumeratorResult The unsolved enumeration
+   * @return The used packages and classes
+   */
   private static Set<String> getUsedPackagesAndClasses(
       SliceResult sliceResult, UnsolvedSymbolEnumeratorResult enumeratorResult) {
     Set<String> usedPackagesAndClasses = new HashSet<>();

--- a/src/main/java/org/checkerframework/specimin/SpeciminTypeSolvers.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminTypeSolvers.java
@@ -1,0 +1,128 @@
+package org.checkerframework.specimin;
+
+import com.github.javaparser.resolution.cache.Cache;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.model.SymbolReference;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.List;
+
+/**
+ * Creates and manages the type solvers required for Specimin, in addition to some reflection-based
+ * utility methods.
+ */
+public class SpeciminTypeSolvers {
+  /** The combined type solver. */
+  private final CombinedTypeSolver typeSolver;
+
+  /** The solver that reads in files from the root. */
+  private final JavaParserTypeSolver javaParserTypeSolver;
+
+  /** Type solver for types created during Specimin's run. */
+  private final MemoryTypeSolver memoryTypeSolver;
+
+  /**
+   * Creates the necessary type solvers for Specimin.
+   *
+   * @param root The root directory of the input.
+   * @param jarPaths The paths to the jar files.
+   */
+  public SpeciminTypeSolvers(String root, List<String> jarPaths) throws IOException {
+    this.memoryTypeSolver = new MemoryTypeSolver();
+    this.javaParserTypeSolver = new JavaParserTypeSolver(new File(root));
+    this.typeSolver =
+        new CombinedTypeSolver(new JdkTypeSolver(), javaParserTypeSolver, memoryTypeSolver);
+
+    for (String path : jarPaths) {
+      this.typeSolver.add(new JarTypeSolver(path));
+    }
+  }
+
+  /**
+   * Gets the {@link CombinedTypeSolver} associated with this instance. Use this as the type solver
+   * for resolution.
+   *
+   * @return The {@link CombinedTypeSolver}
+   */
+  public CombinedTypeSolver getTypeSolver() {
+    return typeSolver;
+  }
+
+  /**
+   * Gets the {@link MemoryTypeSolver} associated with this instance.
+   *
+   * @return The {@link MemoryTypeSolver}
+   */
+  public MemoryTypeSolver getMemoryTypeSolver() {
+    return memoryTypeSolver;
+  }
+
+  /**
+   * Clears a type's cache from JavaParser's resolution cache. This method uses reflection--there is
+   * no way to clear the cache otherwise. Call this method when you have modified the AST and you
+   * cannot have a stale cache for that object.
+   *
+   * @param fqn The type to clear from the cache
+   */
+  public void clearCache(String fqn) {
+    clearCombinedTypeSolverCache(fqn);
+    clearJavaParserTypeSolverCache(fqn);
+  }
+
+  /**
+   * Clears the cache in {@link SpeciminTypeSolvers#typeSolver} for the given type.
+   *
+   * @param fqn The FQN of the type to clear from the cache
+   */
+  private void clearCombinedTypeSolverCache(String fqn) {
+    try {
+      clearFromJavaParserCacheImpl(
+          CombinedTypeSolver.class.getDeclaredField("typeCache"), fqn, typeSolver);
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Clears the cache in {@link SpeciminTypeSolvers#javaParserTypeSolver} for the given type.
+   *
+   * @param fqn The FQN of the type to clear from the cache
+   */
+  private void clearJavaParserTypeSolverCache(String fqn) {
+    try {
+      clearFromJavaParserCacheImpl(
+          JavaParserTypeSolver.class.getDeclaredField("foundTypes"), fqn, javaParserTypeSolver);
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Gets the cache from the given field and clears the given type.
+   *
+   * @param field The field containing the cache
+   * @param fqn The type to clear
+   */
+  private void clearFromJavaParserCacheImpl(Field field, String fqn, Object solver) {
+    try {
+      field.setAccessible(true);
+
+      @SuppressWarnings("unchecked")
+      // This is safe; both type solvers declares this type
+      Cache<String, SymbolReference<ResolvedReferenceTypeDeclaration>> value =
+          (Cache<String, SymbolReference<ResolvedReferenceTypeDeclaration>>) field.get(solver);
+
+      if (value == null) {
+        throw new RuntimeException("Could not access JavaParser's symbol resolution cache.");
+      }
+
+      value.remove(fqn);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/SpeciminTypeSolvers.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminTypeSolvers.java
@@ -1,5 +1,6 @@
 package org.checkerframework.specimin;
 
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.resolution.cache.Cache;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.model.SymbolReference;
@@ -30,6 +31,7 @@ public class SpeciminTypeSolvers {
    *
    * @param root The root directory of the input.
    * @param jarPaths The paths to the jar files.
+   * @throws IOException if something goes wrong
    */
   public SpeciminTypeSolvers(String root, List<String> jarPaths) throws IOException {
     this.memoryTypeSolver = new MemoryTypeSolver();
@@ -62,52 +64,75 @@ public class SpeciminTypeSolvers {
   }
 
   /**
-   * Clears a type's cache from JavaParser's resolution cache. This method uses reflection--there is
-   * no way to clear the cache otherwise. Call this method when you have modified the AST and you
-   * cannot have a stale cache for that object.
+   * Overrides a type's cache from JavaParser's resolution cache. This method uses reflection--there
+   * is no way to modify the cache otherwise. Call this method when you have modified the AST and
+   * you cannot have a stale cache for that object.
+   *
+   * <p>We must manually set the cache, because clearing it is not enough. In JavaParserTypeSolver,
+   * it simply reparses the original source file, which does not contain any AST changes made during
+   * Specimin's run.
    *
    * @param fqn The type to clear from the cache
+   * @param resolvedReferenceTypeDeclaration The declaration to override in the cache. MUST BE THE
+   *     OBJECT RETURNED FROM {@link TypeDeclaration#resolve()}; OTHERWISE, NOTHING WILL BE CHANGED.
    */
-  public void clearCache(String fqn) {
-    clearCombinedTypeSolverCache(fqn);
-    clearJavaParserTypeSolverCache(fqn);
+  public void overrideCache(
+      String fqn, ResolvedReferenceTypeDeclaration resolvedReferenceTypeDeclaration) {
+    overrideInCombinedTypeSolverCache(fqn, resolvedReferenceTypeDeclaration);
+    overrideInJavaParserTypeSolverCache(fqn, resolvedReferenceTypeDeclaration);
   }
 
   /**
-   * Clears the cache in {@link SpeciminTypeSolvers#typeSolver} for the given type.
+   * Overrides the cache in {@link SpeciminTypeSolvers#typeSolver} for the given type.
    *
-   * @param fqn The FQN of the type to clear from the cache
+   * @param fqn The FQN of the type to override in the cache
+   * @param resolvedReferenceTypeDeclaration The declaration to override in the cache
    */
-  private void clearCombinedTypeSolverCache(String fqn) {
+  private void overrideInCombinedTypeSolverCache(
+      String fqn, ResolvedReferenceTypeDeclaration resolvedReferenceTypeDeclaration) {
     try {
-      clearFromJavaParserCacheImpl(
-          CombinedTypeSolver.class.getDeclaredField("typeCache"), fqn, typeSolver);
+      overrideInJavaParserCacheImpl(
+          CombinedTypeSolver.class.getDeclaredField("typeCache"),
+          fqn,
+          typeSolver,
+          resolvedReferenceTypeDeclaration);
     } catch (NoSuchFieldException e) {
       throw new RuntimeException(e);
     }
   }
 
   /**
-   * Clears the cache in {@link SpeciminTypeSolvers#javaParserTypeSolver} for the given type.
+   * Overrides the cache in {@link SpeciminTypeSolvers#javaParserTypeSolver} for the given type.
    *
-   * @param fqn The FQN of the type to clear from the cache
+   * @param fqn The FQN of the type to override in the cache
+   * @param resolvedReferenceTypeDeclaration The declaration to override in the cache
    */
-  private void clearJavaParserTypeSolverCache(String fqn) {
+  private void overrideInJavaParserTypeSolverCache(
+      String fqn, ResolvedReferenceTypeDeclaration resolvedReferenceTypeDeclaration) {
     try {
-      clearFromJavaParserCacheImpl(
-          JavaParserTypeSolver.class.getDeclaredField("foundTypes"), fqn, javaParserTypeSolver);
+      overrideInJavaParserCacheImpl(
+          JavaParserTypeSolver.class.getDeclaredField("foundTypes"),
+          fqn,
+          javaParserTypeSolver,
+          resolvedReferenceTypeDeclaration);
     } catch (NoSuchFieldException e) {
       throw new RuntimeException(e);
     }
   }
 
   /**
-   * Gets the cache from the given field and clears the given type.
+   * Gets the cache from the given field and overrides the given type.
    *
    * @param field The field containing the cache
    * @param fqn The type to clear
+   * @param solver The solver containing the field
+   * @param resolvedReferenceTypeDeclaration The declaration to override in the cache
    */
-  private void clearFromJavaParserCacheImpl(Field field, String fqn, Object solver) {
+  private void overrideInJavaParserCacheImpl(
+      Field field,
+      String fqn,
+      Object solver,
+      ResolvedReferenceTypeDeclaration resolvedReferenceTypeDeclaration) {
     try {
       field.setAccessible(true);
 
@@ -120,7 +145,7 @@ public class SpeciminTypeSolvers {
         throw new RuntimeException("Could not access JavaParser's symbol resolution cache.");
       }
 
-      value.remove(fqn);
+      value.put(fqn, SymbolReference.solved(resolvedReferenceTypeDeclaration));
     } catch (IllegalAccessException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
+++ b/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
@@ -73,6 +73,12 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
   private final Set<ResolvedMethodDeclaration> nonJDKMustImplementMethods = new HashSet<>();
 
   /**
+   * A set of seen type declarations so we can rediscover must implement methods if we already
+   * processed a declaration but later discover a must implement method.
+   */
+  private final Set<TypeDeclaration<?>> seenTypeDeclarations = new HashSet<>();
+
+  /**
    * Creates a new StandardTypeRuleDependencyMap to be passed into Slicer.
    *
    * @param fqnToCompilationUnits The map of type FQNs to their compilation units.
@@ -134,16 +140,9 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
     }
 
     // Type declarations
-    if (node instanceof NodeWithImplements<?> withImplements) {
-      elements.addAll(withImplements.getImplementedTypes());
-    }
-    if (node instanceof NodeWithExtends<?> withExtends) {
-      elements.addAll(withExtends.getExtendedTypes());
-    }
-    if (node instanceof ClassOrInterfaceDeclaration decl) {
-      elements.addAll(decl.getPermittedTypes());
-    }
     if (node instanceof TypeDeclaration<?> typeDeclaration) {
+      seenTypeDeclarations.add(typeDeclaration);
+
       List<MethodDeclaration> mustImplement =
           JavaParserUtil.getDeclarationsForAllMustImplementMethods(
               typeDeclaration, nonJDKMustImplementMethods, fqnToCompilationUnits);
@@ -177,6 +176,15 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
           // Methods like getAllAncestors() can throw an UnsolvedSymbolException
         }
       }
+    }
+    if (node instanceof NodeWithImplements<?> withImplements) {
+      elements.addAll(withImplements.getImplementedTypes());
+    }
+    if (node instanceof NodeWithExtends<?> withExtends) {
+      elements.addAll(withExtends.getExtendedTypes());
+    }
+    if (node instanceof ClassOrInterfaceDeclaration decl) {
+      elements.addAll(decl.getPermittedTypes());
     }
 
     // If the node is a type declaration, exit now, so we don't unintentionally
@@ -432,15 +440,21 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
       }
 
       if (resolved instanceof ResolvedMethodDeclaration resolvedMethodDeclaration) {
+        int before = nonJDKMustImplementMethods.size();
+
         if (isAnonymousClass && typeParametersMapForAnonClass != null) {
           // The current type is already a parent class, so we need to add those too
-          List<MethodDeclaration> methods = new ArrayList<>();
-          addOverriddenMethodsToList(
-              type, resolvedMethodDeclaration, typeParametersMapForAnonClass, methods);
-          elements.addAll(methods);
+          elements.addAll(
+              getOverriddenMethodsInDeclaration(
+                  type, resolvedMethodDeclaration, typeParametersMapForAnonClass));
         }
 
         elements.addAll(getAllOverriddenMethods(resolvedMethodDeclaration, type));
+
+        if (nonJDKMustImplementMethods.size() > before) {
+          elements.addAll(
+              seenTypeDeclarations.stream().flatMap(d -> getRelevantElements(d).stream()).toList());
+        }
       }
 
       // Case: new Foo() but Foo does not contain a constructor
@@ -559,57 +573,64 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
         continue;
       }
 
-      addOverriddenMethodsToList(
-          typeDecl, original, parentType.asReferenceType().getTypeParametersMap(), result);
+      result.addAll(
+          getOverriddenMethodsInDeclaration(
+              typeDecl, original, parentType.asReferenceType().getTypeParametersMap()));
 
       getAllOverriddenMethodsImpl(original, typeDecl, result);
     }
   }
 
   /**
-   * Helper method to add methods of matching signature to {@code original} from {@code typeDecl} to
-   * {@code result}.
+   * Helper method to find methods of matching signature to {@code original} from {@code typeDecl}.
    *
    * @param typeDecl The type declaration to search for overridden methods in
    * @param original The original method declaration to find overridden methods for
    * @param typeParametersMap The type parameters map
-   * @param result A list to collect all overridden methods found
+   * @return the list of overridden methods
    */
-  private void addOverriddenMethodsToList(
+  private List<MethodDeclaration> getOverriddenMethodsInDeclaration(
       TypeDeclaration<?> typeDecl,
       ResolvedMethodDeclaration original,
-      List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeParametersMap,
-      List<MethodDeclaration> result) {
+      List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeParametersMap) {
+    List<MethodDeclaration> result = new ArrayList<>();
+
     for (MethodDeclaration method : typeDecl.getMethods()) {
-      ResolvedMethodDeclaration resolved = Resolver.resolve(method);
+      ResolvedMethodDeclaration resolved = Resolver.resolveGuaranteeNonNull(method);
 
       String signature = null;
       String signatureOfDeclarationWithTypeParamsAdjusted = null;
-      if (resolved != null) {
-        try {
-          signature = original.getSignature();
-          signatureOfDeclarationWithTypeParamsAdjusted =
-              JavaParserUtil.getSignatureFromResolvedMethodWithTypeVariablesMap(
-                  resolved, typeParametersMap);
-        } catch (UnsolvedSymbolException ex) {
-          // getSignature() and getSignature...Map() both could throw
-        }
+      try {
+        signature = original.getSignature();
+        signatureOfDeclarationWithTypeParamsAdjusted =
+            JavaParserUtil.getSignatureFromResolvedMethodWithTypeVariablesMap(
+                resolved, typeParametersMap);
+      } catch (UnsolvedSymbolException ex) {
+        // getSignature() and getSignature...Map() both could throw
       }
 
-      if (resolved != null
-          && signature != null
-          && signatureOfDeclarationWithTypeParamsAdjusted != null) {
+      if (signature != null && signatureOfDeclarationWithTypeParamsAdjusted != null) {
         if (signature.equals(signatureOfDeclarationWithTypeParamsAdjusted)) {
           result.add(method);
+
+          if (method.isAbstract()) {
+            nonJDKMustImplementMethods.add(resolved);
+          }
         }
       } else {
         // At least one parameter type may not be solvable. In this case, try comparing
         // simple names.
         if (areAstAndResolvedMethodLikelyEqual(original, method)) {
           result.add(method);
+
+          if (method.isAbstract()) {
+            nonJDKMustImplementMethods.add(resolved);
+          }
         }
       }
     }
+
+    return result;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
+++ b/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
@@ -39,6 +39,7 @@ import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclar
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.DefaultConstructorDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserRecordDeclaration;
 import com.github.javaparser.utils.Pair;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -358,7 +359,7 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
   }
 
   @Override
-  public List<Node> getRelevantElements(Object resolved) {
+  public List<Node> getRelevantElements(Object resolved, Node node) {
     List<Node> elements = new ArrayList<>();
 
     if (resolved instanceof ResolvedType resolvedType) {
@@ -367,7 +368,7 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
       }
       if (resolvedType.isReferenceType()
           && resolvedType.asReferenceType().getTypeDeclaration().isPresent()) {
-        return getRelevantElements(resolvedType.asReferenceType().getTypeDeclaration().get());
+        return getRelevantElements(resolvedType.asReferenceType().getTypeDeclaration().get(), node);
       }
     }
 
@@ -402,6 +403,19 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
                                 n -> n.getNameAsString().equals(member.getName()))
                             .get())
                 .toList());
+      }
+
+      // By default, #getRelevantElements(Node) does not include a record's canonical constructor's
+      // parameters. This is because we do not want to preserve record fields that are unused.
+      // However, if we encounter a call to this canonical constructor, then we must preserve all
+      // those fields. We know that the following refers to the canonical constructor because only
+      // the canonical constructor resolved results in a resolved type declaration (others are all
+      // ResolvedConstructorDeclaration).
+
+      // Another case where resolve() yields the canonical constructor is handled in the next if
+      // block.
+      if (type.isRecordDeclaration() && node instanceof ObjectCreationExpr) {
+        elements.addAll(type.asRecordDeclaration().getParameters());
       }
 
       elements.add(type);
@@ -462,11 +476,15 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
       if (!(resolved instanceof DefaultConstructorDeclaration)
           && !isAnonymousClass
           && resolvedMethodLikeDeclaration.toAst().isPresent()) {
-        Node unattached = resolvedMethodLikeDeclaration.toAst().get();
-        CallableDeclaration<?> methodLike =
-            type.findFirst(CallableDeclaration.class, n -> n.equals(unattached)).get();
+        elements.add(
+            JavaParserUtil.findAttachedNode(resolvedMethodLikeDeclaration, fqnToCompilationUnits));
+      }
 
-        elements.add(methodLike);
+      // By default, #getRelevantElements(Node) does not include a record's canonical constructor's
+      // parameters. See reasoning for this in the last big if block; this is another variant of the
+      // same case.
+      if (resolved instanceof JavaParserRecordDeclaration.CanonicalRecordConstructor) {
+        elements.addAll(type.asRecordDeclaration().getParameters());
       }
 
       elements.add(type);
@@ -516,10 +534,10 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
       // Most of the time, this method will return one constructor. However, there may be cases
       // where we include multiple constructors, but this is because we simply don't know which
       // one to use.
-      List<? extends CallableDeclaration<?>> constructors =
+      List<? extends NodeWithParameters<?>> constructors =
           JavaParserUtil.tryResolveNodeWithUnresolvableArguments(
               enumConstant, fqnToCompilationUnits);
-      elements.addAll(constructors);
+      elements.addAll(constructors.stream().map(c -> (Node) c).toList());
     }
 
     return elements;

--- a/src/main/java/org/checkerframework/specimin/TypeRuleDependencyMap.java
+++ b/src/main/java/org/checkerframework/specimin/TypeRuleDependencyMap.java
@@ -22,7 +22,8 @@ public interface TypeRuleDependencyMap {
    * would return the method declaration and its declaring type, both as attached nodes.
    *
    * @param resolved The resolved object
+   * @param node The node that was resolved
    * @return All relevant nodes to the input resolved object.
    */
-  List<Node> getRelevantElements(Object resolved);
+  List<Node> getRelevantElements(Object resolved, Node node);
 }

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -7,7 +7,6 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.TypeDeclaration;
@@ -28,6 +27,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithCondition;
 import com.github.javaparser.ast.nodeTypes.NodeWithExtends;
 import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
 import com.github.javaparser.ast.nodeTypes.NodeWithType;
@@ -1426,7 +1426,7 @@ public class FullyQualifiedNameGenerator {
 
     Node attached = JavaParserUtil.tryFindAttachedNode(resolved, fqnToCompilationUnits);
     if (attached != null) {
-      CallableDeclaration<?> callableDecl = (CallableDeclaration<?>) attached;
+      NodeWithParameters<?> callableDecl = (NodeWithParameters<?>) attached;
 
       for (Parameter param : callableDecl.getParameters()) {
         FullyQualifiedNameSet nonWildcard = getFQNsFromType(param.getType());
@@ -1561,12 +1561,6 @@ public class FullyQualifiedNameGenerator {
     Object resolved = Resolver.resolve((Resolvable<?>) expr);
 
     if (resolved == null) {
-      if (expr instanceof NodeWithArguments<?> withArguments) {
-        resolved =
-            JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
-                withArguments, fqnToCompilationUnits);
-      }
-
       @Nullable FullyQualifiedNameSet findableDeclarationTypeFQNs =
           getFQNsForExpressionInAnonymousClass(expr);
       if (findableDeclarationTypeFQNs != null) {
@@ -1724,7 +1718,13 @@ public class FullyQualifiedNameGenerator {
 
               return Set.of(getFQNsForResolvedType(paramType));
             } catch (UnsolvedSymbolException ex) {
-              // getType() may throw an UnsolvedSymbolException
+              NodeWithParameters<?> withParams =
+                  (NodeWithParameters<?>)
+                      JavaParserUtil.tryFindAttachedNode(resolvedMethodLike, fqnToCompilationUnits);
+
+              if (withParams != null) {
+                return Set.of(getFQNsFromType(withParams.getParameter(param).getType()));
+              }
             }
           }
 
@@ -1776,19 +1776,12 @@ public class FullyQualifiedNameGenerator {
             }
           }
 
-          CallableDeclaration<?> singleCallable =
-              JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
-                  withArguments, fqnToCompilationUnits);
-          if (singleCallable != null) {
-            return Set.of(getFQNsFromType(singleCallable.getParameter(param).getType()));
-          }
-
-          List<? extends CallableDeclaration<?>> allPotentialCallables =
+          List<? extends NodeWithParameters<?>> allPotentialCallables =
               JavaParserUtil.tryResolveNodeWithUnresolvableArguments(
                   withArguments, fqnToCompilationUnits);
           Set<FullyQualifiedNameSet> result = new LinkedHashSet<>();
 
-          for (CallableDeclaration<?> callable : allPotentialCallables) {
+          for (NodeWithParameters<?> callable : allPotentialCallables) {
             result.add(getFQNsFromType(callable.getParameter(param).getType()));
           }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedFieldAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedFieldAlternates.java
@@ -1,6 +1,7 @@
 package org.checkerframework.specimin.unsolved;
 
-import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +49,7 @@ public class UnsolvedFieldAlternates extends UnsolvedSymbolAlternates<UnsolvedFi
    */
   public static UnsolvedFieldAlternates create(
       String name,
-      Map<MemberType, CallableDeclaration<?>> typesToMustPreserveNodes,
+      Map<MemberType, NodeWithParameters<?>> typesToMustPreserveNodes,
       List<UnsolvedClassOrInterfaceAlternates> alternateDeclaringTypes,
       boolean isStatic,
       boolean isFinal) {
@@ -58,10 +59,10 @@ public class UnsolvedFieldAlternates extends UnsolvedSymbolAlternates<UnsolvedFi
 
     UnsolvedFieldAlternates result = new UnsolvedFieldAlternates(alternateDeclaringTypes);
 
-    for (Map.Entry<MemberType, CallableDeclaration<?>> entry :
-        typesToMustPreserveNodes.entrySet()) {
+    for (Map.Entry<MemberType, NodeWithParameters<?>> entry : typesToMustPreserveNodes.entrySet()) {
       UnsolvedField field =
-          new UnsolvedField(name, entry.getKey(), isStatic, isFinal, Set.of(entry.getValue()));
+          new UnsolvedField(
+              name, entry.getKey(), isStatic, isFinal, Set.of((Node) entry.getValue()));
       result.addAlternate(field);
     }
 
@@ -130,7 +131,7 @@ public class UnsolvedFieldAlternates extends UnsolvedSymbolAlternates<UnsolvedFi
    * @param typesToPreserveNodes A map of field types to nodes that must be preserved
    */
   public void updateFieldTypesAndMustPreserveNodes(
-      Map<MemberType, CallableDeclaration<?>> typesToPreserveNodes) {
+      Map<MemberType, NodeWithParameters<?>> typesToPreserveNodes) {
     // Update in-place; intersection = removing all elements in the original set
     // that isn't found in the updated set
     UnsolvedField old = getAlternates().get(0);
@@ -140,14 +141,14 @@ public class UnsolvedFieldAlternates extends UnsolvedSymbolAlternates<UnsolvedFi
     if (getAlternates().isEmpty() && oldFieldTypes.size() == 1) {
       // If it's now empty and old field types was of size 1, it was probably a synthetic field
       // type
-      for (Map.Entry<MemberType, CallableDeclaration<?>> entry : typesToPreserveNodes.entrySet()) {
+      for (Map.Entry<MemberType, NodeWithParameters<?>> entry : typesToPreserveNodes.entrySet()) {
         UnsolvedField field =
             new UnsolvedField(
                 old.getName(),
                 entry.getKey(),
                 old.isStatic(),
                 old.isFinal(),
-                Set.of(entry.getValue()));
+                Set.of((Node) entry.getValue()));
         addAlternate(field);
       }
     }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
@@ -43,6 +43,9 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
   /** The access modifier of the method. */
   private String accessModifier;
 
+  /** The content of the method. */
+  private String content = "throw new java.lang.Error();";
+
   /**
    * Create an instance of UnsolvedMethod.
    *
@@ -267,7 +270,7 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
         || type == UnsolvedClassOrInterfaceType.INTERFACE) {
       return "\n    " + signature + ";\n";
     } else {
-      return "\n    " + signature + " {\n        throw new java.lang.Error();\n    }\n";
+      return "\n    " + signature + " {\n        " + content + "\n    }\n";
     }
   }
 
@@ -361,6 +364,11 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
   @Override
   public void setAccessModifier(String accessModifier) {
     this.accessModifier = accessModifier;
+  }
+
+  @Override
+  public void setContent(String content) {
+    this.content = content;
   }
 
   @Override

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -1,7 +1,7 @@
 package org.checkerframework.specimin.unsolved;
 
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -186,7 +186,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
    */
   public static UnsolvedMethodAlternates createWithPreservation(
       String name,
-      Map<MemberType, CallableDeclaration<?>> returnTypesToMustPreserveNodes,
+      Map<MemberType, NodeWithParameters<?>> returnTypesToMustPreserveNodes,
       List<UnsolvedClassOrInterfaceAlternates> alternateDeclaringTypes,
       List<Map<MemberType, @Nullable Node>> parameters,
       List<MemberType> exceptions) {
@@ -198,7 +198,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
 
     for (List<Map.Entry<MemberType, @Nullable Node>> parameterList :
         JavaParserUtil.generateAllCombinationsForListOfMaps(parameters)) {
-      for (Map.Entry<MemberType, CallableDeclaration<?>> returnType :
+      for (Map.Entry<MemberType, NodeWithParameters<?>> returnType :
           returnTypesToMustPreserveNodes.entrySet()) {
         List<MemberType> params = parameterList.stream().map(Map.Entry::getKey).toList();
         Set<Node> toPreserve = new HashSet<>();
@@ -209,7 +209,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
           }
         }
 
-        Node returnTypePreserve = returnType.getValue();
+        Node returnTypePreserve = (Node) returnType.getValue();
 
         if (returnTypePreserve != null) {
           toPreserve.add(returnTypePreserve);
@@ -231,7 +231,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
    * @param returnsToPreserveNodes A map of return types to nodes that must be preserved
    */
   public void updateReturnTypesAndMustPreserveNodes(
-      Map<MemberType, CallableDeclaration<?>> returnsToPreserveNodes) {
+      Map<MemberType, NodeWithParameters<?>> returnsToPreserveNodes) {
     // Update in-place; intersection = removing all elements in the original set
     // that isn't found in the updated set
     UnsolvedMethod old = getAlternates().get(0);
@@ -245,8 +245,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
         .removeIf(alternate -> !returnsToPreserveNodes.containsKey(alternate.getReturnType()));
 
     if (getAlternates().isEmpty()) {
-      for (Map.Entry<MemberType, CallableDeclaration<?>> entry :
-          returnsToPreserveNodes.entrySet()) {
+      for (Map.Entry<MemberType, NodeWithParameters<?>> entry : returnsToPreserveNodes.entrySet()) {
         for (List<MemberType> parameterList : parameterLists) {
           UnsolvedMethod method =
               new UnsolvedMethod(
@@ -254,7 +253,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
                   entry.getKey(),
                   parameterList,
                   old.getThrownExceptions(),
-                  Set.of(entry.getValue()));
+                  Set.of((Node) entry.getValue()));
           addAlternate(method);
         }
       }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -525,6 +525,11 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
   }
 
   @Override
+  public void setContent(String content) {
+    applyToAllAlternates(UnsolvedMethod::setContent, content);
+  }
+
+  @Override
   public boolean isStatic() {
     return getAlternates().get(0).isStatic();
   }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodCommon.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodCommon.java
@@ -66,4 +66,11 @@ public interface UnsolvedMethodCommon {
    * @param accessModifier The access modifier
    */
   void setAccessModifier(String accessModifier);
+
+  /**
+   * Sets the content of the method (default: {@code throw new java.lang.Error();})
+   *
+   * @param content The content to set to
+   */
+  void setContent(String content);
 }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -4,7 +4,6 @@ import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.EnumConstantDeclaration;
@@ -34,6 +33,7 @@ import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
@@ -631,8 +631,8 @@ public class UnsolvedSymbolGenerator {
       }
     }
 
-    Map<MemberType, CallableDeclaration<?>> typeToMustPreserveNode =
-        getTypeToCallableDeclarationFromArgument(field);
+    Map<MemberType, NodeWithParameters<?>> typeToMustPreserveNode =
+        getTypeToNodeWithParametersFromArgument(field);
 
     UnsolvedSymbolAlternates<?> alreadyGenerated = findExistingAndUpdateFQNs(potentialFQNs);
 
@@ -763,8 +763,8 @@ public class UnsolvedSymbolGenerator {
       }
     }
 
-    Map<MemberType, CallableDeclaration<?>> typeToMustPreserveNode =
-        getTypeToCallableDeclarationFromArgument(nameExpr);
+    Map<MemberType, NodeWithParameters<?>> typeToMustPreserveNode =
+        getTypeToNodeWithParametersFromArgument(nameExpr);
 
     UnsolvedSymbolAlternates<?> generatedField = findExistingAndUpdateFQNs(fieldFQNs);
 
@@ -825,17 +825,6 @@ public class UnsolvedSymbolGenerator {
   private void handleMethodCallExpr(
       MethodCallExpr methodCall, List<UnsolvedSymbolAlternates<?>> result) {
     ResolvedMethodDeclaration resolvedMethodDeclaration = Resolver.resolve(methodCall);
-    if (resolvedMethodDeclaration != null) {
-      if (JavaParserUtil.tryResolveNodeIfInAnonymousClass(methodCall) != null) {
-        return;
-      }
-
-      if (JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
-              methodCall, fqnsToCompilationUnits)
-          != null) {
-        return;
-      }
-    }
 
     if (resolvedMethodDeclaration != null) {
       Node node =
@@ -850,7 +839,7 @@ public class UnsolvedSymbolGenerator {
       return;
     }
 
-    List<? extends CallableDeclaration<?>> definitions =
+    List<? extends NodeWithParameters<?>> definitions =
         JavaParserUtil.tryResolveNodeWithUnresolvableArguments(methodCall, fqnsToCompilationUnits);
 
     if (!definitions.isEmpty()
@@ -863,7 +852,7 @@ public class UnsolvedSymbolGenerator {
       // type is not. In this case, the type of the parameters are unsolved, and should be preserved
       // if the parameter type ever ends up becoming used (which it will, after addInformation is
       // done).
-      for (CallableDeclaration<?> callable : definitions) {
+      for (NodeWithParameters<?> callable : definitions) {
         for (Parameter param : callable.getParameters()) {
           List<UnsolvedSymbolAlternates<?>> generated = inferContext(param.getType());
           // Find the generated param type, if any
@@ -871,7 +860,7 @@ public class UnsolvedSymbolGenerator {
             if (symbol instanceof UnsolvedClassOrInterfaceAlternates type) {
               if (type.getClassName().equals(JavaParserUtil.erase(param.getTypeAsString()))) {
                 for (UnsolvedClassOrInterface alt : type.getAlternates()) {
-                  alt.addMustPreserveNode(callable);
+                  alt.addMustPreserveNode((Node) callable);
                 }
                 break;
               }
@@ -1001,8 +990,8 @@ public class UnsolvedSymbolGenerator {
     UnsolvedSymbolAlternates<?> generated = findExistingAndUpdateFQNs(potentialFQNs);
 
     // TODO: see if this is an issue if two different methods have the same parameter type
-    Map<MemberType, CallableDeclaration<?>> returnTypeToMustPreserveNode =
-        getTypeToCallableDeclarationFromArgument(methodCall);
+    Map<MemberType, NodeWithParameters<?>> returnTypeToMustPreserveNode =
+        getTypeToNodeWithParametersFromArgument(methodCall);
 
     List<Map<MemberType, @Nullable Node>> parametersToMustPreserve =
         generateParameterToMustPreserveMap(
@@ -1578,8 +1567,8 @@ public class UnsolvedSymbolGenerator {
             JavaParserUtil.getMethodDeclarationsFromMethodRef(argument.asMethodReferenceExpr());
 
         for (ResolvedMethodLikeDeclaration method : resolved) {
-          CallableDeclaration<?> ast =
-              (CallableDeclaration<?>)
+          NodeWithParameters<?> ast =
+              (NodeWithParameters<?>)
                   JavaParserUtil.tryFindAttachedNode(method, fqnsToCompilationUnits);
 
           if (ast == null) {
@@ -1596,7 +1585,7 @@ public class UnsolvedSymbolGenerator {
             potentialParameterType = modifiedFQNs.get(potentialParameterType);
           }
 
-          potentialParameterToMustPreserveNode.put(potentialParameterType, ast);
+          potentialParameterToMustPreserveNode.put(potentialParameterType, (Node) ast);
         }
       }
 
@@ -2230,24 +2219,24 @@ public class UnsolvedSymbolGenerator {
 
   /**
    * Given a potential argument expression, this method returns a map of MemberType to
-   * CallableDeclaration. For example, if the argument is a method call expression, foo(), as an
+   * NodeWithParameters. For example, if the argument is a method call expression, foo(), as an
    * argument of another method call, bar(foo()), this method will return a map of potential return
-   * types of foo() (based on the definitions of bar with an arity of 1) to the CallableDeclaration
+   * types of foo() (based on the definitions of bar with an arity of 1) to the NodeWithParameters
    * of bar. This method also works if {@code argument} is a field expression, or if the parent node
    * is a constructor/explicit constructor invocation.
    *
    * @param argument The argument expression to analyze
-   * @return A map of potential return types to their corresponding CallableDeclaration. Returns an
+   * @return A map of potential return types to their corresponding NodeWithParameters. Returns an
    *     empty map if no potential return types are found, or if the argument is not part of a
    *     solvable method/constructor call.
    */
-  private Map<MemberType, CallableDeclaration<?>> getTypeToCallableDeclarationFromArgument(
+  private Map<MemberType, NodeWithParameters<?>> getTypeToNodeWithParametersFromArgument(
       Expression argument) {
     // If this expression is an argument of a solvable method call, we have multiple potential field
     // types to choose from, based on each definition
     Node parent = argument.getParentNode().get();
     int paramNum = -1;
-    Map<MemberType, CallableDeclaration<?>> returnTypeToMustPreserveNode = new LinkedHashMap<>();
+    Map<MemberType, NodeWithParameters<?>> returnTypeToMustPreserveNode = new LinkedHashMap<>();
 
     if (!(parent instanceof NodeWithArguments<?> withArgs)) {
       return returnTypeToMustPreserveNode;
@@ -2266,10 +2255,10 @@ public class UnsolvedSymbolGenerator {
       return returnTypeToMustPreserveNode;
     }
 
-    List<? extends CallableDeclaration<?>> parentCallableDeclarations =
+    List<? extends NodeWithParameters<?>> parentNodeWithParams =
         JavaParserUtil.tryResolveNodeWithUnresolvableArguments(withArgs, fqnsToCompilationUnits);
 
-    for (CallableDeclaration<?> callable : parentCallableDeclarations) {
+    for (NodeWithParameters<?> callable : parentNodeWithParams) {
       Parameter param = callable.getParameter(paramNum);
 
       MemberType memberType =
@@ -2377,7 +2366,7 @@ public class UnsolvedSymbolGenerator {
           }
 
           if (parameterTypes != null && !parameterTypes.isEmpty()) {
-            String superCall = JavaParserUtil.getDefaultSuperConstructorCall(parameterTypes);
+            String superCall = JavaParserUtil.getDefaultConstructorCall(parameterTypes, false);
 
             boolean foundConstructor = false;
 
@@ -2826,8 +2815,8 @@ public class UnsolvedSymbolGenerator {
       }
 
       if (resolved != null) {
-        CallableDeclaration<?> asAst =
-            (CallableDeclaration<?>)
+        NodeWithParameters<?> asAst =
+            (NodeWithParameters<?>)
                 JavaParserUtil.tryFindAttachedNode(resolved, fqnsToCompilationUnits);
 
         for (int i = 0; i < nodeWithArgs.getArguments().size(); i++) {
@@ -2887,7 +2876,7 @@ public class UnsolvedSymbolGenerator {
           handleLHSAndRHSRelationship(Set.of(lhsType), rhsType, getResolvedTypeOfLHS);
         }
       } else {
-        List<? extends CallableDeclaration<?>> withUnresolvableArgs =
+        List<? extends NodeWithParameters<?>> withUnresolvableArgs =
             JavaParserUtil.tryResolveNodeWithUnresolvableArguments(
                 nodeWithArgs, fqnsToCompilationUnits);
 
@@ -3200,24 +3189,8 @@ public class UnsolvedSymbolGenerator {
     MethodDeclaration ast = null;
 
     if (resolvedMethod == null) {
-      ast =
-          (MethodDeclaration)
-              JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
-                  methodCall, fqnsToCompilationUnits);
-
-      if (ast == null) {
-        resolvedMethod =
-            (ResolvedMethodDeclaration)
-                JavaParserUtil.tryFindCorrespondingDeclarationForConstraintQualifiedExpression(
-                    methodCall);
-
-        if (resolvedMethod == null) {
-          potentialScopeFQNs = fullyQualifiedNameGenerator.getFQNsForExpressionLocation(methodCall);
-        }
-      }
-    }
-
-    if (resolvedMethod != null) {
+      potentialScopeFQNs = fullyQualifiedNameGenerator.getFQNsForExpressionLocation(methodCall);
+    } else {
       // Potential scope is all unsolvable ancestors
       ast =
           (MethodDeclaration)

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -66,6 +67,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -2307,11 +2309,12 @@ public class UnsolvedSymbolGenerator {
    * this method AFTER all unsolved symbols are generated.
    *
    * @param node The node to gather more information from
+   * @param slice The slice, for reference.
    * @return An object of type {@link UnsolvedGenerationResult}, usually empty, but the close()
    *     method(s) if first time confirmation of an AutoCloseable, or if the return type is updated
    *     in a method call expression.
    */
-  public UnsolvedGenerationResult addInformation(Node node) {
+  public UnsolvedGenerationResult addInformation(Node node, Set<Node> slice) {
     List<UnsolvedSymbolAlternates<?>> toAdd = new ArrayList<>();
     List<UnsolvedSymbolAlternates<?>> toRemove = new ArrayList<>();
 
@@ -2357,6 +2360,53 @@ public class UnsolvedSymbolGenerator {
           // Sealedness best effort should be final unless we have evidence against it
           syntheticType.addSealedness(Sealedness.FINAL);
           syntheticType.addSealedness(Sealedness.NON_SEALED);
+
+          List<String> parameterTypes = null;
+          for (ConstructorDeclaration constructor : decl.getConstructors()) {
+            if (!slice.contains(constructor)) {
+              continue;
+            }
+
+            if (parameterTypes != null
+                && parameterTypes.size() <= constructor.getParameters().size()) {
+              continue;
+            }
+
+            parameterTypes =
+                constructor.getParameters().stream().map(p -> p.getType().toString()).toList();
+          }
+
+          if (parameterTypes != null && !parameterTypes.isEmpty()) {
+            String superCall = JavaParserUtil.getDefaultSuperConstructorCall(parameterTypes);
+
+            boolean foundConstructor = false;
+
+            for (UnsolvedSymbolAlternates<?> alternate : generatedSymbols.values()) {
+              if (!(alternate instanceof UnsolvedMethodAlternates method)
+                  || !alternate.getAlternateDeclaringTypes().contains(syntheticType)) {
+                continue;
+              }
+
+              if (!Objects.equals(method.getName(), syntheticType.getClassName())) {
+                continue;
+              }
+
+              foundConstructor = true;
+              method.setContent(superCall);
+            }
+
+            if (!foundConstructor) {
+              UnsolvedMethodAlternates constructor =
+                  UnsolvedMethodAlternates.create(
+                      syntheticType.getClassName(),
+                      Set.of(new SolvedMemberType("")),
+                      List.of(syntheticType),
+                      List.of());
+
+              constructor.setContent(superCall);
+              toAdd.add(constructor);
+            }
+          }
         }
       }
     } else if (node instanceof EnumDeclaration decl) {
@@ -3825,8 +3875,8 @@ public class UnsolvedSymbolGenerator {
   }
 
   /**
-   * Once {@link #addInformation(Node)} is done, call this method to make sure all generated symbols
-   * are consistent with their super type relationships.
+   * Once {@link #addInformation} is done, call this method to make sure all generated symbols are
+   * consistent with their super type relationships.
    */
   public void generateAllAlternatesBasedOnSuperTypeRelationships() {
     // This method is called after all unsolved symbols are generated and all information is added
@@ -3957,12 +4007,12 @@ public class UnsolvedSymbolGenerator {
 
   /**
    * Returns whether a node needs to undergo post-processing or not; i.e., if {@link
-   * #addInformation(Node)} needs to be called on it. This is used in the initial worklist when some
+   * #addInformation} needs to be called on it. This is used in the initial worklist when some
    * unsolved symbols may not be generated yet to defer additional information processing to a time
    * when all unsolved symbols are generated.
    *
    * @param node The node to query about
-   * @return Whether {@link #addInformation(Node)} accepts this node
+   * @return Whether {@link #addInformation} accepts this node
    */
   public boolean needToPostProcess(Node node) {
     return node instanceof ClassOrInterfaceDeclaration

--- a/src/test/java/org/checkerframework/specimin/MustImplementMethodAdjacentClassTest.java
+++ b/src/test/java/org/checkerframework/specimin/MustImplementMethodAdjacentClassTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that methods are properly preserved even if it is never called, in these cases:
+ *
+ * <p>Given:
+ *
+ * <ul>
+ *   <li>Class A implements C, and class B implements C.
+ *   <li>C declares foo(), so both A and B must implement foo().
+ *   <li>A uses B, but never calls B.foo(). However, A.foo() is used.
+ *   <li>Therefore, B.foo() must also be preserved because it is required to satisfy the interface
+ *       implementation.
+ * </ul>
+ */
+public class MustImplementMethodAdjacentClassTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "mustimplementmethodsadjacentclass",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#foo()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/PermitsConstructorsTest.java
+++ b/src/test/java/org/checkerframework/specimin/PermitsConstructorsTest.java
@@ -1,0 +1,17 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks if constructor stubs are properly generated for types found in permits clauses.
+ */
+public class PermitsConstructorsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "permitsconstructors",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#foo()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/RecordsTest.java
+++ b/src/test/java/org/checkerframework/specimin/RecordsTest.java
@@ -1,0 +1,13 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/** This test checks if Specimin will work for record types */
+public class RecordsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "records", new String[] {"com/example/Foo.java"}, new String[] {"com.example.Foo#foo()"});
+  }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Bar.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Bar.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Bar implements Baz {
+    public void mustImplement() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Baz.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Baz.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface Baz {
+    void mustImplement();
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Foo.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Foo.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public class Foo implements Baz {
+    public void mustImplement() {
+        throw new java.lang.Error();
+    }
+
+    void foo() {
+        mustImplement();
+        Bar bar = new Bar();
+    }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Bar.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Bar.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public class Bar implements Baz {
+    public void mustImplement() { }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Baz.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Baz.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface Baz {
+    void mustImplement();
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Foo.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Foo.java
@@ -1,0 +1,10 @@
+package com.example;
+
+public class Foo implements Baz {
+    public void mustImplement() { }
+
+    void foo() {
+        mustImplement();
+        Bar bar = new Bar();
+    }
+}

--- a/src/test/resources/permitsconstructors/expected/com/example/Foo.java
+++ b/src/test/resources/permitsconstructors/expected/com/example/Foo.java
@@ -1,0 +1,25 @@
+package com.example;
+
+public sealed class Foo permits Bar, Baz, Unsolved {
+    public Foo(int a, String b, Object c, char d, boolean e, Unsolved f) {
+        throw new java.lang.Error();
+    }
+
+    void foo() {
+        Foo foo = new Foo(100, "", null, 'a', true, null);
+
+        Bar bar = new Bar(0);
+    }
+}
+
+final class Bar extends Foo {
+    public Bar(int x) {
+        super(0, null, null, '\u0000', false, null);
+    }
+}
+
+final class Baz extends Foo {
+    public Baz() {
+        super(0, null, null, '\u0000', false, null);
+    }
+}

--- a/src/test/resources/permitsconstructors/expected/com/example/Unsolved.java
+++ b/src/test/resources/permitsconstructors/expected/com/example/Unsolved.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public final class Unsolved extends com.example.Foo {
+    public Unsolved() {
+        super(0, null, null, '\u0000', false, null);
+    }
+}

--- a/src/test/resources/permitsconstructors/input/com/example/Foo.java
+++ b/src/test/resources/permitsconstructors/input/com/example/Foo.java
@@ -1,0 +1,30 @@
+package com.example;
+
+public sealed class Foo permits Bar, Baz, Unsolved {
+    public Foo() { }
+
+    public Foo(int a, String b, Object c, char d, boolean e, Unsolved f) { }
+
+    void foo() {
+        Foo foo = new Foo(100, "", null, 'a', true, null);
+
+        Bar bar = new Bar(0);
+    }
+}
+
+final class Bar extends Foo {
+    public Bar() {
+        super();
+    }
+
+    public Bar(int x) {
+        // This should become super(0, null, ...) because Foo's parameterless constructor will be removed
+        super();
+
+        // Should be removed...
+        System.out.println();
+        int x = 0;
+    }
+}
+
+final class Baz extends Foo { }

--- a/src/test/resources/records/expected/com/example/Foo.java
+++ b/src/test/resources/records/expected/com/example/Foo.java
@@ -1,0 +1,14 @@
+package com.example;
+
+public class Foo {
+    void foo() {
+        MyRecord record1 = new MyRecord();
+
+        record1.str();
+        record1.foo();
+        record1.x();
+
+        MyRecord record2 = new MyRecord("", this);
+        MyOtherRecord other = new MyOtherRecord("");
+    }
+}

--- a/src/test/resources/records/expected/com/example/MyOtherRecord.java
+++ b/src/test/resources/records/expected/com/example/MyOtherRecord.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public record MyOtherRecord(String str) {
+}

--- a/src/test/resources/records/expected/com/example/MyRecord.java
+++ b/src/test/resources/records/expected/com/example/MyRecord.java
@@ -1,0 +1,11 @@
+package com.example;
+
+public record MyRecord(String str, Foo foo, int x) {
+    public MyRecord(String str, Foo foo) {
+        this(null, null, 0);
+    }
+
+    public MyRecord() {
+        this(null, null, 0);
+    }
+}

--- a/src/test/resources/records/input/com/example/Foo.java
+++ b/src/test/resources/records/input/com/example/Foo.java
@@ -1,0 +1,14 @@
+package com.example;
+
+public class Foo {
+    void foo() {
+        MyRecord record1 = new MyRecord();
+
+        record1.str();
+        record1.foo();
+        record1.x();
+
+        MyRecord record2 = new MyRecord("", this);
+        MyOtherRecord other = new MyOtherRecord("");
+    }
+}

--- a/src/test/resources/records/input/com/example/MyOtherRecord.java
+++ b/src/test/resources/records/input/com/example/MyOtherRecord.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public record MyOtherRecord(String str) {
+}

--- a/src/test/resources/records/input/com/example/MyRecord.java
+++ b/src/test/resources/records/input/com/example/MyRecord.java
@@ -1,0 +1,11 @@
+package com.example;
+
+public record MyRecord(String str, Foo foo, int x, boolean unusedVariableToRemove) {
+    public MyRecord(String str, Foo foo) {
+        this(str, foo, 0, false);
+    }
+
+    public MyRecord() {
+        this("", null);
+    }
+}


### PR DESCRIPTION
This PR makes four changes:
* Static wildcard imports are not removed if they import from a used class
* Constructors are preserved/created with a minimal `super` call when its superclass does not have a parameterless constructor
* Support for record classes (behavior: only used members are preserved, and non-canonical constructors are trimmed down to a minimal `this` call to the canonical constructor)
* Method preservation for "adjacent" classes, where a used type implementing an interface with a known method that must be preserved also has to preserve that method, even if that method is never actually called by that specific used type, but is called by another used type that implements the same interface (see MustImplementMethodsAdjacentClassTest for an example)