### PR TITLE
If a class extends an unmodifiable class (e.g., from the JDK) without a zero-argument constructor, we must preserve a compatible constructor or the output won't be compilable

### DIFF
--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -420,6 +420,13 @@ public class Slicer {
           List<String> parameterTypes = null;
 
           for (ResolvedConstructorDeclaration constructor : superClassDecl.getConstructors()) {
+            // A private constructor can't be the target of a super() call, so it can't rescue
+            // this class' compilability. Check this before the arity comparison below, so that
+            // an inaccessible constructor can never displace an accessible one.
+            if (constructor.accessSpecifier() == AccessSpecifier.PRIVATE) {
+              continue;
+            }
+
             if (parameterTypes != null
                 && parameterTypes.size() <= constructor.getNumberOfParams()) {
               continue;
@@ -436,11 +443,6 @@ public class Slicer {
                       .map(p -> p.getType().toString())
                       .toList();
             } else if (attached != null || !superClassIsModifiable) {
-              // A private constructor can't be the target of a super() call, so it can't
-              // rescue this class' compilability.
-              if (constructor.accessSpecifier() == AccessSpecifier.PRIVATE) {
-                continue;
-              }
               parameterTypes =
                   constructor.formalParameterTypes().stream().map(ResolvedType::describe).toList();
             }

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -1,6 +1,7 @@
 package org.checkerframework.specimin;
 
 import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
@@ -26,6 +27,7 @@ import com.github.javaparser.ast.type.UnknownType;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
@@ -404,10 +406,20 @@ public class Slicer {
 
         if (superClass instanceof ResolvedReferenceType superClassResolved
             && superClassResolved.getTypeDeclaration().isPresent()) {
+          ResolvedReferenceTypeDeclaration superClassDecl =
+              superClassResolved.getTypeDeclaration().get();
+
+          // If the superclass isn't one of the input files (e.g., it's a JDK class like
+          // LineNumberReader), then Specimin can't remove its constructors to give it an
+          // implicit zero-argument constructor. In that case, this class must keep a
+          // constructor that calls one of the superclass' constructors, even if the slice
+          // doesn't otherwise require any constructor at all.
+          boolean superClassIsModifiable =
+              fqnToCompilationUnits.containsKey(superClassDecl.getQualifiedName());
+
           List<String> parameterTypes = null;
 
-          for (ResolvedConstructorDeclaration constructor :
-              superClassResolved.getTypeDeclaration().get().getConstructors()) {
+          for (ResolvedConstructorDeclaration constructor : superClassDecl.getConstructors()) {
             if (parameterTypes != null
                 && parameterTypes.size() <= constructor.getNumberOfParams()) {
               continue;
@@ -423,7 +435,12 @@ public class Slicer {
                   constructorNode.getParameters().stream()
                       .map(p -> p.getType().toString())
                       .toList();
-            } else if (attached != null) {
+            } else if (attached != null || !superClassIsModifiable) {
+              // A private constructor can't be the target of a super() call, so it can't
+              // rescue this class' compilability.
+              if (constructor.accessSpecifier() == AccessSpecifier.PRIVATE) {
+                continue;
+              }
               parameterTypes =
                   constructor.formalParameterTypes().stream().map(ResolvedType::describe).toList();
             }

--- a/src/test/java/org/checkerframework/specimin/NoZeroArgCtorIntTest.java
+++ b/src/test/java/org/checkerframework/specimin/NoZeroArgCtorIntTest.java
@@ -1,0 +1,19 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that when extending a non-JDK class with only constructors that take more than
+ * zero arguments (all of which are primitives rather than objects), at least one constructor gets
+ * preserved so that the result compiles.
+ */
+public class NoZeroArgCtorIntTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nozeroargctorint",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NoZeroArgCtorIntTest.java
+++ b/src/test/java/org/checkerframework/specimin/NoZeroArgCtorIntTest.java
@@ -1,7 +1,7 @@
 package org.checkerframework.specimin;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test checks that when extending a non-JDK class with only constructors that take more than

--- a/src/test/java/org/checkerframework/specimin/NoZeroArgCtorJDKTest.java
+++ b/src/test/java/org/checkerframework/specimin/NoZeroArgCtorJDKTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that when extending a JDK class with only constructors that take more than zero
+ * arguments, at least one constructor gets preserved so that the result compiles.
+ *
+ * <p>I tried to write an equivalent of the {@link NoZeroArgCtorIntTest} using a JDK class, but I
+ * couldn't find a suitable JDK class to extend that only has constructors that take primitives. I
+ * considered the following unsuitable JDK classes: Number (has a zero arg ctor), Integer (final),
+ * Date (zero arg ctor again), BigInteger (has a ctor that takes a String). Then, I gave up and
+ * decided to only deal with that situation if we encounter it in practice.
+ */
+public class NoZeroArgCtorJDKTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nozeroargctorjdk",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NoZeroArgCtorJDKTest.java
+++ b/src/test/java/org/checkerframework/specimin/NoZeroArgCtorJDKTest.java
@@ -1,7 +1,7 @@
 package org.checkerframework.specimin;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test checks that when extending a JDK class with only constructors that take more than zero

--- a/src/test/java/org/checkerframework/specimin/NoZeroArgCtorPrivateTest.java
+++ b/src/test/java/org/checkerframework/specimin/NoZeroArgCtorPrivateTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that when a preserved superclass constructor is private, Specimin does not use
+ * it as the target of the super(...) call in the constructor that it preserves in the subclass,
+ * even if it is the constructor with the fewest parameters. A subclass cannot call a private
+ * constructor, so doing so would produce output that does not compile.
+ */
+public class NoZeroArgCtorPrivateTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nozeroargctorprivate",
+        new String[] {"com/example/Simple.java", "com/example/SomeOtherClass.java"},
+        new String[] {"com.example.Simple#bar()", "com.example.SomeOtherClass#make()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NoZeroArgCtorTest.java
+++ b/src/test/java/org/checkerframework/specimin/NoZeroArgCtorTest.java
@@ -1,7 +1,7 @@
 package org.checkerframework.specimin;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test checks that when extending a non-JDK class with only constructors that take more than

--- a/src/test/java/org/checkerframework/specimin/NoZeroArgCtorTest.java
+++ b/src/test/java/org/checkerframework/specimin/NoZeroArgCtorTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that when extending a non-JDK class with only constructors that take more than
+ * zero arguments, at least one constructor gets preserved so that the result compiles.
+ */
+public class NoZeroArgCtorTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nozeroargctor",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/nozeroargctor/expected/com/example/Simple.java
+++ b/src/test/resources/nozeroargctor/expected/com/example/Simple.java
@@ -1,0 +1,7 @@
+package com.example;
+
+class Simple extends SomeOtherClass {
+    void bar() {
+
+    }
+}

--- a/src/test/resources/nozeroargctor/expected/com/example/Simple.java
+++ b/src/test/resources/nozeroargctor/expected/com/example/Simple.java
@@ -2,6 +2,10 @@ package com.example;
 
 class Simple extends SomeOtherClass {
     void bar() {
+        SomeOtherClass s = new SomeOtherClass(this);
+    }
 
+    public Simple() {
+        super(null);
     }
 }

--- a/src/test/resources/nozeroargctor/expected/com/example/SomeOtherClass.java
+++ b/src/test/resources/nozeroargctor/expected/com/example/SomeOtherClass.java
@@ -1,4 +1,7 @@
 package com.example;
 
 class SomeOtherClass {
+    public SomeOtherClass(Object object) {
+        throw new java.lang.Error();
+    }
 }

--- a/src/test/resources/nozeroargctor/expected/com/example/SomeOtherClass.java
+++ b/src/test/resources/nozeroargctor/expected/com/example/SomeOtherClass.java
@@ -1,0 +1,4 @@
+package com.example;
+
+class SomeOtherClass {
+}

--- a/src/test/resources/nozeroargctor/input/com/example/Simple.java
+++ b/src/test/resources/nozeroargctor/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+class Simple extends SomeOtherClass {
+    // Target method.
+    void bar() {
+
+    }
+
+    // This needs to be preserved, because otherwise the class won't compile.
+    public Simple() {
+        super(null);
+    }
+}

--- a/src/test/resources/nozeroargctor/input/com/example/Simple.java
+++ b/src/test/resources/nozeroargctor/input/com/example/Simple.java
@@ -3,7 +3,7 @@ package com.example;
 class Simple extends SomeOtherClass {
     // Target method.
     void bar() {
-
+        SomeOtherClass s = new SomeOtherClass(this);
     }
 
     // This needs to be preserved, because otherwise the class won't compile.

--- a/src/test/resources/nozeroargctor/input/com/example/SomeOtherClass.java
+++ b/src/test/resources/nozeroargctor/input/com/example/SomeOtherClass.java
@@ -1,0 +1,7 @@
+package com.example;
+
+class SomeOtherClass {
+    public SomeOtherClass(Object object) {
+
+    }
+}

--- a/src/test/resources/nozeroargctorint/expected/com/example/Simple.java
+++ b/src/test/resources/nozeroargctorint/expected/com/example/Simple.java
@@ -1,0 +1,7 @@
+package com.example;
+
+class Simple extends SomeOtherClass {
+    void bar() {
+
+    }
+}

--- a/src/test/resources/nozeroargctorint/expected/com/example/Simple.java
+++ b/src/test/resources/nozeroargctorint/expected/com/example/Simple.java
@@ -2,6 +2,10 @@ package com.example;
 
 class Simple extends SomeOtherClass {
     void bar() {
+        SomeOtherClass s = new SomeOtherClass(0);
+    }
 
+    public Simple() {
+        super(0);
     }
 }

--- a/src/test/resources/nozeroargctorint/expected/com/example/SomeOtherClass.java
+++ b/src/test/resources/nozeroargctorint/expected/com/example/SomeOtherClass.java
@@ -1,0 +1,4 @@
+package com.example;
+
+class SomeOtherClass {
+}

--- a/src/test/resources/nozeroargctorint/expected/com/example/SomeOtherClass.java
+++ b/src/test/resources/nozeroargctorint/expected/com/example/SomeOtherClass.java
@@ -1,4 +1,7 @@
 package com.example;
 
 class SomeOtherClass {
+    public SomeOtherClass(int object) {
+        throw new java.lang.Error();
+    }
 }

--- a/src/test/resources/nozeroargctorint/input/com/example/Simple.java
+++ b/src/test/resources/nozeroargctorint/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+class Simple extends SomeOtherClass {
+    // Target method.
+    void bar() {
+
+    }
+
+    // This needs to be preserved, because otherwise the class won't compile.
+    public Simple() {
+        super(5);
+    }
+}

--- a/src/test/resources/nozeroargctorint/input/com/example/Simple.java
+++ b/src/test/resources/nozeroargctorint/input/com/example/Simple.java
@@ -3,7 +3,7 @@ package com.example;
 class Simple extends SomeOtherClass {
     // Target method.
     void bar() {
-
+        SomeOtherClass s = new SomeOtherClass(0);
     }
 
     // This needs to be preserved, because otherwise the class won't compile.

--- a/src/test/resources/nozeroargctorint/input/com/example/SomeOtherClass.java
+++ b/src/test/resources/nozeroargctorint/input/com/example/SomeOtherClass.java
@@ -1,0 +1,7 @@
+package com.example;
+
+class SomeOtherClass {
+    public SomeOtherClass(int object) {
+
+    }
+}

--- a/src/test/resources/nozeroargctorjdk/expected/com/example/Simple.java
+++ b/src/test/resources/nozeroargctorjdk/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.io.LineNumberReader;
+
+class Simple extends LineNumberReader {
+    void bar() {
+
+    }
+
+    public Simple() {
+        super(null);
+    }
+}

--- a/src/test/resources/nozeroargctorjdk/input/com/example/Simple.java
+++ b/src/test/resources/nozeroargctorjdk/input/com/example/Simple.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import java.io.LineNumberReader;
+
+class Simple extends LineNumberReader {
+    // Target method.
+    void bar() {
+
+    }
+
+    // This needs to be preserved, because otherwise the class won't compile.
+    public Simple() {
+        // Note that this input won't compile (String <: Reader is obviously false), but
+        // that's okay. This is just here to test that Specimin will replace any argument
+        // with a null literal.
+        super("bananas");
+    }
+}

--- a/src/test/resources/nozeroargctorprivate/expected/com/example/Simple.java
+++ b/src/test/resources/nozeroargctorprivate/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+class Simple extends SomeOtherClass {
+    void bar() {
+        new SomeOtherClass(1, 2);
+    }
+
+    public Simple() {
+        super(0, 0);
+    }
+}

--- a/src/test/resources/nozeroargctorprivate/expected/com/example/SomeOtherClass.java
+++ b/src/test/resources/nozeroargctorprivate/expected/com/example/SomeOtherClass.java
@@ -1,0 +1,15 @@
+package com.example;
+
+class SomeOtherClass {
+    private SomeOtherClass(Object object) {
+        throw new java.lang.Error();
+    }
+
+    public SomeOtherClass(int first, int second) {
+        throw new java.lang.Error();
+    }
+
+    static SomeOtherClass make() {
+        return new SomeOtherClass(null);
+    }
+}

--- a/src/test/resources/nozeroargctorprivate/input/com/example/Simple.java
+++ b/src/test/resources/nozeroargctorprivate/input/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+class Simple extends SomeOtherClass {
+    // Target method. Its body keeps the public constructor of SomeOtherClass in the slice.
+    void bar() {
+        new SomeOtherClass(1, 2);
+    }
+
+    // A constructor needs to be preserved, because otherwise the class won't compile:
+    // SomeOtherClass keeps both of its constructors, so it has no default constructor.
+    public Simple() {
+        super(1, 2);
+    }
+}

--- a/src/test/resources/nozeroargctorprivate/input/com/example/SomeOtherClass.java
+++ b/src/test/resources/nozeroargctorprivate/input/com/example/SomeOtherClass.java
@@ -1,0 +1,18 @@
+package com.example;
+
+class SomeOtherClass {
+    // This constructor has the fewest parameters, but Specimin must not use it as the
+    // target of a generated super(...) call, because a subclass cannot call it.
+    private SomeOtherClass(Object object) {
+
+    }
+
+    public SomeOtherClass(int first, int second) {
+
+    }
+
+    // Target method. Its body keeps the private constructor above in the slice.
+    static SomeOtherClass make() {
+        return new SomeOtherClass(null);
+    }
+}


### PR DESCRIPTION
Test cases from the `entryreader` branch (#393).