### PR TITLE
Fix logic for deciding whether a lambda is void- or value-compatible

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -2569,20 +2569,31 @@ public class JavaParserUtil {
    *
    * <p>Per JLS 15.27.2, a block lambda body is void-compatible iff every return statement in it is
    * a bare {@code return;}, and value-compatible iff every return statement has an expression. A
-   * body that mixes the two is not legal Java, so any one return statement of the lambda's own
-   * settles the question; a body with no return statement of its own is void.
-   *
-   * <p>Two subtleties. First, a return may be nested arbitrarily deep inside the body (inside an
-   * {@code if}, a loop, a {@code try}, etc.), so the search must be recursive. Second, a return
-   * inside a <em>nested</em> lambda, or inside a method of an anonymous or local class declared in
-   * the body, belongs to that construct rather than to this lambda. Ownership must therefore be
-   * established before a return statement is allowed to decide anything: the first return reached
-   * by the traversal is frequently one of a nested construct's.
+   * body that mixes the two is not legal Java.
    *
    * @param lambda a lambda expression whose body is a block statement
    * @return true iff the lambda's functional interface method returns void
    */
   public static boolean isVoidBlockBodyLambda(LambdaExpr lambda) {
+    // Every return statement of a legal block body is of the same kind, so the first one that
+    // belongs to this lambda settles it; a body with none of its own cannot return a value.
+    ReturnStmt ownReturn = findOwnReturnStmt(lambda);
+    return ownReturn == null || ownReturn.getExpression().isEmpty();
+  }
+
+  /**
+   * Returns the first return statement in the given lambda's block body that belongs to that
+   * lambda, or null if it has none of its own.
+   *
+   * <p>A return may be nested arbitrarily deep inside the body, so the search is recursive. It is
+   * therefore also frequent for the first return reached to belong to a nested lambda, or to a
+   * method of an anonymous or local class declared in the body; such a return belongs to that
+   * construct rather than to this lambda, and is skipped.
+   *
+   * @param lambda a lambda expression whose body is a block statement
+   * @return the first return statement belonging to {@code lambda}, or null if it has none
+   */
+  public static @Nullable ReturnStmt findOwnReturnStmt(LambdaExpr lambda) {
     for (ReturnStmt returnStmt : lambda.getBody().asBlockStmt().findAll(ReturnStmt.class)) {
       // Reference equality is intentional: we need to know whether this exact return statement
       // belongs to this lambda, not whether some structurally-equal return statement does (a
@@ -2592,13 +2603,10 @@ public class JavaParserUtil {
       @SuppressWarnings({"ReferenceEquality", "not.interned"})
       boolean belongsToThisLambda = findClosestMethodOrLambdaAncestor(returnStmt) == lambda;
       if (belongsToThisLambda) {
-        // Every return statement of a legal block body is of the same kind, so the first one
-        // that belongs to this lambda settles it.
-        return returnStmt.getExpression().isEmpty();
+        return returnStmt;
       }
     }
-    // This lambda has no return statement of its own, so its body cannot return a value.
-    return true;
+    return null;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -2564,6 +2564,44 @@ public class JavaParserUtil {
   }
 
   /**
+   * Returns true iff the given lambda expression, whose body must be a block, is void: that is, iff
+   * the method of its functional interface returns void.
+   *
+   * <p>Per JLS 15.27.2, a block lambda body is void-compatible iff every return statement in it is
+   * a bare {@code return;}, and value-compatible iff every return statement has an expression. A
+   * body that mixes the two is not legal Java, so any one return statement of the lambda's own
+   * settles the question; a body with no return statement of its own is void.
+   *
+   * <p>Two subtleties. First, a return may be nested arbitrarily deep inside the body (inside an
+   * {@code if}, a loop, a {@code try}, etc.), so the search must be recursive. Second, a return
+   * inside a <em>nested</em> lambda, or inside a method of an anonymous or local class declared in
+   * the body, belongs to that construct rather than to this lambda. Ownership must therefore be
+   * established before a return statement is allowed to decide anything: the first return reached
+   * by the traversal is frequently one of a nested construct's.
+   *
+   * @param lambda a lambda expression whose body is a block statement
+   * @return true iff the lambda's functional interface method returns void
+   */
+  public static boolean isVoidBlockBodyLambda(LambdaExpr lambda) {
+    for (ReturnStmt returnStmt : lambda.getBody().asBlockStmt().findAll(ReturnStmt.class)) {
+      // Reference equality is intentional: we need to know whether this exact return statement
+      // belongs to this lambda, not whether some structurally-equal return statement does (a
+      // nested lambda can easily contain an identical one). No interning is okay because this is
+      // a pointer-equality check.
+      // Extracted into a local variable to minimize suppression scope.
+      @SuppressWarnings({"ReferenceEquality", "not.interned"})
+      boolean belongsToThisLambda = findClosestMethodOrLambdaAncestor(returnStmt) == lambda;
+      if (belongsToThisLambda) {
+        // Every return statement of a legal block body is of the same kind, so the first one
+        // that belongs to this lambda settles it.
+        return returnStmt.getExpression().isEmpty();
+      }
+    }
+    // This lambda has no return statement of its own, so its body cannot return a value.
+    return true;
+  }
+
+  /**
    * If the given name expression is used as (or within) a case label of an enclosing switch
    * statement or switch expression, returns the selector expression of that switch. Otherwise
    * (including when the name appears in the body/statements of a switch entry, or outside of any

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -1504,9 +1504,7 @@ public class FullyQualifiedNameGenerator {
       Set<String> fqns = getFQNsForExpressionType(body).iterator().next().erasedFqns();
       isVoid = fqns.size() == 1 && fqns.iterator().next().equals("void");
     } else {
-      isVoid =
-          lambda.getBody().asBlockStmt().getStatements().stream()
-              .noneMatch(stmt -> stmt instanceof ReturnStmt);
+      isVoid = JavaParserUtil.isVoidBlockBodyLambda(lambda);
     }
 
     FullyQualifiedNameSet functionalInterface =

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2239,9 +2239,7 @@ public class UnsolvedSymbolGenerator {
               && fqns.iterator().next().erasedFqns().size() == 1
               && fqns.iterator().next().erasedFqns().iterator().next().equals("void");
     } else {
-      isVoid =
-          lambda.getBody().asBlockStmt().getStatements().stream()
-              .noneMatch(stmt -> stmt instanceof ReturnStmt);
+      isVoid = JavaParserUtil.isVoidBlockBodyLambda(lambda);
     }
 
     int arity = lambda.getParameters().size();

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2832,12 +2832,7 @@ public class UnsolvedSymbolGenerator {
           rhs = lambdaExpr.getExpressionBody().get();
 
         } else {
-          ReturnStmt returnStmt =
-              (ReturnStmt)
-                  lambdaExpr.getBody().asBlockStmt().stream()
-                      .filter(n -> n instanceof ReturnStmt)
-                      .findFirst()
-                      .orElse(null);
+          ReturnStmt returnStmt = JavaParserUtil.findOwnReturnStmt(lambdaExpr);
 
           if (returnStmt == null || returnStmt.getExpression().isEmpty()) {
             return UnsolvedGenerationResult.EMPTY;

--- a/src/test/java/org/checkerframework/specimin/LambdaBareReturnTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaBareReturnTest.java
@@ -1,0 +1,30 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A lambda whose body ends in a bare {@code return;} is void, so the synthetic functional interface
+ * for the method it is passed to must be a {@code Consumer} rather than a {@code Function}.
+ *
+ * <p>This is the converse of {@link LambdaNestedReturnTest}: both come from {@code
+ * FullyQualifiedNameGenerator#getFQNsForLambdaType} deciding voidness with {@code stmt instanceof
+ * ReturnStmt} over the lambda body's top-level statements only. That test covers a value-returning
+ * lambda misclassified as void; this one covers a void lambda misclassified as value-returning,
+ * because a {@code ReturnStmt} with no expression is counted as a return of a value. Today Specimin
+ * emits {@code Function<? extends SyntheticTypeForItem, ?>} here and the output fails to compile
+ * with "bad return type in lambda expression: missing return value".
+ *
+ * <p>A fix for the nested-return case that recurses for {@code ReturnStmt} without also checking
+ * that the statement has an expression would leave this case broken, which is why it is tested
+ * separately.
+ */
+public class LambdaBareReturnTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdabarereturn",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Wrapper)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaBareReturnTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaBareReturnTest.java
@@ -6,18 +6,6 @@ import org.junit.jupiter.api.Test;
 /**
  * A lambda whose body ends in a bare {@code return;} is void, so the synthetic functional interface
  * for the method it is passed to must be a {@code Consumer} rather than a {@code Function}.
- *
- * <p>This is the converse of {@link LambdaNestedReturnTest}: both come from {@code
- * FullyQualifiedNameGenerator#getFQNsForLambdaType} deciding voidness with {@code stmt instanceof
- * ReturnStmt} over the lambda body's top-level statements only. That test covers a value-returning
- * lambda misclassified as void; this one covers a void lambda misclassified as value-returning,
- * because a {@code ReturnStmt} with no expression is counted as a return of a value. Today Specimin
- * emits {@code Function<? extends SyntheticTypeForItem, ?>} here and the output fails to compile
- * with "bad return type in lambda expression: missing return value".
- *
- * <p>A fix for the nested-return case that recurses for {@code ReturnStmt} without also checking
- * that the statement has an expression would leave this case broken, which is why it is tested
- * separately.
  */
 public class LambdaBareReturnTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/LambdaDifferingReturnTypesTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaDifferingReturnTypesTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A lambda with several value returns of differing types, here {@code Dog} and {@code Cat}.
+ *
+ * <p>No least upper bound is computed, and none is needed: a synthetic functional interface always
+ * takes an unbounded wildcard as its return type argument, so {@code map} gets {@code Function<?
+ * extends SyntheticTypeForItem, ?>} whatever the lambda returns. That is safe rather than merely
+ * imprecise — the ground target type of {@code Function<X, ?>} is {@code Function<X, Object>}, so
+ * every return expression is assignable regardless of type.
+ *
+ * <p>This pins that behavior: deriving a return type from the return expressions instead would
+ * change this output, and would need to justify itself against the wildcard, which cannot fail to
+ * compile.
+ */
+public class LambdaDifferingReturnTypesTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdadifferingreturntypes",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Wrapper, Dog, Cat)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaNestedBareReturnTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaNestedBareReturnTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A {@code return} statement inside a lambda nested in another lambda's body belongs to the inner
+ * lambda, and must not be used to classify the outer one.
+ *
+ * <p>Here the outer lambda returns a value, so {@code map} must take a {@code Function}, but the
+ * inner {@code Runnable} ends in a bare {@code return;}. A recursive search for the outer lambda's
+ * returns reaches the inner lambda's bare return <em>first</em>, since it appears earlier in the
+ * body. Attributing it to the outer lambda would classify the outer lambda as void, giving {@code
+ * map} a {@code Consumer} parameter and producing output that fails to compile.
+ */
+public class LambdaNestedBareReturnTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdanestedbarereturn",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Wrapper)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaNestedReturnTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaNestedReturnTest.java
@@ -1,0 +1,30 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A lambda whose only {@code return} statements are nested inside an {@code if} must still be
+ * treated as returning a value, so that the synthetic functional interface for the method it is
+ * passed to is a {@code Function} rather than a {@code Consumer}.
+ *
+ * <p>This is one of the two causes of the non-compiling output reported in <a
+ * href="https://github.com/njit-jerse/specimin/issues/442">issue #442</a>. In that issue's input,
+ * two lambdas are passed to two synthetic methods in the same chained call: {@code skipUntil}'s
+ * lambda ends in a top-level {@code return} and correctly gets a {@code Function}, while {@code
+ * map}'s lambda returns from inside an if/else and incorrectly gets a {@code Consumer}. The output
+ * then fails to compile with "incompatible types: unexpected return value".
+ *
+ * <p>The cause is in {@code FullyQualifiedNameGenerator#getFQNsForLambdaType}, which decides
+ * voidness by scanning only the top-level statements of the lambda's block body for a {@code
+ * ReturnStmt}. See {@link LambdaBareReturnTest} for the converse defect at the same site.
+ */
+public class LambdaNestedReturnTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdanestedreturn",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Wrapper)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaNestedReturnTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaNestedReturnTest.java
@@ -7,17 +7,6 @@ import org.junit.jupiter.api.Test;
  * A lambda whose only {@code return} statements are nested inside an {@code if} must still be
  * treated as returning a value, so that the synthetic functional interface for the method it is
  * passed to is a {@code Function} rather than a {@code Consumer}.
- *
- * <p>This is one of the two causes of the non-compiling output reported in <a
- * href="https://github.com/njit-jerse/specimin/issues/442">issue #442</a>. In that issue's input,
- * two lambdas are passed to two synthetic methods in the same chained call: {@code skipUntil}'s
- * lambda ends in a top-level {@code return} and correctly gets a {@code Function}, while {@code
- * map}'s lambda returns from inside an if/else and incorrectly gets a {@code Consumer}. The output
- * then fails to compile with "incompatible types: unexpected return value".
- *
- * <p>The cause is in {@code FullyQualifiedNameGenerator#getFQNsForLambdaType}, which decides
- * voidness by scanning only the top-level statements of the lambda's block body for a {@code
- * ReturnStmt}. See {@link LambdaBareReturnTest} for the converse defect at the same site.
  */
 public class LambdaNestedReturnTest {
   @Test

--- a/src/test/resources/lambdabarereturn/expected/com/example/FlagReturnType.java
+++ b/src/test/resources/lambdabarereturn/expected/com/example/FlagReturnType.java
@@ -1,0 +1,3 @@
+package com.example;
+public class FlagReturnType {
+}

--- a/src/test/resources/lambdabarereturn/expected/com/example/Simple.java
+++ b/src/test/resources/lambdabarereturn/expected/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import com.example.other.Wrapper;
+
+public class Simple {
+
+  public void target(Wrapper w) {
+    w.each(
+        item -> {
+          item.flag();
+          return;
+        });
+  }
+}

--- a/src/test/resources/lambdabarereturn/expected/com/example/SyntheticTypeForItem.java
+++ b/src/test/resources/lambdabarereturn/expected/com/example/SyntheticTypeForItem.java
@@ -1,0 +1,7 @@
+package com.example;
+public class SyntheticTypeForItem {
+
+    public com.example.FlagReturnType flag() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdabarereturn/expected/com/example/other/EachReturnType.java
+++ b/src/test/resources/lambdabarereturn/expected/com/example/other/EachReturnType.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class EachReturnType {
+}

--- a/src/test/resources/lambdabarereturn/expected/com/example/other/Wrapper.java
+++ b/src/test/resources/lambdabarereturn/expected/com/example/other/Wrapper.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Wrapper {
+
+    public com.example.other.EachReturnType each(java.util.function.Consumer<? extends com.example.SyntheticTypeForItem> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdabarereturn/input/com/example/Simple.java
+++ b/src/test/resources/lambdabarereturn/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import com.example.other.Wrapper;
+
+public class Simple {
+  public void target(Wrapper w) {
+    w.each(
+        item -> {
+          item.flag();
+          return;
+        });
+  }
+}

--- a/src/test/resources/lambdadifferingreturntypes/expected/com/example/Animal.java
+++ b/src/test/resources/lambdadifferingreturntypes/expected/com/example/Animal.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Animal {}

--- a/src/test/resources/lambdadifferingreturntypes/expected/com/example/Cat.java
+++ b/src/test/resources/lambdadifferingreturntypes/expected/com/example/Cat.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Cat extends Animal {}

--- a/src/test/resources/lambdadifferingreturntypes/expected/com/example/Dog.java
+++ b/src/test/resources/lambdadifferingreturntypes/expected/com/example/Dog.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Dog extends Animal {}

--- a/src/test/resources/lambdadifferingreturntypes/expected/com/example/Simple.java
+++ b/src/test/resources/lambdadifferingreturntypes/expected/com/example/Simple.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import com.example.other.Wrapper;
+
+public class Simple {
+
+  public Object target(Wrapper w, Dog dog, Cat cat) {
+    return w.map(
+        item -> {
+          if (item.flag()) {
+            return dog;
+          }
+          return cat;
+        });
+  }
+}

--- a/src/test/resources/lambdadifferingreturntypes/expected/com/example/SyntheticTypeForItem.java
+++ b/src/test/resources/lambdadifferingreturntypes/expected/com/example/SyntheticTypeForItem.java
@@ -1,0 +1,7 @@
+package com.example;
+public class SyntheticTypeForItem {
+
+    public boolean flag() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdadifferingreturntypes/expected/com/example/other/Wrapper.java
+++ b/src/test/resources/lambdadifferingreturntypes/expected/com/example/other/Wrapper.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Wrapper {
+
+    public java.lang.Object map(java.util.function.Function<? extends com.example.SyntheticTypeForItem, ?> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdadifferingreturntypes/input/com/example/Animal.java
+++ b/src/test/resources/lambdadifferingreturntypes/input/com/example/Animal.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Animal {}

--- a/src/test/resources/lambdadifferingreturntypes/input/com/example/Cat.java
+++ b/src/test/resources/lambdadifferingreturntypes/input/com/example/Cat.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Cat extends Animal {}

--- a/src/test/resources/lambdadifferingreturntypes/input/com/example/Dog.java
+++ b/src/test/resources/lambdadifferingreturntypes/input/com/example/Dog.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Dog extends Animal {}

--- a/src/test/resources/lambdadifferingreturntypes/input/com/example/Simple.java
+++ b/src/test/resources/lambdadifferingreturntypes/input/com/example/Simple.java
@@ -1,0 +1,15 @@
+package com.example;
+
+import com.example.other.Wrapper;
+
+public class Simple {
+  public Object target(Wrapper w, Dog dog, Cat cat) {
+    return w.map(
+        item -> {
+          if (item.flag()) {
+            return dog;
+          }
+          return cat;
+        });
+  }
+}

--- a/src/test/resources/lambdanestedbarereturn/expected/com/example/FlagReturnType.java
+++ b/src/test/resources/lambdanestedbarereturn/expected/com/example/FlagReturnType.java
@@ -1,0 +1,3 @@
+package com.example;
+public class FlagReturnType {
+}

--- a/src/test/resources/lambdanestedbarereturn/expected/com/example/Simple.java
+++ b/src/test/resources/lambdanestedbarereturn/expected/com/example/Simple.java
@@ -1,0 +1,19 @@
+package com.example;
+
+import com.example.other.Wrapper;
+
+public class Simple {
+
+  public Object target(Wrapper w) {
+    return w.map(
+        item -> {
+          Runnable r =
+              () -> {
+                item.flag();
+                return;
+              };
+          r.run();
+          return item;
+        });
+  }
+}

--- a/src/test/resources/lambdanestedbarereturn/expected/com/example/SyntheticTypeForItem.java
+++ b/src/test/resources/lambdanestedbarereturn/expected/com/example/SyntheticTypeForItem.java
@@ -1,0 +1,7 @@
+package com.example;
+public class SyntheticTypeForItem {
+
+    public com.example.FlagReturnType flag() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdanestedbarereturn/expected/com/example/other/Wrapper.java
+++ b/src/test/resources/lambdanestedbarereturn/expected/com/example/other/Wrapper.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Wrapper {
+
+    public java.lang.Object map(java.util.function.Function<? extends com.example.SyntheticTypeForItem, ?> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdanestedbarereturn/input/com/example/Simple.java
+++ b/src/test/resources/lambdanestedbarereturn/input/com/example/Simple.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import com.example.other.Wrapper;
+
+public class Simple {
+  public Object target(Wrapper w) {
+    return w.map(
+        item -> {
+          Runnable r =
+              () -> {
+                item.flag();
+                return;
+              };
+          r.run();
+          return item;
+        });
+  }
+}

--- a/src/test/resources/lambdanestedreturn/expected/com/example/Simple.java
+++ b/src/test/resources/lambdanestedreturn/expected/com/example/Simple.java
@@ -1,0 +1,17 @@
+package com.example;
+
+import com.example.other.Wrapper;
+
+public class Simple {
+
+  public Object target(Wrapper w) {
+    return w.map(
+        item -> {
+          if (item.flag()) {
+            return item;
+          } else {
+            return item;
+          }
+        });
+  }
+}

--- a/src/test/resources/lambdanestedreturn/expected/com/example/SyntheticTypeForItem.java
+++ b/src/test/resources/lambdanestedreturn/expected/com/example/SyntheticTypeForItem.java
@@ -1,0 +1,7 @@
+package com.example;
+public class SyntheticTypeForItem {
+
+    public boolean flag() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdanestedreturn/expected/com/example/other/Wrapper.java
+++ b/src/test/resources/lambdanestedreturn/expected/com/example/other/Wrapper.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Wrapper {
+
+    public java.lang.Object map(java.util.function.Function<? extends com.example.SyntheticTypeForItem, ?> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdanestedreturn/input/com/example/Simple.java
+++ b/src/test/resources/lambdanestedreturn/input/com/example/Simple.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import com.example.other.Wrapper;
+
+public class Simple {
+  public Object target(Wrapper w) {
+    return w.map(
+        item -> {
+          if (item.flag()) {
+            return item;
+          } else {
+            return item;
+          }
+        });
+  }
+}


### PR DESCRIPTION
This is one of the blockers of Specimin's output on #442 compiling.