### PR TITLE
Record classes

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
 import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
+import com.github.javaparser.ast.nodeTypes.NodeWithType;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -466,7 +467,7 @@ public class JavaParserUtil {
       return getTypeFromResolvedValueDeclaration(valueDecl, fqnToCompilationUnits);
     } else if (resolved instanceof ResolvedMethodDeclaration resolvedMethodDecl) {
       if (resolvedMethodDecl.toAst().isPresent()) {
-        MethodDeclaration methodDecl = (MethodDeclaration) resolvedMethodDecl.toAst().get();
+        NodeWithType<?, ?> methodDecl = (NodeWithType<?, ?>) resolvedMethodDecl.toAst().get();
         return methodDecl.getType();
       }
     }

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithExtends;
 import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -1201,10 +1202,10 @@ public class JavaParserUtil {
    * @param withArgs The node representing a method call, constructor call, or enum constant
    *     declaration with arguments
    * @param fqnsToCompilationUnits The map of fully qualified names to their compilation units
-   * @return A list of matching {@link CallableDeclaration} instances, or an empty list if none are
+   * @return A list of matching {@link NodeWithParameters} instances, or an empty list if none are
    *     found
    */
-  public static List<? extends CallableDeclaration<?>> tryResolveNodeWithUnresolvableArguments(
+  public static List<? extends NodeWithParameters<?>> tryResolveNodeWithUnresolvableArguments(
       NodeWithArguments<?> withArgs, Map<String, CompilationUnit> fqnsToCompilationUnits) {
     if (withArgs instanceof MethodCallExpr parentMethodCall) {
       return tryResolveMethodCallWithUnresolvableArguments(
@@ -1233,10 +1234,10 @@ public class JavaParserUtil {
    * @param fqnsToCompilationUnits The map of fully qualified names to their compilation units
    * @return A resolvable callable if it can be found, null otherwise
    */
-  public static @Nullable CallableDeclaration<?>
+  public static @Nullable NodeWithParameters<?>
       tryFindSingleCallableForNodeWithUnresolvableArguments(
           NodeWithArguments<?> node, Map<String, CompilationUnit> fqnsToCompilationUnits) {
-    List<? extends CallableDeclaration<?>> callables =
+    List<? extends NodeWithParameters<?>> callables =
         tryResolveNodeWithUnresolvableArguments(node, fqnsToCompilationUnits);
     if (callables.isEmpty()) {
       return null;
@@ -1258,12 +1259,12 @@ public class JavaParserUtil {
 
     // If there is only one callable where the rest of the parameters match and a few others that
     // are null, return this maybe best match
-    CallableDeclaration<?> maybeBestMatch = null;
+    NodeWithParameters<?> maybeBestMatch = null;
     // If there are multiple callables, find the best match, i.e., FQNs = FQNs and simple names =
     // simple names
     // If there is one that matches exactly, return it; others that match it directly are simply
     // overrides
-    for (CallableDeclaration<?> callable : callables) {
+    for (NodeWithParameters<?> callable : callables) {
       boolean isAMatch = true;
       int nulls = 0;
       for (int i = 0; i < callable.getParameters().size(); i++) {
@@ -1310,13 +1311,15 @@ public class JavaParserUtil {
   /**
    * Given a constructor call, returns all possible constructors that match the arity and known
    * types of the arguments. This returns an empty list if no matching constructors were found or if
-   * the declaring type could not be solved.
+   * the declaring type could not be solved. Most list elements will be of type
+   * ConstructorDeclaration, but may be a RecordDeclaration if the constructor call is a potential
+   * match for a record's canonical constructor.
    *
    * @param constructorCall The constructor call expression
    * @param fqnToCompilationUnits The map of type FQNs to their compilation units
    * @return All possible constructor declarations
    */
-  private static List<ConstructorDeclaration> tryResolveConstructorCallWithUnresolvableArguments(
+  private static List<NodeWithParameters<?>> tryResolveConstructorCallWithUnresolvableArguments(
       ObjectCreationExpr constructorCall, Map<String, CompilationUnit> fqnToCompilationUnits) {
     List<@Nullable ResolvedType> parameterTypes =
         getArgumentTypesAsResolved(constructorCall.getArguments());
@@ -1335,10 +1338,19 @@ public class JavaParserUtil {
       return List.of();
     }
 
-    List<ConstructorDeclaration> candidates = new ArrayList<>();
+    List<NodeWithParameters<?>> candidates = new ArrayList<>();
+    if (enclosingClass.isRecordDeclaration()) {
+      if (isNodeWithParametersACandidate(enclosingClass.asRecordDeclaration(), parameterTypes)) {
+        candidates.add(enclosingClass.asRecordDeclaration());
+      }
+    }
+
+    List<ConstructorDeclaration> constructors = new ArrayList<>();
 
     addAllMatchingCallablesToList(
-        enclosingClass, parameterTypes, candidates, null, ConstructorDeclaration.class);
+        enclosingClass, parameterTypes, constructors, null, ConstructorDeclaration.class);
+
+    candidates.addAll(constructors);
 
     return candidates;
   }
@@ -1495,15 +1507,19 @@ public class JavaParserUtil {
     }
 
     if (enclosingAnonymousClass != null) {
-      addAllMatchingCallablesToListImpl(
+      for (MethodDeclaration method :
           enclosingAnonymousClass.getAnonymousClassBody().get().stream()
-              .filter(BodyDeclaration::isCallableDeclaration)
-              .map(c -> (CallableDeclaration<?>) c)
-              .toList(),
-          parameterTypes,
-          candidates,
-          methodCall.getNameAsString(),
-          MethodDeclaration.class);
+              .filter(BodyDeclaration::isMethodDeclaration)
+              .map(BodyDeclaration::asMethodDeclaration)
+              .toList()) {
+        if (!method.getNameAsString().equals(methodCall.getNameAsString())) {
+          continue;
+        }
+
+        if (isNodeWithParametersACandidate(method, parameterTypes)) {
+          candidates.add(method);
+        }
+      }
     }
 
     return candidates;
@@ -1641,95 +1657,86 @@ public class JavaParserUtil {
       List<T> result,
       @Nullable String methodName,
       Class<T> callableType) {
-    List<? extends CallableDeclaration<?>> callables;
+    List<? extends NodeWithParameters<?>> callables;
     if (callableType == ConstructorDeclaration.class) {
       callables = typeDecl.getConstructors();
     } else if (callableType == MethodDeclaration.class) {
-      callables = typeDecl.getMethods();
+      callables =
+          typeDecl.getMethods().stream()
+              .filter(m -> m.getNameAsString().equals(methodName))
+              .collect(Collectors.toList());
     } else {
       // Impossible: see
       // https://www.javadoc.io/doc/com.github.javaparser/javaparser-core/latest/com/github/javaparser/ast/body/CallableDeclaration.html
       throw new IllegalArgumentException("Impossible CallableDeclaration type.");
     }
 
-    addAllMatchingCallablesToListImpl(callables, parameterTypes, result, methodName, callableType);
+    for (NodeWithParameters<?> nodeWithParameters : callables) {
+      if (isNodeWithParametersACandidate(nodeWithParameters, parameterTypes)) {
+        result.add(callableType.cast(nodeWithParameters));
+      }
+    }
   }
 
   /**
-   * Actual logic for {@link #addAllMatchingCallablesToList}.
+   * Helper function for {@link #addAllMatchingCallablesToList(TypeDeclaration, List, List, String,
+   * Class)}. Determines whether a given NodeWithParameters is a potential candidate for a given set
+   * of parameter types. That list of parameter types should either contain ResolvedTypes or nulls,
+   * depending on whether that type was originally resolvable or not.
    *
-   * @param callables The list of callables to check against
-   * @param parameterTypes The resolved parameter types. Fully qualified names if resolvable, simple
-   *     names if not, and null if no type could be found at all.
-   * @param result The list to append to
-   * @param methodName The method name, if the callable is a method (it is ignored otherwise)
-   * @param callableType The type of callable (i.e., ConstructorDeclaration or MethodDeclaration)
+   * @param candidate The potential candidate to check
+   * @param requiredParamTypes The required parameter types
+   * @return True if it is a candidate, false otherwise
    */
-  private static <T extends CallableDeclaration<?>> void addAllMatchingCallablesToListImpl(
-      List<? extends CallableDeclaration<?>> callables,
-      List<@Nullable ResolvedType> parameterTypes,
-      List<T> result,
-      @Nullable String methodName,
-      Class<T> callableType) {
-    for (CallableDeclaration<?> callable : callables) {
-      if (callable.getParameters().size() != parameterTypes.size()) {
-        continue;
-      }
-      if (callableType == MethodDeclaration.class
-          && !callable.getNameAsString().equals(methodName)) {
-        continue;
-      }
+  private static boolean isNodeWithParametersACandidate(
+      NodeWithParameters<?> candidate, List<@Nullable ResolvedType> requiredParamTypes) {
+    if (candidate.getParameters().size() != requiredParamTypes.size()) {
+      return false;
+    }
 
-      boolean isAMatch = true;
+    for (int i = 0; i < candidate.getParameters().size(); i++) {
+      ResolvedType typeInCall = requiredParamTypes.get(i);
 
-      for (int i = 0; i < callable.getParameters().size(); i++) {
-        ResolvedType typeInCall = parameterTypes.get(i);
+      ResolvedParameterDeclaration resolvedParam = Resolver.resolve(candidate.getParameter(i));
+      boolean isParamTypeUnsolved = resolvedParam == null;
 
-        ResolvedParameterDeclaration resolvedParam = Resolver.resolve(callable.getParameter(i));
-        boolean isParamTypeUnsolved = resolvedParam == null;
+      if (resolvedParam != null) {
+        ResolvedType resolvedParameterType = null;
+        try {
+          resolvedParameterType = resolvedParam.getType();
+        } catch (UnsolvedSymbolException ex) {
+          isParamTypeUnsolved = true;
+          // getType() may throw an UnsolvedSymbolException
+        }
 
-        if (resolvedParam != null) {
-          ResolvedType resolvedParameterType = null;
-          try {
-            resolvedParameterType = resolvedParam.getType();
-          } catch (UnsolvedSymbolException ex) {
-            isParamTypeUnsolved = true;
-            // getType() may throw an UnsolvedSymbolException
-          }
+        if (typeInCall == null || isParamTypeUnsolved || resolvedParameterType == null) {
+          continue;
+        }
 
-          if (typeInCall == null || isParamTypeUnsolved || resolvedParameterType == null) {
+        if (!resolvedParameterType.isAssignableBy(typeInCall)) {
+          // If either is a type variable and the other is a reference type, it is likely valid
+          // Note that isAssignableBy will return false in those cases
+          if (typeInCall.isTypeVariable() && resolvedParameterType.isReference()) {
             continue;
           }
-
-          if (!resolvedParameterType.isAssignableBy(typeInCall)) {
-            // If either is a type variable and the other is a reference type, it is likely valid
-            // Note that isAssignableBy will return false in those cases
-            if (typeInCall.isTypeVariable() && resolvedParameterType.isReference()) {
-              continue;
-            }
-            if (resolvedParameterType.isTypeVariable() && typeInCall.isReference()) {
-              continue;
-            }
-            // JavaParser can't handle constraint types well. This isn't perfect (i.e., doesn't
-            // properly match bounds), but it should work for most cases.
-            if (typeInCall.isConstraint() && resolvedParameterType.isReference()) {
-              continue;
-            }
-            isAMatch = false;
-            break;
+          if (resolvedParameterType.isTypeVariable() && typeInCall.isReference()) {
+            continue;
           }
-        }
-
-        if (isParamTypeUnsolved && typeInCall != null) {
-          isAMatch = false;
-          break;
+          // JavaParser can't handle constraint types well. This isn't perfect (i.e., doesn't
+          // properly match bounds), but it should work for most cases.
+          if (typeInCall.isConstraint() && resolvedParameterType.isReference()) {
+            continue;
+          }
+          return false;
         }
       }
 
-      if (isAMatch) {
-        result.add(callableType.cast(callable));
+      if (isParamTypeUnsolved && typeInCall != null) {
+        return false;
       }
     }
+
+    return true;
   }
 
   /**
@@ -2017,16 +2024,18 @@ public class JavaParserUtil {
   }
 
   /**
-   * Given a list of parameter types, return a super(...) call with the default values of those
+   * Given a list of parameter types, return a super/this(...) call with the default values of those
    * types.
    *
-   * @param paramTypes The parameter types
-   * @return The super(...) call; i.e., super(0, null);
+   * @param paramTypes The parameter types*
+   * @param isThis If true, then {@code this}; else, {@code super}
+   * @return The super/this(...) call; i.e., super(0, null); or this(0, null);
    */
-  public static String getDefaultSuperConstructorCall(List<String> paramTypes) {
+  public static String getDefaultConstructorCall(List<String> paramTypes, boolean isThis) {
     StringBuilder sb = new StringBuilder();
 
-    sb.append("super(");
+    sb.append(isThis ? "this" : "super");
+    sb.append("(");
 
     for (String paramType : paramTypes) {
       sb.append(getInitializerRHS(paramType));

--- a/src/main/java/org/checkerframework/specimin/Resolver.java
+++ b/src/main/java/org/checkerframework/specimin/Resolver.java
@@ -1,20 +1,29 @@
 package org.checkerframework.specimin;
 
+import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.resolution.MethodAmbiguityException;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -196,11 +205,19 @@ public class Resolver {
       if (result != null) {
         return result;
       }
+
+      if (expr.isMethodCallExpr()) {
+        result = handleUnresolvableRecordMember(expr.asMethodCallExpr());
+
+        if (result != null) {
+          return result;
+        }
+      }
     }
 
     // Handle cases where a method/constructor call cannot be resolved because of unresolvable
     // arguments, but its definition exists
-    CallableDeclaration<?> potentiallyResolvableCallable =
+    NodeWithParameters<?> potentiallyResolvableCallable =
         unsolvable instanceof NodeWithArguments<?> withArgs
             ? JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
                 withArgs, fqnToCompilationUnits)
@@ -249,17 +266,83 @@ public class Resolver {
           "fqnToCompilationUnits must be set before calling handleMethodAmbiguityException");
     }
     if (!ex.toString().contains("ReflectionMethodDeclaration")) {
-      if (node instanceof MethodCallExpr methodCallExpr) {
-        CallableDeclaration<?> potentialMethod =
-            JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
-                methodCallExpr, fqnToCompilationUnits);
-
-        if (potentialMethod != null) {
-          return potentialMethod.asMethodDeclaration().resolve();
-        }
+      if (node instanceof MethodCallExpr methodCallExpr
+          && JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
+                  methodCallExpr, fqnToCompilationUnits)
+              instanceof MethodDeclaration methodDecl) {
+        return methodDecl.resolve();
       }
 
       throw ex;
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolves record members because JavaParser can't.
+   *
+   * @param methodCallExpr The method call expression
+   * @return The parameter representing the record member, or null if not found
+   */
+  private static @Nullable ResolvedMethodDeclaration handleUnresolvableRecordMember(
+      MethodCallExpr methodCallExpr) {
+    if (fqnToCompilationUnits == null) {
+      throw new UnsupportedOperationException(
+          "fqnToCompilationUnits must be set before calling handleUnsupportedOperationException");
+    }
+
+    if (methodCallExpr.getArguments().isNonEmpty()) {
+      return null;
+    }
+
+    // JavaParser bug: cannot resolve MethodCallExpr if it represents a record member
+
+    // We have to use our own implementation, ResolvedRecordMemberDeclaration, since JavaParser
+    // throws an IllegalStateException anytime we try to resolve the original parameter.
+    if (methodCallExpr.getArguments().isEmpty()) {
+      if (methodCallExpr.hasScope()) {
+        ResolvedType scopeType = calculateResolvedType(methodCallExpr.getScope().get());
+
+        if (scopeType == null
+            || !scopeType.isReferenceType()
+            || scopeType.asReferenceType().getTypeDeclaration().isEmpty()
+            || !scopeType.asReferenceType().getTypeDeclaration().get().isRecord()) {
+          return null;
+        }
+
+        TypeDeclaration<?> typeDecl =
+            JavaParserUtil.getTypeFromQualifiedName(scopeType.describe(), fqnToCompilationUnits);
+
+        if (typeDecl != null) {
+          for (Parameter param : typeDecl.asRecordDeclaration().getParameters()) {
+            if (param.getNameAsString().equals(methodCallExpr.getNameAsString())) {
+              return new ResolvedRecordMemberDeclaration(param);
+            }
+          }
+        }
+      } else {
+        TypeDeclaration<?> encapsulating =
+            JavaParserUtil.getEnclosingClassLikeOptional(methodCallExpr);
+
+        while (encapsulating != null) {
+          if (encapsulating.isRecordDeclaration()) {
+            for (Parameter param : encapsulating.asRecordDeclaration().getParameters()) {
+              if (param.getNameAsString().equals(methodCallExpr.getNameAsString())) {
+                return new ResolvedRecordMemberDeclaration(param);
+              }
+            }
+          }
+
+          if (encapsulating.getParentNode().isEmpty()) {
+            return null;
+          }
+
+          // Check all outer classes
+          encapsulating =
+              JavaParserUtil.getEnclosingClassLikeOptional(encapsulating.getParentNode().get());
+        }
+      }
     }
 
     return null;
@@ -311,5 +394,86 @@ public class Resolver {
       }
     }
     throw ex;
+  }
+
+  /**
+   * Custom class to hold a record member declaration, since JavaParser cannot handle this case.
+   *
+   * @param parameter The wrapped parameter.
+   */
+  private record ResolvedRecordMemberDeclaration(Parameter parameter)
+      implements ResolvedMethodDeclaration {
+    @Override
+    public ResolvedType getReturnType() {
+      return Resolver.resolveGuaranteeNonNull(parameter.getType());
+    }
+
+    @Override
+    public boolean isAbstract() {
+      return false;
+    }
+
+    @Override
+    public boolean isDefaultMethod() {
+      return false;
+    }
+
+    @Override
+    public boolean isStatic() {
+      return false;
+    }
+
+    @Override
+    public String toDescriptor() {
+      return "";
+    }
+
+    @Override
+    public ResolvedReferenceTypeDeclaration declaringType() {
+      return (ResolvedReferenceTypeDeclaration)
+          resolveGuaranteeNonNull((Resolvable<?>) JavaParserUtil.getEnclosingClassLike(parameter));
+    }
+
+    @Override
+    public int getNumberOfParams() {
+      return 0;
+    }
+
+    @Override
+    public ResolvedParameterDeclaration getParam(int i) {
+      throw new IndexOutOfBoundsException(
+          "There are no parameters in a record member declaration.");
+    }
+
+    @Override
+    public int getNumberOfSpecifiedExceptions() {
+      return 0;
+    }
+
+    @Override
+    public ResolvedType getSpecifiedException(int index) {
+      throw new IndexOutOfBoundsException(
+          "There are no exceptions in a record member declaration.");
+    }
+
+    @Override
+    public AccessSpecifier accessSpecifier() {
+      return AccessSpecifier.PUBLIC;
+    }
+
+    @Override
+    public String getName() {
+      return parameter.getNameAsString();
+    }
+
+    @Override
+    public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
+      return List.of();
+    }
+
+    @Override
+    public Optional<Node> toAst() {
+      return Optional.of(parameter);
+    }
   }
 }

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -427,7 +427,7 @@ public class Slicer {
                   constructorNode.getParameters().stream()
                       .map(p -> p.getType().toString())
                       .toList();
-            } else {
+            } else if (attached != null) {
               parameterTypes =
                   constructor.formalParameterTypes().stream().map(ResolvedType::describe).toList();
             }

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -10,6 +10,10 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.RecordDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AssignExpr;
@@ -285,7 +289,7 @@ public class Slicer {
       throw new RuntimeException("Unexpected null value in resolve() call");
     }
 
-    List<Node> toAddToWorklist = typeRuleDependencyMap.getRelevantElements(resolved);
+    List<Node> toAddToWorklist = typeRuleDependencyMap.getRelevantElements(resolved, unresolved);
     worklist.addAll(toAddToWorklist);
 
     // Since resolved declarations may reference another file, we need to add that compilation
@@ -376,6 +380,20 @@ public class Slicer {
         if (!isSet) {
           fieldDeclarator.setInitializer(
               JavaParserUtil.getInitializerRHS(fieldDeclarator.getType().toString()));
+        }
+      } else if (node instanceof RecordDeclaration recordDecl) {
+        String thisInvocationStmt =
+                JavaParserUtil.getDefaultConstructorCall(
+                        recordDecl.getParameters().stream().map(Parameter::getTypeAsString).toList(), true);
+
+        for (ConstructorDeclaration decl : recordDecl.getConstructors()) {
+          if (!slice.contains(decl)) {
+            continue;
+          }
+
+          // Record non-canonical constructors must call the canonical
+          decl.setBody(
+                  new BlockStmt(new NodeList<>(StaticJavaParser.parseStatement(thisInvocationStmt))));
         }
       }
 

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -8,7 +8,6 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
-import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
@@ -438,7 +437,7 @@ public class Slicer {
             return;
           }
 
-          String superCall = JavaParserUtil.getDefaultSuperConstructorCall(parameterTypes);
+          String superCall = JavaParserUtil.getDefaultConstructorCall(parameterTypes, false);
 
           boolean foundConstructor = false;
           for (ConstructorDeclaration constructorDeclaration :

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -8,10 +8,9 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.Parameter;
-import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
@@ -383,8 +382,8 @@ public class Slicer {
         }
       } else if (node instanceof RecordDeclaration recordDecl) {
         String thisInvocationStmt =
-                JavaParserUtil.getDefaultConstructorCall(
-                        recordDecl.getParameters().stream().map(Parameter::getTypeAsString).toList(), true);
+            JavaParserUtil.getDefaultConstructorCall(
+                recordDecl.getParameters().stream().map(Parameter::getTypeAsString).toList(), true);
 
         for (ConstructorDeclaration decl : recordDecl.getConstructors()) {
           if (!slice.contains(decl)) {
@@ -393,7 +392,7 @@ public class Slicer {
 
           // Record non-canonical constructors must call the canonical
           decl.setBody(
-                  new BlockStmt(new NodeList<>(StaticJavaParser.parseStatement(thisInvocationStmt))));
+              new BlockStmt(new NodeList<>(StaticJavaParser.parseStatement(thisInvocationStmt))));
         }
       }
 

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -457,6 +457,13 @@ public class SpeciminRunner {
     }
   }
 
+  /**
+   * Gets the packages and classes used in the given slice and unsolved symbol enumeration.
+   *
+   * @param sliceResult The slice
+   * @param enumeratorResult The unsolved enumeration
+   * @return The used packages and classes
+   */
   private static Set<String> getUsedPackagesAndClasses(
       SliceResult sliceResult, UnsolvedSymbolEnumeratorResult enumeratorResult) {
     Set<String> usedPackagesAndClasses = new HashSet<>();

--- a/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
+++ b/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
@@ -74,6 +74,12 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
   private final Set<ResolvedMethodDeclaration> nonJDKMustImplementMethods = new HashSet<>();
 
   /**
+   * A set of seen type declarations so we can rediscover must implement methods if we already
+   * processed a declaration but later discover a must implement method.
+   */
+  private final Set<TypeDeclaration<?>> seenTypeDeclarations = new HashSet<>();
+
+  /**
    * Creates a new StandardTypeRuleDependencyMap to be passed into Slicer.
    *
    * @param fqnToCompilationUnits The map of type FQNs to their compilation units.
@@ -135,16 +141,9 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
     }
 
     // Type declarations
-    if (node instanceof NodeWithImplements<?> withImplements) {
-      elements.addAll(withImplements.getImplementedTypes());
-    }
-    if (node instanceof NodeWithExtends<?> withExtends) {
-      elements.addAll(withExtends.getExtendedTypes());
-    }
-    if (node instanceof ClassOrInterfaceDeclaration decl) {
-      elements.addAll(decl.getPermittedTypes());
-    }
     if (node instanceof TypeDeclaration<?> typeDeclaration) {
+      seenTypeDeclarations.add(typeDeclaration);
+
       List<MethodDeclaration> mustImplement =
           JavaParserUtil.getDeclarationsForAllMustImplementMethods(
               typeDeclaration, nonJDKMustImplementMethods, fqnToCompilationUnits);
@@ -178,6 +177,15 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
           // Methods like getAllAncestors() can throw an UnsolvedSymbolException
         }
       }
+    }
+    if (node instanceof NodeWithImplements<?> withImplements) {
+      elements.addAll(withImplements.getImplementedTypes());
+    }
+    if (node instanceof NodeWithExtends<?> withExtends) {
+      elements.addAll(withExtends.getExtendedTypes());
+    }
+    if (node instanceof ClassOrInterfaceDeclaration decl) {
+      elements.addAll(decl.getPermittedTypes());
     }
 
     // If the node is a type declaration, exit now, so we don't unintentionally
@@ -446,15 +454,21 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
       }
 
       if (resolved instanceof ResolvedMethodDeclaration resolvedMethodDeclaration) {
+        int before = nonJDKMustImplementMethods.size();
+
         if (isAnonymousClass && typeParametersMapForAnonClass != null) {
           // The current type is already a parent class, so we need to add those too
-          List<MethodDeclaration> methods = new ArrayList<>();
-          addOverriddenMethodsToList(
-              type, resolvedMethodDeclaration, typeParametersMapForAnonClass, methods);
-          elements.addAll(methods);
+          elements.addAll(
+              getOverriddenMethodsInDeclaration(
+                  type, resolvedMethodDeclaration, typeParametersMapForAnonClass));
         }
 
         elements.addAll(getAllOverriddenMethods(resolvedMethodDeclaration, type));
+
+        if (nonJDKMustImplementMethods.size() > before) {
+          elements.addAll(
+              seenTypeDeclarations.stream().flatMap(d -> getRelevantElements(d).stream()).toList());
+        }
       }
 
       // Case: new Foo() but Foo does not contain a constructor
@@ -577,57 +591,64 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
         continue;
       }
 
-      addOverriddenMethodsToList(
-          typeDecl, original, parentType.asReferenceType().getTypeParametersMap(), result);
+      result.addAll(
+          getOverriddenMethodsInDeclaration(
+              typeDecl, original, parentType.asReferenceType().getTypeParametersMap()));
 
       getAllOverriddenMethodsImpl(original, typeDecl, result);
     }
   }
 
   /**
-   * Helper method to add methods of matching signature to {@code original} from {@code typeDecl} to
-   * {@code result}.
+   * Helper method to find methods of matching signature to {@code original} from {@code typeDecl}.
    *
    * @param typeDecl The type declaration to search for overridden methods in
    * @param original The original method declaration to find overridden methods for
    * @param typeParametersMap The type parameters map
-   * @param result A list to collect all overridden methods found
+   * @return the list of overridden methods
    */
-  private void addOverriddenMethodsToList(
+  private List<MethodDeclaration> getOverriddenMethodsInDeclaration(
       TypeDeclaration<?> typeDecl,
       ResolvedMethodDeclaration original,
-      List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeParametersMap,
-      List<MethodDeclaration> result) {
+      List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeParametersMap) {
+    List<MethodDeclaration> result = new ArrayList<>();
+
     for (MethodDeclaration method : typeDecl.getMethods()) {
-      ResolvedMethodDeclaration resolved = Resolver.resolve(method);
+      ResolvedMethodDeclaration resolved = Resolver.resolveGuaranteeNonNull(method);
 
       String signature = null;
       String signatureOfDeclarationWithTypeParamsAdjusted = null;
-      if (resolved != null) {
-        try {
-          signature = original.getSignature();
-          signatureOfDeclarationWithTypeParamsAdjusted =
-              JavaParserUtil.getSignatureFromResolvedMethodWithTypeVariablesMap(
-                  resolved, typeParametersMap);
-        } catch (UnsolvedSymbolException ex) {
-          // getSignature() and getSignature...Map() both could throw
-        }
+      try {
+        signature = original.getSignature();
+        signatureOfDeclarationWithTypeParamsAdjusted =
+            JavaParserUtil.getSignatureFromResolvedMethodWithTypeVariablesMap(
+                resolved, typeParametersMap);
+      } catch (UnsolvedSymbolException ex) {
+        // getSignature() and getSignature...Map() both could throw
       }
 
-      if (resolved != null
-          && signature != null
-          && signatureOfDeclarationWithTypeParamsAdjusted != null) {
+      if (signature != null && signatureOfDeclarationWithTypeParamsAdjusted != null) {
         if (signature.equals(signatureOfDeclarationWithTypeParamsAdjusted)) {
           result.add(method);
+
+          if (method.isAbstract()) {
+            nonJDKMustImplementMethods.add(resolved);
+          }
         }
       } else {
         // At least one parameter type may not be solvable. In this case, try comparing
         // simple names.
         if (areAstAndResolvedMethodLikelyEqual(original, method)) {
           result.add(method);
+
+          if (method.isAbstract()) {
+            nonJDKMustImplementMethods.add(resolved);
+          }
         }
       }
     }
+
+    return result;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
+++ b/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
@@ -39,6 +39,7 @@ import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclar
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.DefaultConstructorDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserRecordDeclaration;
 import com.github.javaparser.utils.Pair;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -350,7 +351,7 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
   }
 
   @Override
-  public List<Node> getRelevantElements(Object resolved) {
+  public List<Node> getRelevantElements(Object resolved, Node node) {
     List<Node> elements = new ArrayList<>();
 
     if (resolved instanceof ResolvedType resolvedType) {
@@ -359,7 +360,7 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
       }
       if (resolvedType.isReferenceType()
           && resolvedType.asReferenceType().getTypeDeclaration().isPresent()) {
-        return getRelevantElements(resolvedType.asReferenceType().getTypeDeclaration().get());
+        return getRelevantElements(resolvedType.asReferenceType().getTypeDeclaration().get(), node);
       }
     }
 
@@ -394,6 +395,19 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
                                 n -> n.getNameAsString().equals(member.getName()))
                             .get())
                 .toList());
+      }
+
+      // By default, #getRelevantElements(Node) does not include a record's canonical constructor's
+      // parameters. This is because we do not want to preserve record fields that are unused.
+      // However, if we encounter a call to this canonical constructor, then we must preserve all
+      // those fields. We know that the following refers to the canonical constructor because only
+      // the canonical constructor resolved results in a resolved type declaration (others are all
+      // ResolvedConstructorDeclaration).
+
+      // Another case where resolve() yields the canonical constructor is handled in the next if
+      // block.
+      if (type.isRecordDeclaration() && node instanceof ObjectCreationExpr) {
+        elements.addAll(type.asRecordDeclaration().getParameters());
       }
 
       elements.add(type);
@@ -448,11 +462,15 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
       if (!(resolved instanceof DefaultConstructorDeclaration)
           && !isAnonymousClass
           && resolvedMethodLikeDeclaration.toAst().isPresent()) {
-        Node unattached = resolvedMethodLikeDeclaration.toAst().get();
-        CallableDeclaration<?> methodLike =
-            type.findFirst(CallableDeclaration.class, n -> n.equals(unattached)).get();
+        elements.add(
+            JavaParserUtil.findAttachedNode(resolvedMethodLikeDeclaration, fqnToCompilationUnits));
+      }
 
-        elements.add(methodLike);
+      // By default, #getRelevantElements(Node) does not include a record's canonical constructor's
+      // parameters. See reasoning for this in the last big if block; this is another variant of the
+      // same case.
+      if (resolved instanceof JavaParserRecordDeclaration.CanonicalRecordConstructor) {
+        elements.addAll(type.asRecordDeclaration().getParameters());
       }
 
       elements.add(type);
@@ -502,10 +520,10 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
       // Most of the time, this method will return one constructor. However, there may be cases
       // where we include multiple constructors, but this is because we simply don't know which
       // one to use.
-      List<? extends CallableDeclaration<?>> constructors =
+      List<? extends NodeWithParameters<?>> constructors =
           JavaParserUtil.tryResolveNodeWithUnresolvableArguments(
               enumConstant, fqnToCompilationUnits);
-      elements.addAll(constructors);
+      elements.addAll(constructors.stream().map(c -> (Node) c).toList());
     }
 
     return elements;

--- a/src/main/java/org/checkerframework/specimin/TypeRuleDependencyMap.java
+++ b/src/main/java/org/checkerframework/specimin/TypeRuleDependencyMap.java
@@ -22,7 +22,8 @@ public interface TypeRuleDependencyMap {
    * would return the method declaration and its declaring type, both as attached nodes.
    *
    * @param resolved The resolved object
+   * @param node The node that was resolved
    * @return All relevant nodes to the input resolved object.
    */
-  List<Node> getRelevantElements(Object resolved);
+  List<Node> getRelevantElements(Object resolved, Node node);
 }

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -7,7 +7,6 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.TypeDeclaration;
@@ -28,6 +27,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithCondition;
 import com.github.javaparser.ast.nodeTypes.NodeWithExtends;
 import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
 import com.github.javaparser.ast.nodeTypes.NodeWithType;
@@ -1426,7 +1426,7 @@ public class FullyQualifiedNameGenerator {
 
     Node attached = JavaParserUtil.tryFindAttachedNode(resolved, fqnToCompilationUnits);
     if (attached != null) {
-      CallableDeclaration<?> callableDecl = (CallableDeclaration<?>) attached;
+      NodeWithParameters<?> callableDecl = (NodeWithParameters<?>) attached;
 
       for (Parameter param : callableDecl.getParameters()) {
         FullyQualifiedNameSet nonWildcard = getFQNsFromType(param.getType());
@@ -1561,12 +1561,6 @@ public class FullyQualifiedNameGenerator {
     Object resolved = Resolver.resolve((Resolvable<?>) expr);
 
     if (resolved == null) {
-      if (expr instanceof NodeWithArguments<?> withArguments) {
-        resolved =
-            JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
-                withArguments, fqnToCompilationUnits);
-      }
-
       @Nullable FullyQualifiedNameSet findableDeclarationTypeFQNs =
           getFQNsForExpressionInAnonymousClass(expr);
       if (findableDeclarationTypeFQNs != null) {
@@ -1724,7 +1718,13 @@ public class FullyQualifiedNameGenerator {
 
               return Set.of(getFQNsForResolvedType(paramType));
             } catch (UnsolvedSymbolException ex) {
-              // getType() may throw an UnsolvedSymbolException
+              NodeWithParameters<?> withParams =
+                  (NodeWithParameters<?>)
+                      JavaParserUtil.tryFindAttachedNode(resolvedMethodLike, fqnToCompilationUnits);
+
+              if (withParams != null) {
+                return Set.of(getFQNsFromType(withParams.getParameter(param).getType()));
+              }
             }
           }
 
@@ -1776,19 +1776,12 @@ public class FullyQualifiedNameGenerator {
             }
           }
 
-          CallableDeclaration<?> singleCallable =
-              JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
-                  withArguments, fqnToCompilationUnits);
-          if (singleCallable != null) {
-            return Set.of(getFQNsFromType(singleCallable.getParameter(param).getType()));
-          }
-
-          List<? extends CallableDeclaration<?>> allPotentialCallables =
+          List<? extends NodeWithParameters<?>> allPotentialCallables =
               JavaParserUtil.tryResolveNodeWithUnresolvableArguments(
                   withArguments, fqnToCompilationUnits);
           Set<FullyQualifiedNameSet> result = new LinkedHashSet<>();
 
-          for (CallableDeclaration<?> callable : allPotentialCallables) {
+          for (NodeWithParameters<?> callable : allPotentialCallables) {
             result.add(getFQNsFromType(callable.getParameter(param).getType()));
           }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedFieldAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedFieldAlternates.java
@@ -1,6 +1,7 @@
 package org.checkerframework.specimin.unsolved;
 
-import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +49,7 @@ public class UnsolvedFieldAlternates extends UnsolvedSymbolAlternates<UnsolvedFi
    */
   public static UnsolvedFieldAlternates create(
       String name,
-      Map<MemberType, CallableDeclaration<?>> typesToMustPreserveNodes,
+      Map<MemberType, NodeWithParameters<?>> typesToMustPreserveNodes,
       List<UnsolvedClassOrInterfaceAlternates> alternateDeclaringTypes,
       boolean isStatic,
       boolean isFinal) {
@@ -58,10 +59,10 @@ public class UnsolvedFieldAlternates extends UnsolvedSymbolAlternates<UnsolvedFi
 
     UnsolvedFieldAlternates result = new UnsolvedFieldAlternates(alternateDeclaringTypes);
 
-    for (Map.Entry<MemberType, CallableDeclaration<?>> entry :
-        typesToMustPreserveNodes.entrySet()) {
+    for (Map.Entry<MemberType, NodeWithParameters<?>> entry : typesToMustPreserveNodes.entrySet()) {
       UnsolvedField field =
-          new UnsolvedField(name, entry.getKey(), isStatic, isFinal, Set.of(entry.getValue()));
+          new UnsolvedField(
+              name, entry.getKey(), isStatic, isFinal, Set.of((Node) entry.getValue()));
       result.addAlternate(field);
     }
 
@@ -130,7 +131,7 @@ public class UnsolvedFieldAlternates extends UnsolvedSymbolAlternates<UnsolvedFi
    * @param typesToPreserveNodes A map of field types to nodes that must be preserved
    */
   public void updateFieldTypesAndMustPreserveNodes(
-      Map<MemberType, CallableDeclaration<?>> typesToPreserveNodes) {
+      Map<MemberType, NodeWithParameters<?>> typesToPreserveNodes) {
     // Update in-place; intersection = removing all elements in the original set
     // that isn't found in the updated set
     UnsolvedField old = getAlternates().get(0);
@@ -140,14 +141,14 @@ public class UnsolvedFieldAlternates extends UnsolvedSymbolAlternates<UnsolvedFi
     if (getAlternates().isEmpty() && oldFieldTypes.size() == 1) {
       // If it's now empty and old field types was of size 1, it was probably a synthetic field
       // type
-      for (Map.Entry<MemberType, CallableDeclaration<?>> entry : typesToPreserveNodes.entrySet()) {
+      for (Map.Entry<MemberType, NodeWithParameters<?>> entry : typesToPreserveNodes.entrySet()) {
         UnsolvedField field =
             new UnsolvedField(
                 old.getName(),
                 entry.getKey(),
                 old.isStatic(),
                 old.isFinal(),
-                Set.of(entry.getValue()));
+                Set.of((Node) entry.getValue()));
         addAlternate(field);
       }
     }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -1,7 +1,7 @@
 package org.checkerframework.specimin.unsolved;
 
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -186,7 +186,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
    */
   public static UnsolvedMethodAlternates createWithPreservation(
       String name,
-      Map<MemberType, CallableDeclaration<?>> returnTypesToMustPreserveNodes,
+      Map<MemberType, NodeWithParameters<?>> returnTypesToMustPreserveNodes,
       List<UnsolvedClassOrInterfaceAlternates> alternateDeclaringTypes,
       List<Map<MemberType, @Nullable Node>> parameters,
       List<MemberType> exceptions) {
@@ -198,7 +198,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
 
     for (List<Map.Entry<MemberType, @Nullable Node>> parameterList :
         JavaParserUtil.generateAllCombinationsForListOfMaps(parameters)) {
-      for (Map.Entry<MemberType, CallableDeclaration<?>> returnType :
+      for (Map.Entry<MemberType, NodeWithParameters<?>> returnType :
           returnTypesToMustPreserveNodes.entrySet()) {
         List<MemberType> params = parameterList.stream().map(Map.Entry::getKey).toList();
         Set<Node> toPreserve = new HashSet<>();
@@ -209,7 +209,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
           }
         }
 
-        Node returnTypePreserve = returnType.getValue();
+        Node returnTypePreserve = (Node) returnType.getValue();
 
         if (returnTypePreserve != null) {
           toPreserve.add(returnTypePreserve);
@@ -231,7 +231,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
    * @param returnsToPreserveNodes A map of return types to nodes that must be preserved
    */
   public void updateReturnTypesAndMustPreserveNodes(
-      Map<MemberType, CallableDeclaration<?>> returnsToPreserveNodes) {
+      Map<MemberType, NodeWithParameters<?>> returnsToPreserveNodes) {
     // Update in-place; intersection = removing all elements in the original set
     // that isn't found in the updated set
     UnsolvedMethod old = getAlternates().get(0);
@@ -245,8 +245,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
         .removeIf(alternate -> !returnsToPreserveNodes.containsKey(alternate.getReturnType()));
 
     if (getAlternates().isEmpty()) {
-      for (Map.Entry<MemberType, CallableDeclaration<?>> entry :
-          returnsToPreserveNodes.entrySet()) {
+      for (Map.Entry<MemberType, NodeWithParameters<?>> entry : returnsToPreserveNodes.entrySet()) {
         for (List<MemberType> parameterList : parameterLists) {
           UnsolvedMethod method =
               new UnsolvedMethod(
@@ -254,7 +253,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
                   entry.getKey(),
                   parameterList,
                   old.getThrownExceptions(),
-                  Set.of(entry.getValue()));
+                  Set.of((Node) entry.getValue()));
           addAlternate(method);
         }
       }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -1,7 +1,7 @@
 package org.checkerframework.specimin.unsolved;
 
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
+import com.github.javaparser.ast.body.CallableDeclaration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.specimin.JavaParserUtil;
 
@@ -245,7 +247,8 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
         .removeIf(alternate -> !returnsToPreserveNodes.containsKey(alternate.getReturnType()));
 
     if (getAlternates().isEmpty()) {
-      for (Map.Entry<MemberType, NodeWithParameters<?>> entry : returnsToPreserveNodes.entrySet()) {
+      for (Map.Entry<MemberType, NodeWithParameters<?>> entry :
+          returnsToPreserveNodes.entrySet()) {
         for (List<MemberType> parameterList : parameterLists) {
           UnsolvedMethod method =
               new UnsolvedMethod(

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -1,7 +1,7 @@
 package org.checkerframework.specimin.unsolved;
 
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.specimin.JavaParserUtil;
 
@@ -247,8 +245,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
         .removeIf(alternate -> !returnsToPreserveNodes.containsKey(alternate.getReturnType()));
 
     if (getAlternates().isEmpty()) {
-      for (Map.Entry<MemberType, NodeWithParameters<?>> entry :
-          returnsToPreserveNodes.entrySet()) {
+      for (Map.Entry<MemberType, NodeWithParameters<?>> entry : returnsToPreserveNodes.entrySet()) {
         for (List<MemberType> parameterList : parameterLists) {
           UnsolvedMethod method =
               new UnsolvedMethod(

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
+import com.github.javaparser.ast.nodeTypes.NodeWithType;
 import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
@@ -831,7 +832,7 @@ public class UnsolvedSymbolGenerator {
           JavaParserUtil.tryFindAttachedNode(resolvedMethodDeclaration, fqnsToCompilationUnits);
 
       if (node != null) {
-        MethodDeclaration toAst = (MethodDeclaration) node;
+        NodeWithType<?, ?> toAst = (NodeWithType<?, ?>) node;
 
         inferContextImpl(toAst.getType(), result);
       }
@@ -3186,14 +3187,14 @@ public class UnsolvedSymbolGenerator {
   private void matchMethodReturnTypesToKnownChildClasses(MethodCallExpr methodCall) {
     Collection<Set<String>> potentialScopeFQNs = null;
     ResolvedMethodDeclaration resolvedMethod = Resolver.resolve(methodCall);
-    MethodDeclaration ast = null;
+    NodeWithType<?, ?> ast = null;
 
     if (resolvedMethod == null) {
       potentialScopeFQNs = fullyQualifiedNameGenerator.getFQNsForExpressionLocation(methodCall);
     } else {
       // Potential scope is all unsolvable ancestors
       ast =
-          (MethodDeclaration)
+          (NodeWithType<?, ?>)
               JavaParserUtil.tryFindAttachedNode(resolvedMethod, fqnsToCompilationUnits);
       if (ast == null) {
         return;
@@ -3203,7 +3204,7 @@ public class UnsolvedSymbolGenerator {
     if (ast != null) {
       List<ClassOrInterfaceType> unsolvableAncestors =
           JavaParserUtil.getAllUnsolvableAncestors(
-              JavaParserUtil.getEnclosingClassLike(ast), fqnsToCompilationUnits);
+              JavaParserUtil.getEnclosingClassLike((Node) ast), fqnsToCompilationUnits);
 
       if (unsolvableAncestors.isEmpty()) {
         return;

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -4,7 +4,6 @@ import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.EnumConstantDeclaration;

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
+import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
@@ -631,8 +632,8 @@ public class UnsolvedSymbolGenerator {
       }
     }
 
-    Map<MemberType, CallableDeclaration<?>> typeToMustPreserveNode =
-        getTypeToCallableDeclarationFromArgument(field);
+    Map<MemberType, NodeWithParameters<?>> typeToMustPreserveNode =
+        getTypeToNodeWithParametersFromArgument(field);
 
     UnsolvedSymbolAlternates<?> alreadyGenerated = findExistingAndUpdateFQNs(potentialFQNs);
 
@@ -763,8 +764,8 @@ public class UnsolvedSymbolGenerator {
       }
     }
 
-    Map<MemberType, CallableDeclaration<?>> typeToMustPreserveNode =
-        getTypeToCallableDeclarationFromArgument(nameExpr);
+    Map<MemberType, NodeWithParameters<?>> typeToMustPreserveNode =
+        getTypeToNodeWithParametersFromArgument(nameExpr);
 
     UnsolvedSymbolAlternates<?> generatedField = findExistingAndUpdateFQNs(fieldFQNs);
 
@@ -825,17 +826,6 @@ public class UnsolvedSymbolGenerator {
   private void handleMethodCallExpr(
       MethodCallExpr methodCall, List<UnsolvedSymbolAlternates<?>> result) {
     ResolvedMethodDeclaration resolvedMethodDeclaration = Resolver.resolve(methodCall);
-    if (resolvedMethodDeclaration != null) {
-      if (JavaParserUtil.tryResolveNodeIfInAnonymousClass(methodCall) != null) {
-        return;
-      }
-
-      if (JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
-              methodCall, fqnsToCompilationUnits)
-          != null) {
-        return;
-      }
-    }
 
     if (resolvedMethodDeclaration != null) {
       Node node =
@@ -850,7 +840,7 @@ public class UnsolvedSymbolGenerator {
       return;
     }
 
-    List<? extends CallableDeclaration<?>> definitions =
+    List<? extends NodeWithParameters<?>> definitions =
         JavaParserUtil.tryResolveNodeWithUnresolvableArguments(methodCall, fqnsToCompilationUnits);
 
     if (!definitions.isEmpty()
@@ -863,7 +853,7 @@ public class UnsolvedSymbolGenerator {
       // type is not. In this case, the type of the parameters are unsolved, and should be preserved
       // if the parameter type ever ends up becoming used (which it will, after addInformation is
       // done).
-      for (CallableDeclaration<?> callable : definitions) {
+      for (NodeWithParameters<?> callable : definitions) {
         for (Parameter param : callable.getParameters()) {
           List<UnsolvedSymbolAlternates<?>> generated = inferContext(param.getType());
           // Find the generated param type, if any
@@ -871,7 +861,7 @@ public class UnsolvedSymbolGenerator {
             if (symbol instanceof UnsolvedClassOrInterfaceAlternates type) {
               if (type.getClassName().equals(JavaParserUtil.erase(param.getTypeAsString()))) {
                 for (UnsolvedClassOrInterface alt : type.getAlternates()) {
-                  alt.addMustPreserveNode(callable);
+                  alt.addMustPreserveNode((Node) callable);
                 }
                 break;
               }
@@ -1001,8 +991,8 @@ public class UnsolvedSymbolGenerator {
     UnsolvedSymbolAlternates<?> generated = findExistingAndUpdateFQNs(potentialFQNs);
 
     // TODO: see if this is an issue if two different methods have the same parameter type
-    Map<MemberType, CallableDeclaration<?>> returnTypeToMustPreserveNode =
-        getTypeToCallableDeclarationFromArgument(methodCall);
+    Map<MemberType, NodeWithParameters<?>> returnTypeToMustPreserveNode =
+        getTypeToNodeWithParametersFromArgument(methodCall);
 
     List<Map<MemberType, @Nullable Node>> parametersToMustPreserve =
         generateParameterToMustPreserveMap(
@@ -1578,8 +1568,8 @@ public class UnsolvedSymbolGenerator {
             JavaParserUtil.getMethodDeclarationsFromMethodRef(argument.asMethodReferenceExpr());
 
         for (ResolvedMethodLikeDeclaration method : resolved) {
-          CallableDeclaration<?> ast =
-              (CallableDeclaration<?>)
+          NodeWithParameters<?> ast =
+              (NodeWithParameters<?>)
                   JavaParserUtil.tryFindAttachedNode(method, fqnsToCompilationUnits);
 
           if (ast == null) {
@@ -1596,7 +1586,7 @@ public class UnsolvedSymbolGenerator {
             potentialParameterType = modifiedFQNs.get(potentialParameterType);
           }
 
-          potentialParameterToMustPreserveNode.put(potentialParameterType, ast);
+          potentialParameterToMustPreserveNode.put(potentialParameterType, (Node) ast);
         }
       }
 
@@ -2230,24 +2220,24 @@ public class UnsolvedSymbolGenerator {
 
   /**
    * Given a potential argument expression, this method returns a map of MemberType to
-   * CallableDeclaration. For example, if the argument is a method call expression, foo(), as an
+   * NodeWithParameters. For example, if the argument is a method call expression, foo(), as an
    * argument of another method call, bar(foo()), this method will return a map of potential return
-   * types of foo() (based on the definitions of bar with an arity of 1) to the CallableDeclaration
+   * types of foo() (based on the definitions of bar with an arity of 1) to the NodeWithParameters
    * of bar. This method also works if {@code argument} is a field expression, or if the parent node
    * is a constructor/explicit constructor invocation.
    *
    * @param argument The argument expression to analyze
-   * @return A map of potential return types to their corresponding CallableDeclaration. Returns an
+   * @return A map of potential return types to their corresponding NodeWithParameters. Returns an
    *     empty map if no potential return types are found, or if the argument is not part of a
    *     solvable method/constructor call.
    */
-  private Map<MemberType, CallableDeclaration<?>> getTypeToCallableDeclarationFromArgument(
+  private Map<MemberType, NodeWithParameters<?>> getTypeToNodeWithParametersFromArgument(
       Expression argument) {
     // If this expression is an argument of a solvable method call, we have multiple potential field
     // types to choose from, based on each definition
     Node parent = argument.getParentNode().get();
     int paramNum = -1;
-    Map<MemberType, CallableDeclaration<?>> returnTypeToMustPreserveNode = new LinkedHashMap<>();
+    Map<MemberType, NodeWithParameters<?>> returnTypeToMustPreserveNode = new LinkedHashMap<>();
 
     if (!(parent instanceof NodeWithArguments<?> withArgs)) {
       return returnTypeToMustPreserveNode;
@@ -2266,10 +2256,10 @@ public class UnsolvedSymbolGenerator {
       return returnTypeToMustPreserveNode;
     }
 
-    List<? extends CallableDeclaration<?>> parentCallableDeclarations =
+    List<? extends NodeWithParameters<?>> parentNodeWithParams =
         JavaParserUtil.tryResolveNodeWithUnresolvableArguments(withArgs, fqnsToCompilationUnits);
 
-    for (CallableDeclaration<?> callable : parentCallableDeclarations) {
+    for (NodeWithParameters<?> callable : parentNodeWithParams) {
       Parameter param = callable.getParameter(paramNum);
 
       MemberType memberType =
@@ -2377,7 +2367,7 @@ public class UnsolvedSymbolGenerator {
           }
 
           if (parameterTypes != null && !parameterTypes.isEmpty()) {
-            String superCall = JavaParserUtil.getDefaultSuperConstructorCall(parameterTypes);
+            String superCall = JavaParserUtil.getDefaultConstructorCall(parameterTypes, false);
 
             boolean foundConstructor = false;
 
@@ -2826,8 +2816,8 @@ public class UnsolvedSymbolGenerator {
       }
 
       if (resolved != null) {
-        CallableDeclaration<?> asAst =
-            (CallableDeclaration<?>)
+        NodeWithParameters<?> asAst =
+            (NodeWithParameters<?>)
                 JavaParserUtil.tryFindAttachedNode(resolved, fqnsToCompilationUnits);
 
         for (int i = 0; i < nodeWithArgs.getArguments().size(); i++) {
@@ -2887,7 +2877,7 @@ public class UnsolvedSymbolGenerator {
           handleLHSAndRHSRelationship(Set.of(lhsType), rhsType, getResolvedTypeOfLHS);
         }
       } else {
-        List<? extends CallableDeclaration<?>> withUnresolvableArgs =
+        List<? extends NodeWithParameters<?>> withUnresolvableArgs =
             JavaParserUtil.tryResolveNodeWithUnresolvableArguments(
                 nodeWithArgs, fqnsToCompilationUnits);
 
@@ -3200,24 +3190,8 @@ public class UnsolvedSymbolGenerator {
     MethodDeclaration ast = null;
 
     if (resolvedMethod == null) {
-      ast =
-          (MethodDeclaration)
-              JavaParserUtil.tryFindSingleCallableForNodeWithUnresolvableArguments(
-                  methodCall, fqnsToCompilationUnits);
-
-      if (ast == null) {
-        resolvedMethod =
-            (ResolvedMethodDeclaration)
-                JavaParserUtil.tryFindCorrespondingDeclarationForConstraintQualifiedExpression(
-                    methodCall);
-
-        if (resolvedMethod == null) {
-          potentialScopeFQNs = fullyQualifiedNameGenerator.getFQNsForExpressionLocation(methodCall);
-        }
-      }
-    }
-
-    if (resolvedMethod != null) {
+      potentialScopeFQNs = fullyQualifiedNameGenerator.getFQNsForExpressionLocation(methodCall);
+    } else {
       // Potential scope is all unsolvable ancestors
       ast =
           (MethodDeclaration)

--- a/src/test/java/org/checkerframework/specimin/MustImplementMethodAdjacentClassTest.java
+++ b/src/test/java/org/checkerframework/specimin/MustImplementMethodAdjacentClassTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that methods are properly preserved even if it is never called, in these cases:
+ *
+ * <p>Given:
+ *
+ * <ul>
+ *   <li>Class A implements C, and class B implements C.
+ *   <li>C declares foo(), so both A and B must implement foo().
+ *   <li>A uses B, but never calls B.foo(). However, A.foo() is used.
+ *   <li>Therefore, B.foo() must also be preserved because it is required to satisfy the interface
+ *       implementation.
+ * </ul>
+ */
+public class MustImplementMethodAdjacentClassTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "mustimplementmethodsadjacentclass",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#foo()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/RecordsTest.java
+++ b/src/test/java/org/checkerframework/specimin/RecordsTest.java
@@ -1,0 +1,13 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/** This test checks if Specimin will work for record types */
+public class RecordsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "records", new String[] {"com/example/Foo.java"}, new String[] {"com.example.Foo#foo()"});
+  }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Bar.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Bar.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Bar implements Baz {
+    public void mustImplement() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Baz.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Baz.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface Baz {
+    void mustImplement();
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Foo.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Foo.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public class Foo implements Baz {
+    public void mustImplement() {
+        throw new java.lang.Error();
+    }
+
+    void foo() {
+        mustImplement();
+        Bar bar = new Bar();
+    }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Bar.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Bar.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public class Bar implements Baz {
+    public void mustImplement() { }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Baz.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Baz.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface Baz {
+    void mustImplement();
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Foo.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Foo.java
@@ -1,0 +1,10 @@
+package com.example;
+
+public class Foo implements Baz {
+    public void mustImplement() { }
+
+    void foo() {
+        mustImplement();
+        Bar bar = new Bar();
+    }
+}

--- a/src/test/resources/records/expected/com/example/Foo.java
+++ b/src/test/resources/records/expected/com/example/Foo.java
@@ -1,0 +1,14 @@
+package com.example;
+
+public class Foo {
+    void foo() {
+        MyRecord record1 = new MyRecord();
+
+        record1.str();
+        record1.foo();
+        record1.x();
+
+        MyRecord record2 = new MyRecord("", this);
+        MyOtherRecord other = new MyOtherRecord("");
+    }
+}

--- a/src/test/resources/records/expected/com/example/MyOtherRecord.java
+++ b/src/test/resources/records/expected/com/example/MyOtherRecord.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public record MyOtherRecord(String str) {
+}

--- a/src/test/resources/records/expected/com/example/MyRecord.java
+++ b/src/test/resources/records/expected/com/example/MyRecord.java
@@ -1,0 +1,11 @@
+package com.example;
+
+public record MyRecord(String str, Foo foo, int x) {
+    public MyRecord(String str, Foo foo) {
+        this(null, null, 0);
+    }
+
+    public MyRecord() {
+        this(null, null, 0);
+    }
+}

--- a/src/test/resources/records/input/com/example/Foo.java
+++ b/src/test/resources/records/input/com/example/Foo.java
@@ -1,0 +1,14 @@
+package com.example;
+
+public class Foo {
+    void foo() {
+        MyRecord record1 = new MyRecord();
+
+        record1.str();
+        record1.foo();
+        record1.x();
+
+        MyRecord record2 = new MyRecord("", this);
+        MyOtherRecord other = new MyOtherRecord("");
+    }
+}

--- a/src/test/resources/records/input/com/example/MyOtherRecord.java
+++ b/src/test/resources/records/input/com/example/MyOtherRecord.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public record MyOtherRecord(String str) {
+}

--- a/src/test/resources/records/input/com/example/MyRecord.java
+++ b/src/test/resources/records/input/com/example/MyRecord.java
@@ -1,0 +1,11 @@
+package com.example;
+
+public record MyRecord(String str, Foo foo, int x, boolean unusedVariableToRemove) {
+    public MyRecord(String str, Foo foo) {
+        this(str, foo, 0, false);
+    }
+
+    public MyRecord() {
+        this("", null);
+    }
+}


### PR DESCRIPTION
Fixes:
* Support for record classes (behavior: only used members are preserved, and non-canonical constructors are trimmed down to a minimal `this` call to the canonical constructor)

Once #460 merges and this PR is reviewed, set base to branch main and let the CI run again.

(I based this off of ensure-constructors instead of main because I figured it would avoid merge conflicts down the line once this is merged)