### PR TITLE
Switch Checker Framework to run during CI instead of on all builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Run build with Gradle Wrapper
-        run: ./gradlew build expectedTestOutputsMustCompile
+        run: ./gradlew build expectedTestOutputsMustCompile -PskipCheckerFramework=false
       - name: export Specimin PATH
         run: echo "SPECIMIN=$(pwd)" >> $GITHUB_ENV
       - name: Setup Python

--- a/build.gradle
+++ b/build.gradle
@@ -126,8 +126,10 @@ tasks.compileTestJava {
 }
 
 checkerFramework {
-    // uncomment for testing
-    // skipCheckerFramework = true
+    // The CF is disabled on dev machine builds by default because it is pretty slow.
+    // These checkers will run in CI, though. To run them locally, run gradle with
+    // `-PskipCheckerFramework=false`.
+    skipCheckerFramework = true
     checkers = [
             "org.checkerframework.checker.nullness.NullnessChecker",
             "org.checkerframework.checker.resourceleak.ResourceLeakChecker",

--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,8 @@ checkerFramework {
     excludeTests = true
 
     extraJavacArgs = [
-            "-Astubs=${projectDir}/JavaParser.astub"
+            "-Astubs=${projectDir}/JavaParser.astub",
+            "-AslowTypecheckingSeconds=180" // UnsolvedSymbolGenerator takes a long time to typecheck, which is fine.
     ]
     version = "4.2.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -141,9 +141,16 @@ checkerFramework {
     extraJavacArgs = [
             "-Astubs=${projectDir}/JavaParser.astub",
             "-AslowTypecheckingSeconds=180", // UnsolvedSymbolGenerator takes a long time to typecheck, which is fine.
-            "-J-Xmx4g" // The CF requires significantly more memory than the typical Java compiler.
     ]
     version = "4.2.0"
+}
+
+tasks.withType(JavaCompile) {
+    // The CF requires significantly more memory than the typical Java compiler.
+    if (!checkerFramework.skipCheckerFramework) {
+        options.fork = true
+        options.forkOptions.memoryMaximumSize = "4g"
+    }
 }
 
 spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,8 @@ checkerFramework {
 
     extraJavacArgs = [
             "-Astubs=${projectDir}/JavaParser.astub",
-            "-AslowTypecheckingSeconds=180" // UnsolvedSymbolGenerator takes a long time to typecheck, which is fine.
+            "-AslowTypecheckingSeconds=180", // UnsolvedSymbolGenerator takes a long time to typecheck, which is fine.
+            "-J-Xmx4g" // The CF requires significantly more memory than the typical Java compiler.
     ]
     version = "4.2.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -147,10 +147,8 @@ checkerFramework {
 
 tasks.withType(JavaCompile) {
     // The CF requires significantly more memory than the typical Java compiler.
-    if (!checkerFramework.skipCheckerFramework) {
-        options.fork = true
-        options.forkOptions.memoryMaximumSize = "4g"
-    }
+    options.fork = true
+    options.forkOptions.memoryMaximumSize = "4g"
 }
 
 spotless {


### PR DESCRIPTION
I'm getting frustrated with long build times, and I've been running local tests with the CF off by default for awhile.