### PR TITLE
Uninstantiated type variables in return types should not contribute to the constraints at call sites

### DIFF
--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -848,6 +848,17 @@ public class FullyQualifiedNameGenerator {
             continue;
           }
 
+          // If the return type is one of the method's own type variables and nothing above
+          // resolved it to a concrete type, then this call site constrains the expression's type
+          // not at all: the variable can be instantiated to whatever the surrounding context
+          // needs. Reporting the variable's name here would be actively wrong, because that name
+          // is only in scope inside the method declaration that binds it, and every consumer of
+          // this result is outside that declaration. Saying nothing is the correct answer; see
+          // getFQNsFromSurroundingContextType for the same principle applied to contexts.
+          if (unsolvedMethodAlternates.isOwnTypeVariable(returnType)) {
+            continue;
+          }
+
           FullyQualifiedNameSet fullyQualifiedNameSet = convertMemberTypeToFQNSet(returnType);
           result.add(fullyQualifiedNameSet);
         }

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -851,10 +851,7 @@ public class FullyQualifiedNameGenerator {
           // If the return type is one of the method's own type variables and nothing above
           // resolved it to a concrete type, then this call site constrains the expression's type
           // not at all: the variable can be instantiated to whatever the surrounding context
-          // needs. Reporting the variable's name here would be actively wrong, because that name
-          // is only in scope inside the method declaration that binds it, and every consumer of
-          // this result is outside that declaration. Saying nothing is the correct answer; see
-          // getFQNsFromSurroundingContextType for the same principle applied to contexts.
+          // needs. So, doing nothing is the right behavior.
           if (unsolvedMethodAlternates.isOwnTypeVariable(returnType)) {
             continue;
           }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterfaceAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterfaceAlternates.java
@@ -10,6 +10,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
+import org.checkerframework.specimin.JavaLangUtils;
 import org.checkerframework.specimin.JavaParserUtil;
 
 /**
@@ -264,8 +265,7 @@ public class UnsolvedClassOrInterfaceAlternates
           continue;
         }
       }
-      if (superType.equals(SolvedMemberType.JAVA_LANG_OBJECT)) {
-        // If the super type is java.lang.Object, we don't need to add it
+      if (shouldNotBeNamedAsASuperType(superType)) {
         continue;
       }
 
@@ -286,6 +286,41 @@ public class UnsolvedClassOrInterfaceAlternates
   }
 
   /**
+   * Returns whether the given type should be left out of the {@code extends} or {@code implements}
+   * clause of a generated class, either because naming it could not compile or because naming it
+   * would say nothing.
+   *
+   * <p>Only {@link SolvedMemberType}s are ever rejected, because Specimin controls all {@link
+   * UnsolvedMemberType}s. By constrast, nothing will be generated for a {@link SolvedMemberType},
+   * so this method rejects them if they have any of these three kinds of names:
+   *
+   * <ul>
+   *   <li>An unqualified name, which is probably a type variable belonging to some other
+   *       declaration. A class declaration is not in the scope of any method's type parameters, so
+   *       naming one here cannot compile. This is a heuristic, because it might also reject names
+   *       in the default package.
+   *   <li>A final JDK class, which nothing is permitted to extend.
+   *   <li>{@code java.lang.Object}, which every class already extends implicitly.
+   * </ul>
+   *
+   * <p>Dropping a supertype only leaves the generated class less constrained, which is always safe,
+   * whereas naming either of the former two is never safe. This is intended as a defensive
+   * backstop: callers are expected not to offer such a type in the first place.
+   *
+   * @param superType The candidate super type
+   * @return true if the type should not be named as a super type
+   */
+  private static boolean shouldNotBeNamedAsASuperType(MemberType superType) {
+    if (!(superType instanceof SolvedMemberType)) {
+      return false;
+    }
+
+    return superType.equals(SolvedMemberType.JAVA_LANG_OBJECT)
+        || SpeciminGenerationUtils.isATypeVariable(superType)
+        || superType.getFullyQualifiedNames().stream().anyMatch(JavaLangUtils::isFinalJdkClass);
+  }
+
+  /**
    * Forces a super class relationship for this type.
    *
    * @param superClass The super class to force
@@ -297,7 +332,7 @@ public class UnsolvedClassOrInterfaceAlternates
 
     if ((superClass instanceof UnsolvedMemberType unsolved
             && unsolved.getUnsolvedType().equals(this))
-        || superClass.equals(SolvedMemberType.JAVA_LANG_OBJECT)) {
+        || shouldNotBeNamedAsASuperType(superClass)) {
       return;
     }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -346,6 +346,35 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
   }
 
   /**
+   * Returns whether the given type is one of the type variables bound by this method's own
+   * declaration (i.e. a name introduced by this method, such as the {@code T} in {@code <T> T
+   * get()}).
+   *
+   * <p>Such a name is only meaningful inside the declaration that binds it. Callers that are about
+   * to use a type outside of that declaration -- for example, to describe the type of an expression
+   * at a call site -- must not use the name, because it is not in scope there.
+   *
+   * @param type The type to check
+   * @return true if the type is a type variable bound by this method
+   */
+  public boolean isOwnTypeVariable(MemberType type) {
+    Set<String> fqns = type.getFullyQualifiedNames();
+    if (fqns.size() != 1 || !type.getTypeArguments().isEmpty()) {
+      return false;
+    }
+
+    String name = fqns.iterator().next();
+    for (UnsolvedMethod alternate : getAlternates()) {
+      for (int i = 0; i < alternate.getNumberOfTypeVariables(); i++) {
+        if (alternate.getTypeVariableName(i).equals(name)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
    * Gets the return types
    *
    * @return The return types

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -3192,11 +3192,13 @@ public class UnsolvedSymbolGenerator {
             fullyQualifiedNameGenerator.getFQNsForExpressionType(operand));
 
     if (operandTypes.isEmpty()) {
-      throw new RuntimeException(
-          "Unsolved "
-              + kind
-              + " operand when all unsolved symbols should be generated: "
-              + operand);
+      // No information about the operand's type. This happens when the operand's type is
+      // unconstrained -- for example, a call to a synthetic method whose return type is one of its
+      // own type variables, which can be instantiated to anything the context needs. There is
+      // nothing to make the synthetic type a subtype of, and nothing needs to be: the type
+      // variable is instantiated to the synthetic type at this site, which makes the cast or
+      // instanceof legal on its own.
+      return;
     }
 
     // Nothing can be made a subtype of a final class. Note that these are the types Specimin

--- a/src/test/java/org/checkerframework/specimin/DanglingUnconstrainedReturnTypeTest.java
+++ b/src/test/java/org/checkerframework/specimin/DanglingUnconstrainedReturnTypeTest.java
@@ -1,0 +1,22 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Checks that Specimin produces a compilable output when a synthetic type is used both as the
+ * supertype of another synthetic type (via a cast) and as the return type of a synthetic method
+ * whose result is assigned to a variable whose type is a final class. The latter makes the method's
+ * return type unconstrained, and the supertype relationship must not be dragged along when that
+ * happens: an {@code extends} clause naming a method type variable is not in scope at the class
+ * declaration, and so does not compile.
+ */
+public class DanglingUnconstrainedReturnTypeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "danglingunconstrainedreturntype",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/UnconstrainedReturnInGenericClassTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnconstrainedReturnInGenericClassTest.java
@@ -1,0 +1,29 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A variant of {@link DanglingUnconstrainedReturnTypeTest} in which the synthetic method's
+ * declaring type is generic, so that the class and the method each have a type variable.
+ *
+ * <p>Specimin names class and method type variables from the same sequence ({@code T}, {@code T1},
+ * ...), so both are called {@code T} here, and the method's {@code T} shadows the class's. That is
+ * why {@code UnsolvedMethodAlternates#isOwnTypeVariable}, which distinguishes a method's own type
+ * variables by name, reads the return type as the method's own: under shadowing that is the correct
+ * reading, because a method's type parameter hides the class's throughout the method's signature.
+ *
+ * <p>This test exists to catch a future change that makes that no longer true. If the two kinds of
+ * type variable are ever given separate namespaces, or a class type variable can otherwise reach a
+ * method's return type without shadowing, the name comparison would no longer be sound and this
+ * fixture's output would change.
+ */
+public class UnconstrainedReturnInGenericClassTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unconstrainedreturningenericclass",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo<Baz>)"});
+  }
+}

--- a/src/test/resources/danglingunconstrainedreturntype/expected/com/example/Simple.java
+++ b/src/test/resources/danglingunconstrainedreturntype/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+
+  public void target(Foo f) {
+    Baz b = (Baz) f.get();
+    String s = f.get();
+    System.out.println(b + s);
+  }
+}

--- a/src/test/resources/danglingunconstrainedreturntype/expected/org/example/Baz.java
+++ b/src/test/resources/danglingunconstrainedreturntype/expected/org/example/Baz.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Baz {
+}

--- a/src/test/resources/danglingunconstrainedreturntype/expected/org/example/Foo.java
+++ b/src/test/resources/danglingunconstrainedreturntype/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Foo {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/danglingunconstrainedreturntype/input/com/example/Simple.java
+++ b/src/test/resources/danglingunconstrainedreturntype/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+  public void target(Foo f) {
+    Baz b = (Baz) f.get();
+    String s = f.get();
+    System.out.println(b + s);
+  }
+}

--- a/src/test/resources/unconstrainedreturningenericclass/expected/com/example/Simple.java
+++ b/src/test/resources/unconstrainedreturningenericclass/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+
+  public void target(Foo<Baz> f) {
+    Baz b = (Baz) f.get();
+    String s = f.get();
+    System.out.println(b + s);
+  }
+}

