### PR TITLE
Fix crash on unsolved argument to JDK constructor

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -1042,6 +1042,9 @@ public class JavaParserUtil {
   /**
    * Checks if the given name is in ALL_CAPS, as is the standard convention for constants. Heuristic
    * for detecting likely enum constants.
+   *
+   * @param simpleName the name to check
+   * @return true if the name matches the standard Java convention for constants, false otherwise
    */
   public static boolean isProbablyAConstant(String simpleName) {
     for (int i = 0; i < simpleName.length(); i++) {

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2997,31 +2997,9 @@ public class UnsolvedSymbolGenerator {
               return UnsolvedGenerationResult.EMPTY;
             }
           } else {
-            // We reach this branch when no matching constructor declaration could be found for a
-            // constructor call whose arguments are not all resolvable. If the constructor's
-            // declaring type is nevertheless a fully-known class (e.g. a JDK type such as
-            // IllegalStateException, or a source type without a matching-arity constructor), then
-            // there is no synthetic constructor to generate: the declaring type is not one of the
-            // synthetic symbols, so getFQNsForUnsolvableConstructor would find a null scope and
-            // crash. Since the declaring type's constructor parameters are already known, there are
-            // no synthetic parameter types to constrain from this call, so there is nothing to do.
-            if (isKnownConstructorDeclaringType(node)) {
-              return UnsolvedGenerationResult.EMPTY;
-            }
             genMethod =
                 (UnsolvedMethodAlternates)
                     findExistingAndUpdateFQNs(getFQNsForUnsolvableConstructor(node));
-
-            // The synthetic constructor's parameter types are computed from the current (best
-            // known) types of the arguments. If those argument types have since been refined (for
-            // example, a synthetic placeholder type was later unified with a more specific type),
-            // the recomputed constructor signature can no longer match the one originally
-            // generated, so no alternates are found. This is only a best-effort step to constrain
-            // argument types against the constructor's parameters, so if the constructor cannot be
-            // located there is nothing further to constrain here.
-            if (genMethod == null) {
-              return UnsolvedGenerationResult.EMPTY;
-            }
           }
 
           if (genMethod == null) {
@@ -3866,26 +3844,6 @@ public class UnsolvedSymbolGenerator {
    *     ExplicitConstructorInvocationStmt
    * @return A set of FQNs representing the constructor
    */
-  /**
-   * Determines whether the declaring type of an unresolvable constructor call is nevertheless a
-   * fully-known class (i.e. one that the symbol solver can resolve, such as a JDK type). Such types
-   * are not among the synthetic symbols, so no synthetic constructor should be generated for them.
-   *
-   * @param node the node representing the constructor call; either an ObjectCreationExpr or
-   *     ExplicitConstructorInvocationStmt
-   * @return true if the constructor's declaring type is resolvable and therefore known
-   */
-  private boolean isKnownConstructorDeclaringType(Node node) {
-    if (node instanceof ObjectCreationExpr constructor) {
-      return Resolver.resolve(constructor.getType()) != null;
-    } else if (node instanceof ExplicitConstructorInvocationStmt constructor
-        && !constructor.isThis()) {
-      ClassOrInterfaceType superClass = JavaParserUtil.getSuperClass(node);
-      return superClass != null && Resolver.resolve(superClass) != null;
-    }
-    return false;
-  }
-
   private Set<String> getFQNsForUnsolvableConstructor(Node node) {
     UnsolvedClassOrInterfaceAlternates scope;
     String constructorName;

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -3886,6 +3886,15 @@ public class UnsolvedSymbolGenerator {
     return false;
   }
 
+    /**
+     * Given an unsolvable constuctor invocation (i.e., to a constructor in a
+     * synthetic class), this method returns a list of fully-qualified names for
+     * the constructor invocation's argument types.
+     *
+     * @param node a constructor invocation: either an ExplicitConstructorInvocationStmt
+     *             or an ObjectCreationExpr
+     * @return a list of fully-qualified names for the constructor invocation's argument types
+     */
   private Set<String> getFQNsForUnsolvableConstructor(Node node) {
     UnsolvedClassOrInterfaceAlternates scope;
     String constructorName;

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -3860,13 +3860,6 @@ public class UnsolvedSymbolGenerator {
   }
 
   /**
-   * Returns the FQNs for an unsolvable constructor call.
-   *
-   * @param node The node representing the constructor call; either an ObjectCreationExpr or
-   *     ExplicitConstructorInvocationStmt
-   * @return A set of FQNs representing the constructor
-   */
-  /**
    * Determines whether the declaring type of an unresolvable constructor call is nevertheless a
    * fully-known class (i.e. one that the symbol solver can resolve, such as a JDK type). Such types
    * are not among the synthetic symbols, so no synthetic constructor should be generated for them.
@@ -3886,15 +3879,14 @@ public class UnsolvedSymbolGenerator {
     return false;
   }
 
-    /**
-     * Given an unsolvable constuctor invocation (i.e., to a constructor in a
-     * synthetic class), this method returns a list of fully-qualified names for
-     * the constructor invocation's argument types.
-     *
-     * @param node a constructor invocation: either an ExplicitConstructorInvocationStmt
-     *             or an ObjectCreationExpr
-     * @return a list of fully-qualified names for the constructor invocation's argument types
-     */
+  /**
+   * Given an unsolvable constuctor invocation (i.e., to a constructor in a synthetic class), this
+   * method returns a list of fully-qualified names for the constructor invocation's argument types.
+   *
+   * @param node a constructor invocation: either an ExplicitConstructorInvocationStmt or an
+   *     ObjectCreationExpr
+   * @return a list of fully-qualified names for the constructor invocation's argument types
+   */
   private Set<String> getFQNsForUnsolvableConstructor(Node node) {
     UnsolvedClassOrInterfaceAlternates scope;
     String constructorName;

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2997,9 +2997,31 @@ public class UnsolvedSymbolGenerator {
               return UnsolvedGenerationResult.EMPTY;
             }
           } else {
+            // We reach this branch when no matching constructor declaration could be found for a
+            // constructor call whose arguments are not all resolvable. If the constructor's
+            // declaring type is nevertheless a fully-known class (e.g. a JDK type such as
+            // IllegalStateException, or a source type without a matching-arity constructor), then
+            // there is no synthetic constructor to generate: the declaring type is not one of the
+            // synthetic symbols, so getFQNsForUnsolvableConstructor would find a null scope and
+            // crash. Since the declaring type's constructor parameters are already known, there are
+            // no synthetic parameter types to constrain from this call, so there is nothing to do.
+            if (isKnownConstructorDeclaringType(node)) {
+              return UnsolvedGenerationResult.EMPTY;
+            }
             genMethod =
                 (UnsolvedMethodAlternates)
                     findExistingAndUpdateFQNs(getFQNsForUnsolvableConstructor(node));
+
+            // The synthetic constructor's parameter types are computed from the current (best
+            // known) types of the arguments. If those argument types have since been refined (for
+            // example, a synthetic placeholder type was later unified with a more specific type),
+            // the recomputed constructor signature can no longer match the one originally
+            // generated, so no alternates are found. This is only a best-effort step to constrain
+            // argument types against the constructor's parameters, so if the constructor cannot be
+            // located there is nothing further to constrain here.
+            if (genMethod == null) {
+              return UnsolvedGenerationResult.EMPTY;
+            }
           }
 
           if (genMethod == null) {
@@ -3844,6 +3866,26 @@ public class UnsolvedSymbolGenerator {
    *     ExplicitConstructorInvocationStmt
    * @return A set of FQNs representing the constructor
    */
+  /**
+   * Determines whether the declaring type of an unresolvable constructor call is nevertheless a
+   * fully-known class (i.e. one that the symbol solver can resolve, such as a JDK type). Such types
+   * are not among the synthetic symbols, so no synthetic constructor should be generated for them.
+   *
+   * @param node the node representing the constructor call; either an ObjectCreationExpr or
+   *     ExplicitConstructorInvocationStmt
+   * @return true if the constructor's declaring type is resolvable and therefore known
+   */
+  private boolean isKnownConstructorDeclaringType(Node node) {
+    if (node instanceof ObjectCreationExpr constructor) {
+      return Resolver.resolve(constructor.getType()) != null;
+    } else if (node instanceof ExplicitConstructorInvocationStmt constructor
+        && !constructor.isThis()) {
+      ClassOrInterfaceType superClass = JavaParserUtil.getSuperClass(node);
+      return superClass != null && Resolver.resolve(superClass) != null;
+    }
+    return false;
+  }
+
   private Set<String> getFQNsForUnsolvableConstructor(Node node) {
     UnsolvedClassOrInterfaceAlternates scope;
     String constructorName;

--- a/src/test/java/org/checkerframework/specimin/JdkCtorUnsolvedArgTest.java
+++ b/src/test/java/org/checkerframework/specimin/JdkCtorUnsolvedArgTest.java
@@ -1,0 +1,19 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A constructor call to a fully-known (JDK) class whose argument's type is unsolvable used to crash
+ * Specimin with "Scope not created when it should've been", because it was treated as a call to a
+ * synthetic constructor. This test exercises that case; the minimized output must compile.
+ */
+public class JdkCtorUnsolvedArgTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "jdkctorunsolvedarg",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target()"});
+  }
+}

--- a/src/test/resources/jdkctorunsolvedarg/expected/com/example/Simple.java
+++ b/src/test/resources/jdkctorunsolvedarg/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Unsolved;
+
+public class Simple {
+
+    Unsolved field;
+
+    void target() {
+        throw new IllegalStateException("bad value: " + field);
+    }
+}

--- a/src/test/resources/jdkctorunsolvedarg/expected/org/example/Unsolved.java
+++ b/src/test/resources/jdkctorunsolvedarg/expected/org/example/Unsolved.java
@@ -1,0 +1,4 @@
+package org.example;
+
+public class Unsolved {
+}

--- a/src/test/resources/jdkctorunsolvedarg/input/com/example/Simple.java
+++ b/src/test/resources/jdkctorunsolvedarg/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Unsolved;
+
+public class Simple {
+
+    Unsolved field;
+
+    void target() {
+        throw new IllegalStateException("bad value: " + field);
+    }
+}


### PR DESCRIPTION
Fixes the crash in #405. The actual test case for #405 still doesn't compile, but I think that's a separate problem. I've manually confirmed that the test case fails with the appropriate crash without the fix commit.

This PR is a further experiment in AI-assisted software engineering. All of the code in this PR was initially authored by Claude, but I've reviewed it and it seems reasonable to me. Here is its change summary:

In UnsolvedSymbolGenerator.java, a constructor call to a fully-known class (e.g. a JDK type like IllegalStateException) whose argument type was unsolvable was being routed down the "synthetic constructor" path. That path assumes the constructor's declaring type is one of Specimin's synthetic symbols, so it looked up a scope that doesn't exist and crashed with Scope not created when it should've been.

Two guards were added in the unresolvable-args branch:
1. isKnownConstructorDeclaringType(node) — if the constructor's declaring type resolves (JDK/known class), there is no synthetic constructor to generate, so return EMPTY.
2. If the synthetic constructor's alternates can't be located (because argument types were refined after the constructor was first generated), return EMPTY gracefully instead of throwing.

The new test (JdkCtorUnsolvedArgTest + jdkctorunsolvedarg/)

A minimal reproduction distilled from the real crash: a target method that throws new IllegalStateException("bad value: " + field) where field has an unsolvable type. This exercises exactly the fixed path.