### PR TITLE
Add must implement method support for "adjacent" classes

### DIFF
--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -427,7 +427,7 @@ public class Slicer {
                   constructorNode.getParameters().stream()
                       .map(p -> p.getType().toString())
                       .toList();
-            } else {
+            } else if (attached != null) {
               parameterTypes =
                   constructor.formalParameterTypes().stream().map(ResolvedType::describe).toList();
             }

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -457,6 +457,13 @@ public class SpeciminRunner {
     }
   }
 
+  /**
+   * Gets the packages and classes used in the given slice and unsolved symbol enumeration.
+   *
+   * @param sliceResult The slice
+   * @param enumeratorResult The unsolved enumeration
+   * @return The used packages and classes
+   */
   private static Set<String> getUsedPackagesAndClasses(
       SliceResult sliceResult, UnsolvedSymbolEnumeratorResult enumeratorResult) {
     Set<String> usedPackagesAndClasses = new HashSet<>();

--- a/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
+++ b/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
@@ -74,6 +74,12 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
   private final Set<ResolvedMethodDeclaration> nonJDKMustImplementMethods = new HashSet<>();
 
   /**
+   * A set of seen type declarations so we can rediscover must implement methods if we already
+   * processed a declaration but later discover a must implement method.
+   */
+  private final Set<TypeDeclaration<?>> seenTypeDeclarations = new HashSet<>();
+
+  /**
    * Creates a new StandardTypeRuleDependencyMap to be passed into Slicer.
    *
    * @param fqnToCompilationUnits The map of type FQNs to their compilation units.
@@ -135,16 +141,9 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
     }
 
     // Type declarations
-    if (node instanceof NodeWithImplements<?> withImplements) {
-      elements.addAll(withImplements.getImplementedTypes());
-    }
-    if (node instanceof NodeWithExtends<?> withExtends) {
-      elements.addAll(withExtends.getExtendedTypes());
-    }
-    if (node instanceof ClassOrInterfaceDeclaration decl) {
-      elements.addAll(decl.getPermittedTypes());
-    }
     if (node instanceof TypeDeclaration<?> typeDeclaration) {
+      seenTypeDeclarations.add(typeDeclaration);
+
       List<MethodDeclaration> mustImplement =
           JavaParserUtil.getDeclarationsForAllMustImplementMethods(
               typeDeclaration, nonJDKMustImplementMethods, fqnToCompilationUnits);
@@ -178,6 +177,15 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
           // Methods like getAllAncestors() can throw an UnsolvedSymbolException
         }
       }
+    }
+    if (node instanceof NodeWithImplements<?> withImplements) {
+      elements.addAll(withImplements.getImplementedTypes());
+    }
+    if (node instanceof NodeWithExtends<?> withExtends) {
+      elements.addAll(withExtends.getExtendedTypes());
+    }
+    if (node instanceof ClassOrInterfaceDeclaration decl) {
+      elements.addAll(decl.getPermittedTypes());
     }
 
     // If the node is a type declaration, exit now, so we don't unintentionally
@@ -446,15 +454,21 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
       }
 
       if (resolved instanceof ResolvedMethodDeclaration resolvedMethodDeclaration) {
+        int before = nonJDKMustImplementMethods.size();
+
         if (isAnonymousClass && typeParametersMapForAnonClass != null) {
           // The current type is already a parent class, so we need to add those too
-          List<MethodDeclaration> methods = new ArrayList<>();
-          addOverriddenMethodsToList(
-              type, resolvedMethodDeclaration, typeParametersMapForAnonClass, methods);
-          elements.addAll(methods);
+          elements.addAll(
+              getOverriddenMethodsInDeclaration(
+                  type, resolvedMethodDeclaration, typeParametersMapForAnonClass));
         }
 
         elements.addAll(getAllOverriddenMethods(resolvedMethodDeclaration, type));
+
+        if (nonJDKMustImplementMethods.size() > before) {
+          elements.addAll(
+              seenTypeDeclarations.stream().flatMap(d -> getRelevantElements(d).stream()).toList());
+        }
       }
 
       // Case: new Foo() but Foo does not contain a constructor
@@ -577,57 +591,64 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
         continue;
       }
 
-      addOverriddenMethodsToList(
-          typeDecl, original, parentType.asReferenceType().getTypeParametersMap(), result);
+      result.addAll(
+          getOverriddenMethodsInDeclaration(
+              typeDecl, original, parentType.asReferenceType().getTypeParametersMap()));
 
       getAllOverriddenMethodsImpl(original, typeDecl, result);
     }
   }
 
   /**
-   * Helper method to add methods of matching signature to {@code original} from {@code typeDecl} to
-   * {@code result}.
+   * Helper method to find methods of matching signature to {@code original} from {@code typeDecl}.
    *
    * @param typeDecl The type declaration to search for overridden methods in
    * @param original The original method declaration to find overridden methods for
    * @param typeParametersMap The type parameters map
-   * @param result A list to collect all overridden methods found
+   * @return the list of overridden methods
    */
-  private void addOverriddenMethodsToList(
+  private List<MethodDeclaration> getOverriddenMethodsInDeclaration(
       TypeDeclaration<?> typeDecl,
       ResolvedMethodDeclaration original,
-      List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeParametersMap,
-      List<MethodDeclaration> result) {
+      List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeParametersMap) {
+    List<MethodDeclaration> result = new ArrayList<>();
+
     for (MethodDeclaration method : typeDecl.getMethods()) {
-      ResolvedMethodDeclaration resolved = Resolver.resolve(method);
+      ResolvedMethodDeclaration resolved = Resolver.resolveGuaranteeNonNull(method);
 
       String signature = null;
       String signatureOfDeclarationWithTypeParamsAdjusted = null;
-      if (resolved != null) {
-        try {
-          signature = original.getSignature();
-          signatureOfDeclarationWithTypeParamsAdjusted =
-              JavaParserUtil.getSignatureFromResolvedMethodWithTypeVariablesMap(
-                  resolved, typeParametersMap);
-        } catch (UnsolvedSymbolException ex) {
-          // getSignature() and getSignature...Map() both could throw
-        }
+      try {
+        signature = original.getSignature();
+        signatureOfDeclarationWithTypeParamsAdjusted =
+            JavaParserUtil.getSignatureFromResolvedMethodWithTypeVariablesMap(
+                resolved, typeParametersMap);
+      } catch (UnsolvedSymbolException ex) {
+        // getSignature() and getSignature...Map() both could throw
       }
 
-      if (resolved != null
-          && signature != null
-          && signatureOfDeclarationWithTypeParamsAdjusted != null) {
+      if (signature != null && signatureOfDeclarationWithTypeParamsAdjusted != null) {
         if (signature.equals(signatureOfDeclarationWithTypeParamsAdjusted)) {
           result.add(method);
+
+          if (method.isAbstract()) {
+            nonJDKMustImplementMethods.add(resolved);
+          }
         }
       } else {
         // At least one parameter type may not be solvable. In this case, try comparing
         // simple names.
         if (areAstAndResolvedMethodLikelyEqual(original, method)) {
           result.add(method);
+
+          if (method.isAbstract()) {
+            nonJDKMustImplementMethods.add(resolved);
+          }
         }
       }
     }
+
+    return result;
   }
 
   /**

--- a/src/test/java/org/checkerframework/specimin/MustImplementMethodAdjacentClassTest.java
+++ b/src/test/java/org/checkerframework/specimin/MustImplementMethodAdjacentClassTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that methods are properly preserved even if it is never called, in these cases:
+ *
+ * <p>Given:
+ *
+ * <ul>
+ *   <li>Class A implements C, and class B implements C.
+ *   <li>C declares foo(), so both A and B must implement foo().
+ *   <li>A uses B, but never calls B.foo(). However, A.foo() is used.
+ *   <li>Therefore, B.foo() must also be preserved because it is required to satisfy the interface
+ *       implementation.
+ * </ul>
+ */
+public class MustImplementMethodAdjacentClassTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "mustimplementmethodsadjacentclass",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#foo()"});
+  }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Bar.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Bar.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Bar implements Baz {
+    public void mustImplement() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Baz.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Baz.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface Baz {
+    void mustImplement();
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Foo.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/expected/com/example/Foo.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public class Foo implements Baz {
+    public void mustImplement() {
+        throw new java.lang.Error();
+    }
+
+    void foo() {
+        mustImplement();
+        Bar bar = new Bar();
+    }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Bar.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Bar.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public class Bar implements Baz {
+    public void mustImplement() { }
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Baz.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Baz.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface Baz {
+    void mustImplement();
+}

--- a/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Foo.java
+++ b/src/test/resources/mustimplementmethodsadjacentclass/input/com/example/Foo.java
@@ -1,0 +1,10 @@
+package com.example;
+
+public class Foo implements Baz {
+    public void mustImplement() { }
+
+    void foo() {
+        mustImplement();
+        Bar bar = new Bar();
+    }
+}


### PR DESCRIPTION
Fixes:
* Method preservation for "adjacent" classes, where a used type implementing an interface with a known method that must be preserved also has to preserve that method, even if that method is never actually called by that specific used type, but is called by another used type that implements the same interface (see MustImplementMethodsAdjacentClassTest for an example)

Once #461 merges and this PR is reviewed, set base to branch main and let the CI run again.

(I based this off of record-classes instead of main because I figured it would avoid merge conflicts down the line once this is merged)