--- a/src/test/resources/unconstrainedreturningenericclass/expected/org/example/Baz.java
+++ b/src/test/resources/unconstrainedreturningenericclass/expected/org/example/Baz.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Baz {
+}

--- a/src/test/resources/unconstrainedreturningenericclass/expected/org/example/Foo.java
+++ b/src/test/resources/unconstrainedreturningenericclass/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Foo<T> {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/unconstrainedreturningenericclass/input/com/example/Simple.java
+++ b/src/test/resources/unconstrainedreturningenericclass/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+  public void target(Foo<Baz> f) {
+    Baz b = (Baz) f.get();
+    String s = f.get();
+    System.out.println(b + s);
+  }
+}


### PR DESCRIPTION
The key change is in `FullyQualifiedNameGenerator.getExpressionTypesIfRepresentsGenerated`: when a return type is the method's own type variable and nothing in the type-parameter usage map resolves it (`get()` takes no arguments, call supplies no type arguments), it fell through to `convertMemberTypeToFQNSet(T)`. A method type variable is only meaningful inside the declaration that binds it; here it escaped to _every_ consumer of that call's type. The cast in the test case was just the first consumer to make it visible.

I also added a defensive "backstop" method to heuristically guard against similar defects of this kind (`shouldNotBeNamedAsASuperType`). This refactoring also simplified some of its callers and united their logic for final JDK classes (which was missing on one path) and for handling java.lang.Object as a supertype.