### PR TITLE
More precise heuristic for what counts as part of the JDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,10 @@ application {
     mainClass = "org.checkerframework.specimin.SpeciminRunner"
 }
 
-// Pin the JDK, matching CI. This is not only for reproducible compilation: Specimin asks the JDK it
-// is running under which packages the JDK provides (JavaLangUtils#inJdkPackage), so the JDK version
-// is an input to Specimin's output, and an unpinned one would let expected test outputs differ
-// between a contributor's machine and CI. CI uses Amazon Corretto, but the vendor is deliberately
-// not pinned: the package set is a property of the Java version, and requiring one vendor's build
-// would fail for contributors who have a different build of 17. This applies to every project,
+// Pin the JDK version. This is not only for reproducible compilation: Specimin uses the JDK it
+// is running under to decide which packages are part of the JDK, so the JDK version
+// is an input to Specimin and an unpinned one would let expected test outputs differ
+// between a contributor's machine and CI. This applies to every project,
 // since error-prone-checks produces a plugin that this project's compiler has to load.
 allprojects {
     plugins.withType(JavaPlugin).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,23 @@ application {
     mainClass = "org.checkerframework.specimin.SpeciminRunner"
 }
 
+// Pin the JDK, matching CI. This is not only for reproducible compilation: Specimin asks the JDK it
+// is running under which packages the JDK provides (JavaLangUtils#inJdkPackage), so the JDK version
+// is an input to Specimin's output, and an unpinned one would let expected test outputs differ
+// between a contributor's machine and CI. CI uses Amazon Corretto, but the vendor is deliberately
+// not pinned: the package set is a property of the Java version, and requiring one vendor's build
+// would fail for contributors who have a different build of 17. This applies to every project,
+// since error-prone-checks produces a plugin that this project's compiler has to load.
+allprojects {
+    plugins.withType(JavaPlugin).configureEach {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(17)
+            }
+        }
+    }
+}
+
 dependencies {
 
     implementation("com.github.javaparser:javaparser-symbol-solver-core:3.28.2")

--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -1,5 +1,7 @@
 package org.checkerframework.specimin;
 
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -374,22 +376,69 @@ public final class JavaLangUtils {
   }
 
   /**
+   * Every package in the JDK that Specimin is running under, including packages that their module
+   * does not export (such as jdk.internal.misc): Specimin deliberately permits access to compiler
+   * internals, so the unexported packages need to be here too.
+   *
+   * <p>This is computed from the JDK's own module descriptors rather than hard-coded, because a
+   * hard-coded table describes a JDK that Specimin may not be running under, and only the running
+   * JDK's classes can actually be read. See {@link #inJdkPackage} for why that distinction matters.
+   */
+  private static final Set<String> jdkPackages = computeJdkPackages();
+
+  /**
+   * Computes the set of package names provided by the JDK that Specimin is running under. This
+   * reads module descriptors only; it neither loads nor initializes any class.
+   *
+   * @return an unmodifiable set of the JDK's package names
+   */
+  private static Set<String> computeJdkPackages() {
+    Set<String> result = new HashSet<>();
+    for (ModuleReference module : ModuleFinder.ofSystem().findAll()) {
+      result.addAll(module.descriptor().packages());
+    }
+    return Collections.unmodifiableSet(result);
+  }
+
+  /**
    * Is the given package name or fully-qualified name in one of the packages provided by the JDK?
+   *
+   * <p>"The JDK" means the JDK that Specimin is currently running under, not any JDK. That is
+   * deliberate: this predicate gates {@link JdkTypeSolver}, which resolves types reflectively
+   * against the running JDK, so answering for some other JDK version would promise a class that
+   * cannot then be read. Getting the answer wrong in either direction is safe, because a false
+   * answer only causes Specimin to synthesize the type, which costs minimality but still compiles;
+   * a false true would claim a type exists that Specimin cannot read a single member from, and the
+   * output would not compile. Compare the packages removed from the JDK in version 11
+   * (javax.xml.bind, javax.annotation, and friends), which are now supplied by ordinary
+   * dependencies and so must be synthesized.
+   *
+   * <p>The granularity here is the package, not the class, so a class that does not exist in an
+   * otherwise-real JDK package (say, a javax.swing.NotARealClass arriving from a split package) is
+   * still reported as being in the JDK. If that imprecision ever matters, the fix is to enumerate
+   * classes instead of packages: open each {@code ModuleReference} from {@link
+   * ModuleFinder#ofSystem} and {@code list()} its ".class" entries. That is a one-time cost of tens
+   * of thousands of strings rather than the few hundred package names here, which is why it is not
+   * done unless it is needed.
    *
    * @param qualifiedName a package name or fully-qualified name of a class or interface
    * @return true if qualifiedName is from the JDK
    */
   public static boolean inJdkPackage(String qualifiedName) {
-    // TODO: can we get a list of such packages from the JDK instead of using this relatively-coarse
-    // heuristic?
-    if (qualifiedName.startsWith("javax.annotation")) {
-      return false;
+    // The input may name a package, a class, or a nested class, so every prefix is a candidate
+    // package name. Checking longest-first means a class in a JDK package matches on the prefix
+    // that drops its own simple name.
+    String candidate = qualifiedName;
+    while (true) {
+      if (jdkPackages.contains(candidate)) {
+        return true;
+      }
+      int lastDot = candidate.lastIndexOf('.');
+      if (lastDot == -1) {
+        return false;
+      }
+      candidate = candidate.substring(0, lastDot);
     }
-
-    return qualifiedName.startsWith("java.")
-        || qualifiedName.startsWith("javax.")
-        || qualifiedName.startsWith("com.sun.")
-        || qualifiedName.startsWith("jdk.");
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -410,7 +410,7 @@ public final class JavaLangUtils {
    * dependencies and so must be synthesized.
    *
    * <p>The check here is by package, not by class, so a class that does not exist in an
-   * otherwise-real JDK package (say, a javax.swing.NotARealClass) wo;; still be reported as being
+   * otherwise-real JDK package (say, a javax.swing.NotARealClass) would still be reported as being
    * in the JDK. If that imprecision ever matters, we could enumerate classes instead of packages:
    * open each {@code ModuleReference} from {@link ModuleFinder#ofSystem} and {@code list()} its
    * ".class" entries. I chose to implement this with packages to 1) keep this API broad (it accepts

--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -379,10 +379,6 @@ public final class JavaLangUtils {
    * Every package in the JDK that Specimin is running under, including packages that their module
    * does not export (such as jdk.internal.misc): Specimin deliberately permits access to compiler
    * internals, so the unexported packages need to be here too.
-   *
-   * <p>This is computed from the JDK's own module descriptors rather than hard-coded, because a
-   * hard-coded table describes a JDK that Specimin may not be running under, and only the running
-   * JDK's classes can actually be read. See {@link #inJdkPackage} for why that distinction matters.
    */
   private static final Set<String> jdkPackages = computeJdkPackages();
 
@@ -413,13 +409,12 @@ public final class JavaLangUtils {
    * (javax.xml.bind, javax.annotation, and friends), which are now supplied by ordinary
    * dependencies and so must be synthesized.
    *
-   * <p>The granularity here is the package, not the class, so a class that does not exist in an
-   * otherwise-real JDK package (say, a javax.swing.NotARealClass arriving from a split package) is
-   * still reported as being in the JDK. If that imprecision ever matters, the fix is to enumerate
-   * classes instead of packages: open each {@code ModuleReference} from {@link
-   * ModuleFinder#ofSystem} and {@code list()} its ".class" entries. That is a one-time cost of tens
-   * of thousands of strings rather than the few hundred package names here, which is why it is not
-   * done unless it is needed.
+   * <p>The check here is by package, not by class, so a class that does not exist in an
+   * otherwise-real JDK package (say, a javax.swing.NotARealClass) wo;; still be reported as being
+   * in the JDK. If that imprecision ever matters, we could enumerate classes instead of packages:
+   * open each {@code ModuleReference} from {@link ModuleFinder#ofSystem} and {@code list()} its
+   * ".class" entries. I chose to implement this with packages to 1) keep this API broad (it accepts
+   * both package and class names as input) and 2) to avoid wasting compute in the common case.
    *
    * @param qualifiedName a package name or fully-qualified name of a class or interface
    * @return true if qualifiedName is from the JDK

--- a/src/test/java/org/checkerframework/specimin/JavaxStaticMethodTest.java
+++ b/src/test/java/org/checkerframework/specimin/JavaxStaticMethodTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Checks that Specimin synthesizes a static method (and the class that its result is chained
+ * against) when the receiver class is unsolved and lives in a package whose name begins with
+ * "javax.". Such packages are not necessarily part of the JDK: javax.ws.rs.core, used here, comes
+ * from JAX-RS.
+ */
+public class JavaxStaticMethodTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "javaxstaticmethod",
+        new String[] {"org/example/Target.java"},
+        new String[] {"org.example.Target#target()"});
+  }
+}

--- a/src/test/resources/javaxstaticmethod/expected/javax/ws/rs/core/JavaxWsRsCoreResponseOkReturnType.java
+++ b/src/test/resources/javaxstaticmethod/expected/javax/ws/rs/core/JavaxWsRsCoreResponseOkReturnType.java
@@ -1,0 +1,8 @@
+package javax.ws.rs.core;
+
+public class JavaxWsRsCoreResponseOkReturnType {
+
+    public javax.ws.rs.core.Response build() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/javaxstaticmethod/expected/javax/ws/rs/core/Response.java
+++ b/src/test/resources/javaxstaticmethod/expected/javax/ws/rs/core/Response.java
@@ -1,0 +1,8 @@
+package javax.ws.rs.core;
+
+public class Response {
+
+    public static javax.ws.rs.core.JavaxWsRsCoreResponseOkReturnType ok(java.lang.String parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/javaxstaticmethod/expected/org/example/Target.java
+++ b/src/test/resources/javaxstaticmethod/expected/org/example/Target.java
@@ -1,0 +1,10 @@
+package org.example;
+
+import javax.ws.rs.core.Response;
+
+public class Target {
+
+    public Response target() {
+        return Response.ok("body").build();
+    }
+}

--- a/src/test/resources/javaxstaticmethod/input/org/example/Target.java
+++ b/src/test/resources/javaxstaticmethod/input/org/example/Target.java
@@ -1,0 +1,9 @@
+package org.example;
+
+import javax.ws.rs.core.Response;
+
+public class Target {
+  public Response target() {
+    return Response.ok("body").build();
+  }
+}


### PR DESCRIPTION
Fixes #494. Specimin already got the right output for input of that shape in the general case, but in the specific case in question a heuristic for "in the JDK" was triggered incorrectly for code that wasn't actually part of the JDK, causing the miscompilation bug.