### PR TITLE
Several related fixes to method reference handling

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -58,11 +58,13 @@ import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclar
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration.Bound;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
+import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedLambdaConstraintType;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.resolution.types.ResolvedWildcard;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFactory;
 import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionFieldDeclaration;
 import com.github.javaparser.symbolsolver.reflectionmodel.ReflectionMethodDeclaration;
 import com.github.javaparser.utils.Pair;
@@ -2888,6 +2890,93 @@ public class JavaParserUtil {
     return methodDeclaringType.asReferenceType().getAllMethods().stream()
         .filter(method -> method.getName().equals(methodName))
         .toList();
+  }
+
+  /**
+   * Returns the variable that the scope of the given method reference names, or null if the scope
+   * does not name a variable.
+   *
+   * <p>JavaParser parses the scope of a method reference whose scope is a bare name -- the {@code
+   * g} in {@code g::mref} -- as a {@link com.github.javaparser.ast.expr.TypeExpr}, because the
+   * grammar cannot tell a type name from an expression name in that position. JLS 15.13 resolves
+   * the ambiguity in favor of a variable whenever one of that name is in scope, and only calls the
+   * name a type when no such variable exists. Code that would otherwise read a {@code TypeExpr}
+   * scope as a type name must therefore consult this method first; see {@link
+   * #methodRefHasTypeScope(MethodReferenceExpr)}.
+   *
+   * @param methodRef The method reference
+   * @return The variable named by the method reference's scope, or null if the scope names a type
+   */
+  public static @Nullable ResolvedValueDeclaration getMethodRefScopeAsVariable(
+      MethodReferenceExpr methodRef) {
+    Expression scope = methodRef.getScope();
+
+    if (!scope.isTypeExpr() || !scope.asTypeExpr().getType().isClassOrInterfaceType()) {
+      // A scope that is not a TypeExpr is already unambiguously a value expression.
+      return null;
+    }
+
+    ClassOrInterfaceType asClassOrInterface = scope.asTypeExpr().getType().asClassOrInterfaceType();
+
+    if (asClassOrInterface.getScope().isPresent()
+        || asClassOrInterface.getTypeArguments().isPresent()) {
+      // A qualified name or an explicitly parameterized name is unambiguously a type.
+      return null;
+    }
+
+    try {
+      SymbolReference<? extends ResolvedValueDeclaration> symbol =
+          JavaParserFactory.getContext(methodRef, getTypeSolvers().getTypeSolver())
+              .solveSymbol(asClassOrInterface.getNameAsString());
+
+      return symbol.isSolved() ? symbol.getCorrespondingDeclaration() : null;
+    } catch (RuntimeException ex) {
+      // The symbol solver throws when some enclosing scope is itself unsolvable. "No variable of
+      // this name is in scope" is the answer that leaves the scope being read as a type, which is
+      // both the JLS's answer when no such variable exists and the behavior Specimin had before
+      // this method existed, so it is the safe result when the lookup cannot be completed.
+      return null;
+    }
+  }
+
+  /**
+   * If the given expression is the scope of a method reference and that scope names a variable
+   * rather than a type, returns the variable's declared type. Returns null otherwise. See {@link
+   * #getMethodRefScopeAsVariable(MethodReferenceExpr)} for why a scope that names a variable can
+   * nonetheless be a {@code TypeExpr}.
+   *
+   * @param expr The expression
+   * @param fqnToCompilationUnits The map of FQNs to compilation units
+   * @return The declared type of the variable the expression names, or null if it names a type
+   */
+  public static @Nullable Type getTypeIfMethodRefScopeNamesVariable(
+      Expression expr, Map<String, CompilationUnit> fqnToCompilationUnits) {
+    if (!(expr.getParentNode().orElse(null) instanceof MethodReferenceExpr methodRef)) {
+      return null;
+    }
+
+    ResolvedValueDeclaration variable = getMethodRefScopeAsVariable(methodRef);
+
+    return variable == null
+        ? null
+        : getTypeFromResolvedValueDeclaration(variable, fqnToCompilationUnits);
+  }
+
+  /**
+   * Returns whether the scope of the given method reference is a type rather than a value, i.e.
+   * whether the reference is an unbound one like {@code Foo::mref} rather than a bound one like
+   * {@code g::mref}. The functional interface of an unbound reference to an instance method takes
+   * the receiver as an extra leading parameter, so the two forms cannot be treated alike.
+   *
+   * <p>This is not the same question as whether the scope is a {@link
+   * com.github.javaparser.ast.expr.TypeExpr}: JavaParser gives a bare-name scope a {@code TypeExpr}
+   * either way. See {@link #getMethodRefScopeAsVariable(MethodReferenceExpr)}.
+   *
+   * @param methodRef The method reference
+   * @return True iff the method reference's scope names a type
+   */
+  public static boolean methodRefHasTypeScope(MethodReferenceExpr methodRef) {
+    return methodRef.getScope().isTypeExpr() && getMethodRefScopeAsVariable(methodRef) == null;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/Resolver.java
+++ b/src/main/java/org/checkerframework/specimin/Resolver.java
@@ -381,9 +381,15 @@ public class Resolver {
           JavaParserUtil.getMethodDeclarationsFromMethodRef(methodRef);
 
       // With more than one candidate the target functional interface would be needed to choose
-      // between the overloads, which is exactly what is unavailable here. Returning null in that
-      // case (and when the scope's type is itself unsolvable, which gives no candidates) makes
-      // the caller synthesize a symbol for the reference instead.
+      // between the overloads, and that is exactly what is unavailable here. Returning null (as
+      // when the scope's type is unsolvable and there are no candidates at all) leaves the caller
+      // to preserve every candidate; see Slicer#preserveAmbiguousMethodRefCandidates.
+      //
+      // Note that for a constructor reference this returns a ResolvedConstructorDeclaration, even
+      // though MethodReferenceExpr is declared as Resolvable<ResolvedMethodDeclaration>. Every
+      // consumer of a resolved node takes it as an Object and dispatches on its runtime type, so
+      // the wider return type is safe; do not narrow a resolved value to ResolvedMethodDeclaration
+      // without checking it first.
       return candidates.size() == 1 ? candidates.get(0) : null;
     }
 

--- a/src/main/java/org/checkerframework/specimin/Resolver.java
+++ b/src/main/java/org/checkerframework/specimin/Resolver.java
@@ -8,6 +8,7 @@ import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.resolution.MethodAmbiguityException;
@@ -16,6 +17,7 @@ import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
@@ -350,19 +352,39 @@ public class Resolver {
 
   /**
    * Handles an UnsupportedOperationException thrown by JavaParser when resolving a method call
-   * referring to a known annotation member declaration.
+   * referring to a known annotation member declaration, or a method reference whose target
+   * functional interface JavaParser cannot determine.
    *
    * @param ex The exception
    * @param node The node
-   * @return The resolved annotation member declaration
+   * @return The resolved declaration, or null if the node is a method reference that should be
+   *     handled by synthesizing an unsolved symbol instead
    * @throws UnsupportedOperationException when the UnsupportedOperationException comes from an
    *     issue Specimin does not know how to address
    */
-  private static ResolvedAnnotationMemberDeclaration handleUnsupportedOperationException(
+  private static @Nullable Object handleUnsupportedOperationException(
       UnsupportedOperationException ex, Node node) throws UnsupportedOperationException {
     if (fqnToCompilationUnits == null) {
       throw new UnsupportedOperationException(
           "fqnToCompilationUnits must be set before calling handleUnsupportedOperationException");
+    }
+
+    // JavaParser bug: MethodReferenceExprContext#inferArgumentTypes only knows how to find the
+    // target functional interface of a method reference when the reference's parent node is a
+    // method call, an object creation, a variable declarator, or a return statement. For every
+    // other parent -- a cast, for instance -- it throws a bare UnsupportedOperationException,
+    // and constructor references always throw regardless of the parent. Specimin does not need
+    // the target functional interface to find the referenced method, though: the scope's type
+    // determines it, so resolve it from the scope instead.
+    if (node instanceof MethodReferenceExpr methodRef) {
+      List<? extends ResolvedMethodLikeDeclaration> candidates =
+          JavaParserUtil.getMethodDeclarationsFromMethodRef(methodRef);
+
+      // With more than one candidate the target functional interface would be needed to choose
+      // between the overloads, which is exactly what is unavailable here. Returning null in that
+      // case (and when the scope's type is itself unsolvable, which gives no candidates) makes
+      // the caller synthesize a symbol for the reference instead.
+      return candidates.size() == 1 ? candidates.get(0) : null;
     }
 
     // JavaParser bug: cannot resolve a method if in an annotation declaration

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -263,6 +263,11 @@ public class Slicer {
       if (resolved != null) {
         generateUnsolvedSymbol = handleResolvedObject(node, resolved);
       } else if (node instanceof MethodReferenceExpr methodRef) {
+        // Deliberately leaves generateUnsolvedSymbol set: preserving candidates and generating
+        // are not alternatives here. Generation still has to run to synthesize the reference's
+        // target functional interface when that interface is the unsolved part, and it cannot
+        // duplicate what was just preserved, because it synthesizes the referenced method only
+        // when there are no candidates -- the same emptiness check this branch preserves on.
         preserveAmbiguousMethodRefCandidates(methodRef);
       }
 

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -18,6 +18,7 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -27,6 +28,7 @@ import com.github.javaparser.ast.type.UnknownType;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
@@ -260,6 +262,8 @@ public class Slicer {
 
       if (resolved != null) {
         generateUnsolvedSymbol = handleResolvedObject(node, resolved);
+      } else if (node instanceof MethodReferenceExpr methodRef) {
+        preserveAmbiguousMethodRefCandidates(methodRef);
       }
 
       if (generateUnsolvedSymbol) {
@@ -272,6 +276,26 @@ public class Slicer {
 
     if (unsolvedSymbolGenerator.needToPostProcess(node)) {
       postProcessingWorklist.add(node);
+    }
+  }
+
+  /**
+   * Preserves every declaration that an unresolvable method reference could be referring to.
+   *
+   * <p>A method reference can fail to resolve while its scope's type is perfectly solvable, if the
+   * reference names an overloaded method or a class with several constructors: telling the
+   * overloads apart needs the target functional interface, which is not always available. Those
+   * candidates would otherwise be dropped on both sides at once -- nothing preserves them, because
+   * resolution failed, and nothing synthesizes a replacement either, because a reference with
+   * candidates is not an unsolved symbol -- and the reference in the output would have nothing to
+   * bind to. Preserving all of them is a conservative over-approximation.
+   *
+   * @param methodRef The method reference that could not be resolved
+   */
+  private void preserveAmbiguousMethodRefCandidates(MethodReferenceExpr methodRef) {
+    for (ResolvedMethodLikeDeclaration candidate :
+        JavaParserUtil.getMethodDeclarationsFromMethodRef(methodRef)) {
+      handleResolvedObject(methodRef, candidate);
     }
   }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -561,7 +561,13 @@ public class FullyQualifiedNameGenerator {
     }
     // Special wrapper for method reference scopes
     else if (expr.isTypeExpr()) {
-      return Set.of(getFQNsFromType(expr.asTypeExpr().getType()));
+      Type variableType =
+          JavaParserUtil.getTypeIfMethodRefScopeNamesVariable(expr, fqnToCompilationUnits);
+
+      // A TypeExpr that actually names a variable has the variable's type, not the type that
+      // shares the variable's name (which usually does not exist at all).
+      return Set.of(
+          getFQNsFromType(variableType != null ? variableType : expr.asTypeExpr().getType()));
     }
     // cast expression
     else if (expr.isCastExpr()) {
@@ -991,7 +997,7 @@ public class FullyQualifiedNameGenerator {
           for (UnsolvedMethod alternate : method.getAlternates()) {
             List<FullyQualifiedNameSet> parameterTypes = new ArrayList<>();
 
-            if (!method.isStatic() && methodRef.getScope().isTypeExpr()) {
+            if (!method.isStatic() && JavaParserUtil.methodRefHasTypeScope(methodRef)) {
               parameterTypes.add(getFQNsFromType(methodRef.getScope().asTypeExpr().getType()));
             }
 
@@ -1362,7 +1368,7 @@ public class FullyQualifiedNameGenerator {
                 .substring(method.getKey().indexOf('(') + 1, method.getKey().lastIndexOf(')'));
         List<FullyQualifiedNameSet> paramList = new ArrayList<>();
 
-        if (methodRef.getScope().isTypeExpr()) {
+        if (JavaParserUtil.methodRefHasTypeScope(methodRef)) {
           FullyQualifiedNameSet nonWildcard =
               getFQNsFromType(methodRef.getScope().asTypeExpr().getType());
           paramList.add(
@@ -1426,7 +1432,7 @@ public class FullyQualifiedNameGenerator {
       MethodReferenceExpr methodRef, ResolvedMethodLikeDeclaration resolved) {
     List<FullyQualifiedNameSet> parameters = new ArrayList<>();
 
-    if (methodRef.getScope().isTypeExpr()
+    if (JavaParserUtil.methodRefHasTypeScope(methodRef)
         // Yes, resolved.isMethod() and asMethod() exist, but JavaParser never implemented those
         && resolved instanceof ResolvedMethodDeclaration resolvedMethodDecl
         && !resolvedMethodDecl.isStatic()) {

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -187,7 +187,13 @@ public class UnsolvedSymbolGenerator {
         inferContextImpl(type, result);
       }
     } else if (node instanceof TypeExpr typeExpr) {
-      inferContextImpl(typeExpr.getType(), result);
+      // A method reference scope that names a variable is a TypeExpr too, but its name is the
+      // variable's, not a type's: generating a type from that name would invent a class named
+      // after the variable. Generate the variable's declared type instead.
+      Type scopeVariableType =
+          JavaParserUtil.getTypeIfMethodRefScopeNamesVariable(typeExpr, fqnsToCompilationUnits);
+
+      inferContextImpl(scopeVariableType != null ? scopeVariableType : typeExpr.getType(), result);
     }
     // Fields (although some types are handled as FieldAccessExpr or NameExpr too)
     else if (node instanceof FieldAccessExpr asField) {
@@ -2152,7 +2158,9 @@ public class UnsolvedSymbolGenerator {
 
       boolean isStatic = false;
 
-      if (methodRef.getScope().isTypeExpr()) {
+      // A constructor is never static, and the scope of a constructor reference is never a
+      // receiver: the functional interface's parameters are the constructor's, one for one.
+      if (!isConstructor && JavaParserUtil.methodRefHasTypeScope(methodRef)) {
         if (parameters.isEmpty()) {
           isStatic = true;
         } else {

--- a/src/test/java/org/checkerframework/specimin/CtorRefSolvedTest.java
+++ b/src/test/java/org/checkerframework/specimin/CtorRefSolvedTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that a constructor reference to a type with several constructors preserves all
+ * of them.
+ *
+ * <p>JavaParser cannot resolve a constructor reference at all, so Specimin recovers by looking up
+ * the candidates on the scope's type (see {@link CtorRefUnsolvedTest}). Here that lookup is
+ * ambiguous: choosing between {@code Foo(String)} and {@code Foo()} needs the target functional
+ * interface, which is what was unavailable in the first place. Dropping the ambiguous candidates
+ * would delete both -- nothing preserves them, since resolution failed, and nothing synthesizes a
+ * replacement either, since a reference with candidates is not an unsolved symbol -- and {@code
+ * Foo::new} would have no constructor to bind to. This test requires that both candidate
+ * constructors are kept but that {@code Foo#unused()} is still pruned.
+ */
+public class CtorRefSolvedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "ctorrefsolved",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/CtorRefUnsolvedTest.java
+++ b/src/test/java/org/checkerframework/specimin/CtorRefUnsolvedTest.java
@@ -6,14 +6,6 @@ import org.junit.jupiter.api.Test;
 /**
  * This test checks that a constructor reference to an unsolved type generates a constructor in that
  * type's synthetic class.
- *
- * <p>JavaParser refuses to resolve any constructor reference at all -- {@code
- * MethodReferenceExprContext#solveMethod} throws "Constructor calls not yet resolvable" for {@code
- * ::new} regardless of context -- so before the fix for
- * https://github.com/njit-jerse/specimin/issues/479, which taught Specimin to recover from that
- * exception, this input crashed and Specimin's code for generating a constructor from a constructor
- * reference was unreachable. That code marked the generated constructor {@code static}, which does
- * not compile; this test pins the corrected output.
  */
 public class CtorRefUnsolvedTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/CtorRefUnsolvedTest.java
+++ b/src/test/java/org/checkerframework/specimin/CtorRefUnsolvedTest.java
@@ -1,0 +1,26 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that a constructor reference to an unsolved type generates a constructor in that
+ * type's synthetic class.
+ *
+ * <p>JavaParser refuses to resolve any constructor reference at all -- {@code
+ * MethodReferenceExprContext#solveMethod} throws "Constructor calls not yet resolvable" for {@code
+ * ::new} regardless of context -- so before the fix for
+ * https://github.com/njit-jerse/specimin/issues/479, which taught Specimin to recover from that
+ * exception, this input crashed and Specimin's code for generating a constructor from a constructor
+ * reference was unreachable. That code marked the generated constructor {@code static}, which does
+ * not compile; this test pins the corrected output.
+ */
+public class CtorRefUnsolvedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "ctorrefunsolved",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/MethodRefAmbiguousTest.java
+++ b/src/test/java/org/checkerframework/specimin/MethodRefAmbiguousTest.java
@@ -1,0 +1,29 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that when a method reference is ambiguous, Specimin both preserves every
+ * candidate and still synthesizes the reference's target functional interface. Here {@code
+ * Foo::mref} matches two overloads, and the interface it targets, {@code org.example.Handler}, is
+ * unsolved; the output needs all three of those symbols to compile.
+ *
+ * <p>These two jobs look mutually exclusive but are not, and the output above is what pins that:
+ * preservation happens only when the reference has candidate declarations, while synthesis of the
+ * referenced method happens only when it has none, so neither can duplicate the other's work.
+ * Synthesis of the target functional interface is a separate matter and has to run either way,
+ * which is why {@link Slicer#handleElement} leaves its {@code generateUnsolvedSymbol} flag set
+ * after preserving candidates. Clearing it there instead breaks this test, {@link
+ * MethodRefInCastTest}, {@link MethodRefUnsolvedScopeTest}, {@link CtorRefUnsolvedTest}, and {@link
+ * UnsolvedMethodReferenceWithKnownLHSTest}.
+ */
+public class MethodRefAmbiguousTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "methodrefambiguous",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/MethodRefInCastSolvedTest.java
+++ b/src/test/java/org/checkerframework/specimin/MethodRefInCastSolvedTest.java
@@ -1,0 +1,25 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that a method reference inside a cast still resolves to the real method it
+ * refers to when that method is defined in the input, rather than being replaced by a synthetic
+ * one: {@code Foo#mref()} is preserved, and {@code Foo#unused()} is pruned as usual.
+ *
+ * <p>The cast makes JavaParser throw rather than resolve the reference (see {@link
+ * MethodRefInCastTest}), so Specimin has to find the referenced method from the scope's type
+ * instead. This test covers that recovery in the case where the scope's type is solvable, which
+ * {@link MethodRefInCastTest} does not reach: there, the scope's type is unsolved, so there is no
+ * declaration to find and a synthetic method is generated instead.
+ */
+public class MethodRefInCastSolvedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "methodrefincastsolved",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/MethodRefInCastTest.java
+++ b/src/test/java/org/checkerframework/specimin/MethodRefInCastTest.java
@@ -1,0 +1,26 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that Specimin can handle a method reference that appears as the operand of a
+ * cast to a functional interface, and whose scope has an unsolved type: it must synthesize the
+ * referenced method in the synthetic class for the scope's type, using the cast's functional
+ * interface to determine the method's parameter types and voidness.
+ *
+ * <p>This is a regression test for https://github.com/njit-jerse/specimin/issues/479. JavaParser's
+ * {@code MethodReferenceExprContext#inferArgumentTypes} only knows how to find the target
+ * functional interface when the method reference's parent is a method call, an object creation, a
+ * variable declarator, or a return statement; for any other parent, including a cast, it throws an
+ * {@code UnsupportedOperationException}.
+ */
+public class MethodRefInCastTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "methodrefincast",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/MethodRefUnsolvedScopeTest.java
+++ b/src/test/java/org/checkerframework/specimin/MethodRefUnsolvedScopeTest.java
@@ -1,0 +1,28 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that a method reference whose scope is a variable of an unsolved type puts the
+ * referenced method in the synthetic class for the variable's type.
+ *
+ * <p>JavaParser parses the {@code g} in {@code g::mref} as a type name, because the grammar cannot
+ * tell a type name from an expression name in that position; JLS 15.13 says it is a variable
+ * whenever one of that name is in scope. Specimin used to take JavaParser's parse at face value and
+ * emit a class named {@code com.example.g} holding a static {@code mref()}, which does not compile,
+ * leaving {@code org.example.Foo} empty.
+ *
+ * <p>Unlike {@link MethodRefInCastTest}, the reference here is the initializer of a variable
+ * declarator, a context in which JavaParser can find the target functional interface. So this test
+ * covers the same disambiguation without the resolution crash that motivated it.
+ */
+public class MethodRefUnsolvedScopeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "methodrefunsolvedscope",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo)"});
+  }
+}

--- a/src/test/resources/ctorrefsolved/expected/com/example/Foo.java
+++ b/src/test/resources/ctorrefsolved/expected/com/example/Foo.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public class Foo {
+
+  public Foo(String s) {
+    throw new java.lang.Error();
+  }
+
+  public Foo() {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/ctorrefsolved/expected/com/example/Simple.java
+++ b/src/test/resources/ctorrefsolved/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import java.util.function.Function;
+
+public class Simple {
+
+  public void target() {
+    Function<String, Foo> mr = Foo::new;
+    System.out.println(mr);
+  }
+}

--- a/src/test/resources/ctorrefsolved/input/com/example/Foo.java
+++ b/src/test/resources/ctorrefsolved/input/com/example/Foo.java
@@ -1,0 +1,13 @@
+package com.example;
+
+public class Foo {
+  public Foo(String s) {
+    System.out.println(s);
+  }
+
+  public Foo() {
+    System.out.println("ctor");
+  }
+
+  public void unused() {}
+}

--- a/src/test/resources/ctorrefsolved/input/com/example/Simple.java
+++ b/src/test/resources/ctorrefsolved/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import java.util.function.Function;
+
+public class Simple {
+  public void target() {
+    Function<String, Foo> mr = Foo::new;
+    System.out.println(mr);
+  }
+}

--- a/src/test/resources/ctorrefunsolved/expected/com/example/Simple.java
+++ b/src/test/resources/ctorrefunsolved/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Foo;
+
+public class Simple {
+
+  public void target(Foo g) {
+    Runnable mr = Foo::new;
+    System.out.println(mr);
+  }
+}

--- a/src/test/resources/ctorrefunsolved/expected/org/example/Foo.java
+++ b/src/test/resources/ctorrefunsolved/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Foo {
+
+    public Foo() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/ctorrefunsolved/input/com/example/Simple.java
+++ b/src/test/resources/ctorrefunsolved/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Foo;
+
+public class Simple {
+  public void target(Foo g) {
+    Runnable mr = Foo::new;
+    System.out.println(mr);
+  }
+}

--- a/src/test/resources/methodrefambiguous/expected/com/example/Foo.java
+++ b/src/test/resources/methodrefambiguous/expected/com/example/Foo.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public class Foo {
+
+  public static void mref() {
+    throw new java.lang.Error();
+  }
+
+  public static void mref(int x) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/methodrefambiguous/expected/com/example/Simple.java
+++ b/src/test/resources/methodrefambiguous/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Handler;
+
+public class Simple {
+
+  public void target() {
+    Handler h = Foo::mref;
+    System.out.println(h);
+  }
+}

--- a/src/test/resources/methodrefambiguous/expected/org/example/Handler.java
+++ b/src/test/resources/methodrefambiguous/expected/org/example/Handler.java
@@ -1,0 +1,6 @@
+package org.example;
+@FunctionalInterface
+public interface Handler {
+
+    public void apply();
+}

--- a/src/test/resources/methodrefambiguous/input/com/example/Foo.java
+++ b/src/test/resources/methodrefambiguous/input/com/example/Foo.java
@@ -1,0 +1,9 @@
+package com.example;
+
+public class Foo {
+  public static void mref() {}
+
+  public static void mref(int x) {}
+
+  public void unused() {}
+}

--- a/src/test/resources/methodrefambiguous/input/com/example/Simple.java
+++ b/src/test/resources/methodrefambiguous/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Handler;
+
+public class Simple {
+  public void target() {
+    Handler h = Foo::mref;
+    System.out.println(h);
+  }
+}

--- a/src/test/resources/methodrefincast/expected/com/example/Simple.java
+++ b/src/test/resources/methodrefincast/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Foo;
+
+public class Simple {
+
+  public void target(Foo g) {
+    Runnable mr = (Runnable) g::mref;
+    System.out.println(mr);
+  }
+}

--- a/src/test/resources/methodrefincast/expected/org/example/Foo.java
+++ b/src/test/resources/methodrefincast/expected/org/example/Foo.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Foo {
+
+    public void mref() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/methodrefincast/input/com/example/Simple.java
+++ b/src/test/resources/methodrefincast/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Foo;
+
+public class Simple {
+  public void target(Foo g) {
+    Runnable mr = (Runnable) g::mref;
+    System.out.println(mr);
+  }
+}

--- a/src/test/resources/methodrefincastsolved/expected/com/example/Foo.java
+++ b/src/test/resources/methodrefincastsolved/expected/com/example/Foo.java
@@ -1,0 +1,8 @@
+package com.example;
+
+public class Foo {
+
+  public void mref() {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/methodrefincastsolved/expected/com/example/Simple.java
+++ b/src/test/resources/methodrefincastsolved/expected/com/example/Simple.java
@@ -1,0 +1,9 @@
+package com.example;
+
+public class Simple {
+
+  public void target(Foo g) {
+    Runnable mr = (Runnable) g::mref;
+    System.out.println(mr);
+  }
+}

--- a/src/test/resources/methodrefincastsolved/input/com/example/Foo.java
+++ b/src/test/resources/methodrefincastsolved/input/com/example/Foo.java
@@ -1,0 +1,9 @@
+package com.example;
+
+public class Foo {
+  public void mref() {
+    System.out.println("mref");
+  }
+
+  public void unused() {}
+}

--- a/src/test/resources/methodrefincastsolved/input/com/example/Simple.java
+++ b/src/test/resources/methodrefincastsolved/input/com/example/Simple.java
@@ -1,0 +1,8 @@
+package com.example;
+
+public class Simple {
+  public void target(Foo g) {
+    Runnable mr = (Runnable) g::mref;
+    System.out.println(mr);
+  }
+}

--- a/src/test/resources/methodrefunsolvedscope/expected/com/example/Simple.java
+++ b/src/test/resources/methodrefunsolvedscope/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Foo;
+
+public class Simple {
+
+  public void target(Foo g) {
+    Runnable mr = g::mref;
+    System.out.println(mr);
+  }
+}

--- a/src/test/resources/methodrefunsolvedscope/expected/org/example/Foo.java
+++ b/src/test/resources/methodrefunsolvedscope/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Foo {
+
+    public void mref() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/methodrefunsolvedscope/input/com/example/Simple.java
+++ b/src/test/resources/methodrefunsolvedscope/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Foo;
+
+public class Simple {
+  public void target(Foo g) {
+    Runnable mr = g::mref;
+    System.out.println(mr);
+  }
+}


### PR DESCRIPTION
Fixes #479.

This PR contains three related fixes:
* `Resolver.handleUnsupportedOperationException` rethrew for method references, so this PR adds support. JavaParser's `MethodReferenceExprContext#inferArgumentTypes` finds the target functional interface only when the reference's parent is a method call, object creation, variable declarator, or return statement; the bug was that any other parent (e.g., a cast) falls through to a bare throw.
* JavaParser parses the `g` in `g::mref` as a `TypeExpr`, because the grammar can't distinguish a type name from an expression name there. JLS 15.13 says it's a variable whenever one of that name is in scope, so we attempt to resolve the name to its declaration; if we succeed, we treat it as a variable. This change involved replacing a lot of predicates of the form `x.isTypeExpr()` in method-reference-related code with a helper method.
* Generated constructors were marked static, which was exposed by the first fix.