### PR TITLE
Ensure that Specimin produces a compilable output when an expression whose type cannot be solved appears as the operand of a cast expression

### DIFF
--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -15,6 +15,7 @@ import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.BinaryExpr.Operator;
+import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.ConditionalExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
@@ -1912,6 +1913,21 @@ public class FullyQualifiedNameGenerator {
         }
         return Set.of(new FullyQualifiedNameSet(result, notArray.typeArguments()));
       }
+    } else if (parentNode instanceof CastExpr castExpr
+        && castExpr.getExpression().equals(expr)
+        && !expr.isLambdaExpr()
+        && !expr.isMethodReferenceExpr()) {
+      // A cast does not tell us the operand's type: it only tells us that the operand must be
+      // cast-compatible with the target type. In fact the operand's type is usually *not* the
+      // target type, since a cast is written precisely when the static type is broader than what
+      // is needed. java.lang.Object is the only choice guaranteed to compile in every such
+      // context: it can be cast to any reference type, and to any primitive type via unboxing.
+      // Guessing the target type instead would fail whenever the same expression is also cast to
+      // an unrelated type somewhere else.
+      //
+      // Lambdas and method references are excluded because they are poly expressions with no type
+      // of their own; they are handled by the functional-interface logic instead.
+      return Set.of(new FullyQualifiedNameSet("java.lang.Object"));
     } else if (parentNode instanceof ExpressionStmt exprStmt
         && exprStmt.getParentNode().orElse(null) instanceof SwitchEntry arrowEntry
         && arrowEntry.getParentNode().orElse(null) instanceof SwitchExpr arrowSwitchExpr

--- a/src/test/java/org/checkerframework/specimin/CastOfUnsolvedTest.java
+++ b/src/test/java/org/checkerframework/specimin/CastOfUnsolvedTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Checks that Specimin produces a compilable output when an expression whose type cannot be solved
+ * appears as the operand of a cast expression.
+ */
+public class CastOfUnsolvedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "castofunsolved",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo)"});
+  }
+}

--- a/src/test/resources/castofunsolved/expected/com/example/Simple.java
+++ b/src/test/resources/castofunsolved/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Foo;
+
+public class Simple {
+
+  public void target(Foo f) {
+    String s = (String) f.get();
+    System.out.println(s);
+  }
+}

--- a/src/test/resources/castofunsolved/expected/org/example/Foo.java
+++ b/src/test/resources/castofunsolved/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Foo {
+
+    public java.lang.Object get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/castofunsolved/input/com/example/Simple.java
+++ b/src/test/resources/castofunsolved/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Foo;
+
+public class Simple {
+  public void target(Foo f) {
+    String s = (String) f.get();
+    System.out.println(s);
+  }
+}


### PR DESCRIPTION
Note that this is orthogonal to #480: I checked both before and after this fix and #480 exists on both sides.

This is a partial fix for the compilation failure of the test case from #403 (more hopefully coming!).