### PR TITLE
Regression test for #495

### DIFF
--- a/src/test/java/org/checkerframework/specimin/AnnotatedParamTypeTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotatedParamTypeTest.java
@@ -1,0 +1,28 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that when a target method's parameter has both an unsolvable annotation and an
+ * unsolvable type, Specimin generates a synthetic class for the parameter's type as well as for the
+ * annotation.
+ *
+ * <p>This is a regression test for https://github.com/njit-jerse/specimin/issues/495. The
+ * annotation was a red herring: the bug was that {@code javax.ws.rs.core.UriInfo} was treated as
+ * part of the JDK (because of a {@code startsWith("javax.")} heuristic) and so was never
+ * synthesized, while the annotation was synthesized on a code path that does not consult that
+ * heuristic. The fix for https://github.com/njit-jerse/specimin/issues/494 (PR #498) replaced the
+ * heuristic with the real package list of the running JDK, which also fixed this input.
+ */
+public class AnnotatedParamTypeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTest(
+        "annotatedparamtype",
+        new String[] {"org/example/Target.java"},
+        new String[] {"org.example.Target#target(UriInfo)"},
+        "cf",
+        new String[] {});
+  }
+}

--- a/src/test/resources/annotatedparamtype/expected/javax/ws/rs/core/Context.java
+++ b/src/test/resources/annotatedparamtype/expected/javax/ws/rs/core/Context.java
@@ -1,0 +1,4 @@
+package javax.ws.rs.core;
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
+public @interface Context {
+}

--- a/src/test/resources/annotatedparamtype/expected/javax/ws/rs/core/UriInfo.java
+++ b/src/test/resources/annotatedparamtype/expected/javax/ws/rs/core/UriInfo.java
@@ -1,0 +1,3 @@
+package javax.ws.rs.core;
+public class UriInfo {
+}

--- a/src/test/resources/annotatedparamtype/expected/org/example/Target.java
+++ b/src/test/resources/annotatedparamtype/expected/org/example/Target.java
@@ -1,0 +1,9 @@
+package org.example;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+public class Target {
+
+  public void target(@Context UriInfo unused) {}
+}

--- a/src/test/resources/annotatedparamtype/input/org/example/Target.java
+++ b/src/test/resources/annotatedparamtype/input/org/example/Target.java
@@ -1,0 +1,8 @@
+package org.example;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+public class Target {
+  public void target(@Context UriInfo unused) {}
+}


### PR DESCRIPTION
#495 was fixed by the change in #498, too, since it had the same root cause. This PR just contains a test case to demonstrate that.