### PR TITLE
Improve conformance to JLS type variable substitution rules

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -3602,16 +3602,27 @@ public class JavaParserUtil {
   }
 
   /**
-   * Returns the names of every type variable whose scope (JLS 6.3) contains the given node: the
-   * type parameters of each enclosing method, constructor, and type declaration.
+   * Returns the names of the type variables that are, approximately, in scope (JLS 6.3) at the
+   * given node: the type parameters of each enclosing method, constructor, and type declaration.
    *
    * <p>These names are meaningful only inside the declarations that bind them. Code that copies a
    * type out of this node and into a declaration somewhere else -- as synthetic member generation
    * does, when it builds a signature out of the types at a call site -- cannot use them there.
    *
-   * <p>The result is ordered innermost-first, so that a caller assigning replacement names in
-   * iteration order spends the lowest-numbered ones on the type variables nearest the node, which
-   * are the ones most likely to actually appear in the copied types.
+   * <p><strong>This is an over-approximation, not the exact scope.</strong> A class's type
+   * parameter is not in scope inside a static member of that class (JLS 8.1.2), but this method
+   * reports it anyway for a node inside a static method. Callers that need the true scope must
+   * exclude those themselves.
+   *
+   * <p>The over-approximation is harmless for asking "which names could a type copied from here
+   * mention", which is what the callers here want: by JLS 8.1.2 no expression inside a static
+   * member can have a type that mentions the class's type parameters, so such a name cannot reach a
+   * copied type in the first place, and {@link
+   * org.checkerframework.specimin.unsolved.UnsolvedMethod} prints only the type variables that a
+   * signature actually uses, so a spurious one is never emitted.
+   *
+   * <p>The result is ordered innermost-first, so that a caller processing it in order reaches the
+   * type variables nearest the node -- the ones most likely to appear in the copied types -- first.
    *
    * @param node the node to compute the in-scope type variables of
    * @return the in-scope type variable names, innermost declaration first

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
 import com.github.javaparser.ast.nodeTypes.NodeWithType;
+import com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -3552,5 +3553,35 @@ public class JavaParserUtil {
    */
   public static String getGeneratedTypeParameterName(int index) {
     return "T" + ((index > 0) ? index : "");
+  }
+
+  /**
+   * Returns the names of every type variable whose scope (JLS 6.3) contains the given node: the
+   * type parameters of each enclosing method, constructor, and type declaration.
+   *
+   * <p>These names are meaningful only inside the declarations that bind them. Code that copies a
+   * type out of this node and into a declaration somewhere else -- as synthetic member generation
+   * does, when it builds a signature out of the types at a call site -- cannot use them there.
+   *
+   * <p>The result is ordered innermost-first, so that a caller assigning replacement names in
+   * iteration order spends the lowest-numbered ones on the type variables nearest the node, which
+   * are the ones most likely to actually appear in the copied types.
+   *
+   * @param node the node to compute the in-scope type variables of
+   * @return the in-scope type variable names, innermost declaration first
+   */
+  public static List<String> getTypeParameterNamesInScope(Node node) {
+    List<String> names = new ArrayList<>();
+    for (Node current = node; current != null; current = current.getParentNode().orElse(null)) {
+      if (current instanceof NodeWithTypeParameters<?> withTypeParams) {
+        for (TypeParameter typeParam : withTypeParams.getTypeParameters()) {
+          String name = typeParam.getNameAsString();
+          if (!names.contains(name)) {
+            names.add(name);
+          }
+        }
+      }
+    }
+    return names;
   }
 }

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -5,15 +5,19 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.AnnotationMemberDeclaration;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.EnumConstantDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.InitializerDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -36,6 +40,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTraversableScope;
 import com.github.javaparser.ast.nodeTypes.NodeWithType;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters;
+import com.github.javaparser.ast.nodeTypes.modifiers.NodeWithStaticModifier;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -3602,43 +3607,118 @@ public class JavaParserUtil {
   }
 
   /**
-   * Returns the names of the type variables that are, approximately, in scope (JLS 6.3) at the
-   * given node: the type parameters of each enclosing method, constructor, and type declaration.
+   * Returns the names of the type variables that may be referred to at the given node: the type
+   * parameters of each enclosing method, constructor, and type declaration, minus those that JLS
+   * 8.1.2 forbids referring to from a static context.
    *
    * <p>These names are meaningful only inside the declarations that bind them. Code that copies a
    * type out of this node and into a declaration somewhere else -- as synthetic member generation
    * does, when it builds a signature out of the types at a call site -- cannot use them there.
    *
-   * <p><strong>This is an over-approximation, not the exact scope.</strong> A class's type
-   * parameter is not in scope inside a static member of that class (JLS 8.1.2), but this method
-   * reports it anyway for a node inside a static method. Callers that need the true scope must
-   * exclude those themselves.
-   *
-   * <p>The over-approximation is harmless for asking "which names could a type copied from here
-   * mention", which is what the callers here want: by JLS 8.1.2 no expression inside a static
-   * member can have a type that mentions the class's type parameters, so such a name cannot reach a
-   * copied type in the first place, and {@link
-   * org.checkerframework.specimin.unsolved.UnsolvedMethod} prints only the type variables that a
-   * signature actually uses, so a spurious one is never emitted.
+   * <p>This is deliberately not the JLS 6.3 scope, which is wider: a generic class's type parameter
+   * is in scope throughout the class body, static members included, and JLS 8.1.2 is a separate
+   * rule making it a compile-time error to refer to it from one. Callers want the names a type at
+   * this node could actually mention, which is the narrower set.
    *
    * <p>The result is ordered innermost-first, so that a caller processing it in order reaches the
    * type variables nearest the node -- the ones most likely to appear in the copied types -- first.
    *
-   * @param node the node to compute the in-scope type variables of
-   * @return the in-scope type variable names, innermost declaration first
+   * @param node the node to compute the referenceable type variables of
+   * @return the referenceable type variable names, innermost declaration first
    */
-  public static List<String> getTypeParameterNamesInScope(Node node) {
+  public static List<String> getReferenceableTypeParameterNames(Node node) {
     List<String> names = new ArrayList<>();
+
+    // Set once the walk outwards leaves a static context. Everything beyond that point is a type
+    // declaration whose type parameters JLS 8.1.2 forbids naming from where this walk started.
+    boolean leftStaticContext = false;
+
     for (Node current = node; current != null; current = current.getParentNode().orElse(null)) {
-      if (current instanceof NodeWithTypeParameters<?> withTypeParams) {
-        for (TypeParameter typeParam : withTypeParams.getTypeParameters()) {
-          String name = typeParam.getNameAsString();
-          if (!names.contains(name)) {
-            names.add(name);
-          }
+      if (current instanceof TypeDeclaration<?> type) {
+        // Enum and annotation declarations cannot have type parameters, so not every type
+        // declaration is a NodeWithTypeParameters.
+        if (!leftStaticContext && type instanceof NodeWithTypeParameters<?> withTypeParams) {
+          addTypeParameterNames(withTypeParams, names);
         }
+        leftStaticContext |= isStaticTypeDeclaration(type);
+      } else if (current instanceof NodeWithTypeParameters<?> withTypeParams) {
+        // A method's or constructor's own type parameters are always referenceable from inside it,
+        // whether or not it is static; only the enclosing class's become unreachable.
+        addTypeParameterNames(withTypeParams, names);
+        leftStaticContext |=
+            current instanceof NodeWithStaticModifier<?> withStatic && withStatic.isStatic();
+      } else if (current instanceof InitializerDeclaration initializer) {
+        leftStaticContext |= initializer.isStatic();
+      } else if (current instanceof FieldDeclaration field) {
+        // A field of an interface is implicitly static (JLS 9.3), so its initializer is a static
+        // context even with no modifier written.
+        leftStaticContext |= field.isStatic() || isInterfaceMember(field);
       }
     }
     return names;
+  }
+
+  /**
+   * Adds the names of a declaration's type parameters to the given list, skipping any already
+   * present.
+   *
+   * @param declaration the declaration whose type parameters to add
+   * @param names the list to add to, modified by side effect
+   */
+  private static void addTypeParameterNames(
+      NodeWithTypeParameters<?> declaration, List<String> names) {
+    for (TypeParameter typeParam : declaration.getTypeParameters()) {
+      String name = typeParam.getNameAsString();
+      if (!names.contains(name)) {
+        names.add(name);
+      }
+    }
+  }
+
+  /**
+   * Returns whether a type declaration is static, counting the cases where the JLS makes it so
+   * without a {@code static} modifier being written: member interfaces, enums, records and
+   * annotations, and any member type of an interface or annotation (JLS 8.5.1, 9.1.1.3, 8.9, 8.10).
+   *
+   * <p>Getting this wrong in the permissive direction is the safer error for the caller in {@link
+   * #getReferenceableTypeParameterNames}: reporting a name that cannot legally be used costs
+   * nothing, because no type at the node can mention it, whereas omitting a usable one loses a type
+   * variable that a generated signature needs.
+   *
+   * @param type the type declaration to check
+   * @return true if the type declaration is static, implicitly or explicitly
+   */
+  private static boolean isStaticTypeDeclaration(TypeDeclaration<?> type) {
+    if (type.isStatic()) {
+      return true;
+    }
+
+    // Local and anonymous classes are never static, and neither is a top-level type in any sense
+    // that matters here, since it has no enclosing type parameters to cut off.
+    if (!type.isNestedType()) {
+      return false;
+    }
+
+    if (type instanceof EnumDeclaration
+        || type instanceof RecordDeclaration
+        || type instanceof AnnotationDeclaration
+        || (type instanceof ClassOrInterfaceDeclaration asClass && asClass.isInterface())) {
+      return true;
+    }
+
+    return isInterfaceMember(type);
+  }
+
+  /**
+   * Returns whether a declaration is a member of an interface or annotation declaration, whose
+   * members are implicitly static.
+   *
+   * @param member the declaration to check
+   * @return true if the declaration's immediately enclosing type is an interface or annotation
+   */
+  private static boolean isInterfaceMember(Node member) {
+    Node parent = member.getParentNode().orElse(null);
+    return parent instanceof AnnotationDeclaration
+        || (parent instanceof ClassOrInterfaceDeclaration asClass && asClass.isInterface());
   }
 }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
@@ -37,16 +37,15 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
   /** The list of the types of the exceptions thrown by the method. */
   private final List<MemberType> throwsList;
 
-  /** The number of type variables for this method. */
-  private int numberOfTypeVariables;
-
   /**
-   * Names for this method's type variables, by index. Indices not covered here are named by {@link
-   * JavaParserUtil#getGeneratedTypeParameterName}; this list holds only the names that differ from
-   * that scheme, which arise when a name already written into the signature has to be bound rather
-   * than replaced. See {@link #declareTypeVariables}.
+   * The names of this method's type variables, in declaration order.
+   *
+   * <p>These names are the state. Most of a method's type
+   * variables are invented by Specimin and named by {@link
+   * JavaParserUtil#getGeneratedTypeParameterName}, but one that {@link #declareTypeVariables} binds
+   * carries a name that is already written into the signature and cannot be renamed.
    */
-  private final List<String> explicitTypeVariableNames = new ArrayList<>();
+  private final List<String> typeVariableNames;
 
   /** The access modifier of the method. */
   private String accessModifier;
@@ -113,6 +112,40 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
       String accessModifier,
       boolean isStatic,
       int numberOfTypeVariables) {
+    this(
+        name,
+        returnType,
+        parameterList,
+        throwsList,
+        mustPreserve,
+        accessModifier,
+        isStatic,
+        generatedTypeVariableNames(numberOfTypeVariables));
+  }
+
+  /**
+   * Create an instance of UnsolvedMethod with the given type variable names. Use this, rather than
+   * the overload taking a count, when copying an existing method: a name that {@link
+   * #declareTypeVariables} bound cannot be reconstructed from a count.
+   *
+   * @param name the name of the method
+   * @param returnType the return type of the method
+   * @param parameterList the list of parameters for this method
+   * @param throwsList the list of exceptions thrown by this method
+   * @param accessModifier the access modifier of this method
+   * @param mustPreserve the set of nodes that must be preserved with this alternate
+   * @param isStatic whether this method is static
+   * @param typeVariableNames the names of this method's type variables, in declaration order
+   */
+  public UnsolvedMethod(
+      String name,
+      MemberType returnType,
+      List<MemberType> parameterList,
+      List<MemberType> throwsList,
+      Set<Node> mustPreserve,
+      String accessModifier,
+      boolean isStatic,
+      List<String> typeVariableNames) {
     super(mustPreserve);
     this.name = name;
     this.returnType = returnType;
@@ -123,7 +156,21 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
 
     this.accessModifier = accessModifier;
     this.isStatic = isStatic;
-    this.numberOfTypeVariables = numberOfTypeVariables;
+    this.typeVariableNames = new ArrayList<>(typeVariableNames);
+  }
+
+  /**
+   * Returns the first {@code count} generated type variable names.
+   *
+   * @param count how many names to generate
+   * @return the generated names, in order
+   */
+  private static List<String> generatedTypeVariableNames(int count) {
+    List<String> names = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      names.add(JavaParserUtil.getGeneratedTypeParameterName(i));
+    }
+    return names;
   }
 
   /**
@@ -198,7 +245,14 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
    */
   @Override
   public void setNumberOfTypeVariables(int numberOfTypeVariables) {
-    this.numberOfTypeVariables = numberOfTypeVariables;
+    // Resize rather than replace, so that a name bound by declareTypeVariables at an index below
+    // the new size survives.
+    while (typeVariableNames.size() > numberOfTypeVariables) {
+      typeVariableNames.remove(typeVariableNames.size() - 1);
+    }
+    while (typeVariableNames.size() < numberOfTypeVariables) {
+      typeVariableNames.add(JavaParserUtil.getGeneratedTypeParameterName(typeVariableNames.size()));
+    }
   }
 
   @Override
@@ -298,7 +352,17 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
    */
   @Override
   public int getNumberOfTypeVariables() {
-    return numberOfTypeVariables;
+    return typeVariableNames.size();
+  }
+
+  /**
+   * Returns the names of this method's type variables, in declaration order. Pass this to {@link
+   * #UnsolvedMethod(String, MemberType, List, List, Set, String, boolean, List)} when copying.
+   *
+   * @return the type variable names; the list is read-only
+   */
+  public List<String> getTypeVariableNames() {
+    return Collections.unmodifiableList(typeVariableNames);
   }
 
   /**
@@ -307,7 +371,7 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
    * @return the synthetic representation for type variables
    */
   private String getTypeVariablesAsString() {
-    if (numberOfTypeVariables == 0) {
+    if (typeVariableNames.isEmpty()) {
       return "";
     }
 
@@ -352,19 +416,17 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
       }
     }
 
-    List<String> typeVariableNames = new ArrayList<>();
-    for (int i = 0; i < numberOfTypeVariables; i++) {
-      String typeVariableName = getTypeVariableName(i);
-
+    List<String> usedTypeVariableNames = new ArrayList<>();
+    for (String typeVariableName : typeVariableNames) {
       for (ClassOrInterfaceType usedType : usedTypes) {
         if (usedType.findAll(ClassOrInterfaceType.class).stream()
             .anyMatch(t -> t.getNameAsString().equals(typeVariableName))) {
-          typeVariableNames.add(typeVariableName);
+          usedTypeVariableNames.add(typeVariableName);
           break;
         }
       }
     }
-    return typeVariableNames;
+    return usedTypeVariableNames;
   }
 
   /**
@@ -376,39 +438,19 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
    */
   @Override
   public String getTypeVariableName(int index) {
-    if (index < 0 || index >= numberOfTypeVariables) {
+    if (index < 0 || index >= typeVariableNames.size()) {
       throw new IllegalArgumentException(
-          "Index out of bounds. There are only " + numberOfTypeVariables + " type variables.");
+          "Index out of bounds. There are only " + typeVariableNames.size() + " type variables.");
     }
-    if (index < explicitTypeVariableNames.size()) {
-      return explicitTypeVariableNames.get(index);
-    }
-    return JavaParserUtil.getGeneratedTypeParameterName(index);
+    return typeVariableNames.get(index);
   }
 
   @Override
   public void declareTypeVariables(List<String> names) {
     for (String name : names) {
-      boolean alreadyDeclared = false;
-      for (int i = 0; i < numberOfTypeVariables; i++) {
-        if (getTypeVariableName(i).equals(name)) {
-          alreadyDeclared = true;
-          break;
-        }
+      if (!typeVariableNames.contains(name)) {
+        typeVariableNames.add(name);
       }
-
-      if (alreadyDeclared) {
-        continue;
-      }
-
-      // Fill in the generated names for any indices below this one, so that the explicit name
-      // lands at the index it is being added at.
-      while (explicitTypeVariableNames.size() < numberOfTypeVariables) {
-        explicitTypeVariableNames.add(
-            JavaParserUtil.getGeneratedTypeParameterName(explicitTypeVariableNames.size()));
-      }
-      explicitTypeVariableNames.add(name);
-      numberOfTypeVariables++;
     }
   }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
@@ -40,10 +40,10 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
   /**
    * The names of this method's type variables, in declaration order.
    *
-   * <p>These names are the state. Most of a method's type
-   * variables are invented by Specimin and named by {@link
-   * JavaParserUtil#getGeneratedTypeParameterName}, but one that {@link #declareTypeVariables} binds
-   * carries a name that is already written into the signature and cannot be renamed.
+   * <p>These names are the state. Most of a method's type variables are invented by Specimin and
+   * named by {@link JavaParserUtil#getGeneratedTypeParameterName}, but one that {@link
+   * #declareTypeVariables} binds carries a name that is already written into the signature and
+   * cannot be renamed.
    */
   private final List<String> typeVariableNames;
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
@@ -40,6 +40,14 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
   /** The number of type variables for this method. */
   private int numberOfTypeVariables;
 
+  /**
+   * Names for this method's type variables, by index. Indices not covered here are named by {@link
+   * JavaParserUtil#getGeneratedTypeParameterName}; this list holds only the names that differ from
+   * that scheme, which arise when a name already written into the signature has to be bound rather
+   * than replaced. See {@link #declareTypeVariables}.
+   */
+  private final List<String> explicitTypeVariableNames = new ArrayList<>();
+
   /** The access modifier of the method. */
   private String accessModifier;
 
@@ -303,7 +311,15 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
       return "";
     }
 
-    return "<" + String.join(", ", getTypeVariablesImpl()) + ">";
+    List<String> used = getTypeVariablesImpl();
+
+    // A type variable may be allocated for this method but end up used by no alternate's
+    // signature, in which case there is no type parameter section to print at all.
+    if (used.isEmpty()) {
+      return "";
+    }
+
+    return "<" + String.join(", ", used) + ">";
   }
 
   /** Gets a list of the type variable names that are used in this method. */
@@ -327,7 +343,8 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
       usedTypes.add(parsedType.asClassOrInterfaceType());
     }
 
-    if (returnType != null) {
+    // A constructor's return type is the empty string, which is not parseable as a type.
+    if (returnType != null && !returnType.toString().isEmpty()) {
       Type parsedType = StaticJavaParser.parseType(returnType.toString());
 
       if (parsedType.isClassOrInterfaceType()) {
@@ -357,12 +374,42 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
    * @return the name of the type variable with the given index
    * @throws IllegalArgumentException if the index is out of bounds
    */
+  @Override
   public String getTypeVariableName(int index) {
     if (index < 0 || index >= numberOfTypeVariables) {
       throw new IllegalArgumentException(
           "Index out of bounds. There are only " + numberOfTypeVariables + " type variables.");
     }
+    if (index < explicitTypeVariableNames.size()) {
+      return explicitTypeVariableNames.get(index);
+    }
     return JavaParserUtil.getGeneratedTypeParameterName(index);
+  }
+
+  @Override
+  public void declareTypeVariables(List<String> names) {
+    for (String name : names) {
+      boolean alreadyDeclared = false;
+      for (int i = 0; i < numberOfTypeVariables; i++) {
+        if (getTypeVariableName(i).equals(name)) {
+          alreadyDeclared = true;
+          break;
+        }
+      }
+
+      if (alreadyDeclared) {
+        continue;
+      }
+
+      // Fill in the generated names for any indices below this one, so that the explicit name
+      // lands at the index it is being added at.
+      while (explicitTypeVariableNames.size() < numberOfTypeVariables) {
+        explicitTypeVariableNames.add(
+            JavaParserUtil.getGeneratedTypeParameterName(explicitTypeVariableNames.size()));
+      }
+      explicitTypeVariableNames.add(name);
+      numberOfTypeVariables++;
+    }
   }
 
   @Override

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -345,6 +345,16 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
     applyToAllAlternates(UnsolvedMethod::setNumberOfTypeVariables, number);
   }
 
+  @Override
+  public String getTypeVariableName(int index) {
+    return getAlternates().get(0).getTypeVariableName(index);
+  }
+
+  @Override
+  public void declareTypeVariables(List<String> names) {
+    applyToAllAlternates(UnsolvedMethod::declareTypeVariables, names);
+  }
+
   /**
    * Returns whether the given type is one of the type variables bound by this method's own
    * declaration (i.e. a name introduced by this method, such as the {@code T} in {@code <T> T

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -253,7 +253,10 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
                   entry.getKey(),
                   parameterList,
                   old.getThrownExceptions(),
-                  Set.of((Node) entry.getValue()));
+                  Set.of((Node) entry.getValue()),
+                  old.getAccessModifier(),
+                  old.isStatic(),
+                  old.getTypeVariableNames());
           addAlternate(method);
         }
       }
@@ -468,7 +471,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
               alternate.getMustPreserveNodes(),
               alternate.getAccessModifier(),
               alternate.isStatic(),
-              alternate.getNumberOfTypeVariables());
+              alternate.getTypeVariableNames());
       copy.addThrownException(exception);
       throwing.add(copy);
     }
@@ -551,7 +554,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
                 alternate.getMustPreserveNodes(),
                 alternate.getAccessModifier(),
                 alternate.isStatic(),
-                alternate.getNumberOfTypeVariables());
+                alternate.getTypeVariableNames());
         addAlternate(newAlternate);
       }
 
@@ -593,7 +596,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
                   alternate.getMustPreserveNodes(),
                   alternate.getAccessModifier(),
                   alternate.isStatic(),
-                  alternate.getNumberOfTypeVariables());
+                  alternate.getTypeVariableNames());
 
           addAlternate(newAlternate);
         }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodCommon.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodCommon.java
@@ -61,6 +61,29 @@ public interface UnsolvedMethodCommon {
   void setNumberOfTypeVariables(int number);
 
   /**
+   * Given the index of a type variable, return the name of that type variable.
+   *
+   * @param index The index
+   * @return the name of the type variable with the given index
+   */
+  String getTypeVariableName(int index);
+
+  /**
+   * Declares additional type variables on this method under the given names, appending them after
+   * the type variables it already has. Names that this method already declares are skipped.
+   *
+   * <p>Use this when a name is already written into the signature and merely needs to be bound --
+   * notably a type variable of the calling context, which a synthetic member's parameter and return
+   * types can mention but which is not in scope where that member is declared. Binding the name
+   * that is already there, rather than rewriting the signature to use a generated name, keeps the
+   * method's fully-qualified names (which are built from its parameter types' erased simple names)
+   * stable.
+   *
+   * @param names the type variable names to declare
+   */
+  void declareTypeVariables(List<String> names);
+
+  /**
    * Sets the return type.
    *
    * @param memberType The return type

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -210,6 +210,9 @@ public class UnsolvedSymbolGenerator {
       String constructorName;
       List<Expression> arguments;
       int numberOfTypeParams = 0;
+      // The type being instantiated plays the role a receiver's type plays for a method call: it
+      // is what supplies the declaring type's type arguments at this call site.
+      FullyQualifiedNameSet instantiatedType;
 
       if (node instanceof ObjectCreationExpr constructor) {
         if (Resolver.calculateResolvedType(constructor) != null) {
@@ -219,11 +222,9 @@ public class UnsolvedSymbolGenerator {
         }
 
         inferContextImpl(constructor.getType(), result);
+        instantiatedType = fullyQualifiedNameGenerator.getFQNsFromType(constructor.getType());
         // Do not generate here; that should be taken care of in the inferContextImpl call above.
-        scope =
-            (UnsolvedClassOrInterfaceAlternates)
-                findExistingAndUpdateFQNs(
-                    fullyQualifiedNameGenerator.getFQNsFromType(constructor.getType()));
+        scope = (UnsolvedClassOrInterfaceAlternates) findExistingAndUpdateFQNs(instantiatedType);
 
         constructorName = constructor.getTypeAsString();
         arguments = constructor.getArguments();
@@ -248,11 +249,9 @@ public class UnsolvedSymbolGenerator {
           }
 
           inferContextImpl(superClass, result);
+          instantiatedType = fullyQualifiedNameGenerator.getFQNsFromType(superClass);
           // Do not generate here; that should be taken care of in the inferContextImpl call above.
-          scope =
-              (UnsolvedClassOrInterfaceAlternates)
-                  findExistingAndUpdateFQNs(
-                      fullyQualifiedNameGenerator.getFQNsFromType(superClass));
+          scope = (UnsolvedClassOrInterfaceAlternates) findExistingAndUpdateFQNs(instantiatedType);
 
           constructorName = superClass.getNameAsString();
           arguments = constructor.getArguments();
@@ -273,7 +272,13 @@ public class UnsolvedSymbolGenerator {
       scope.setType(UnsolvedClassOrInterfaceType.CLASS);
 
       handleConstructorCall(
-          scope, JavaParserUtil.erase(constructorName), arguments, numberOfTypeParams, result);
+          scope,
+          JavaParserUtil.erase(constructorName),
+          arguments,
+          numberOfTypeParams,
+          node,
+          instantiatedType,
+          result);
     } else if (node instanceof MethodDeclaration methodDecl) {
       handleMethodDeclarationWithOverride(methodDecl, result);
     }
@@ -1044,6 +1049,13 @@ public class UnsolvedSymbolGenerator {
             argumentToParameterPotentialFQNs,
             argumentToParameterPotentialFQNsWithMethodRefsHandled);
 
+    // Type variables of the calling context can reach this signature through the argument and
+    // return types, but are not in scope in the synthetic declaration, so the method has to declare
+    // them itself.
+    List<String> callerTypeVariablesToDeclare =
+        typeVariablesToDeclareFromCaller(
+            methodCall, typeVariableNamesSubstitutedAtCallSite(methodCall, potentialScopeFQNs));
+
     boolean hasNullInSignature =
         argumentToParameterPotentialFQNs.keySet().stream().anyMatch(Expression::isNullLiteralExpr);
 
@@ -1209,8 +1221,7 @@ public class UnsolvedSymbolGenerator {
           }
 
           originalToReplacement.put(
-              memberTypeForTypeArg,
-              new SolvedMemberType(JavaParserUtil.getGeneratedTypeParameterName(i)));
+              memberTypeForTypeArg, new SolvedMemberType(generatedMethod.getTypeVariableName(i)));
         }
       } else {
         int typeVar = generatedMethod.getNumberOfTypeVariables();
@@ -1220,7 +1231,7 @@ public class UnsolvedSymbolGenerator {
 
         for (MemberType typeToReplace : typesInOriginalToReplaceWithTypeVariables) {
           MemberType newTypeVariable =
-              new SolvedMemberType(JavaParserUtil.getGeneratedTypeParameterName(typeVar));
+              new SolvedMemberType(generatedMethod.getTypeVariableName(typeVar));
 
           if (typeToReplace.equals(newTypeVariable)) {
             continue;
@@ -1265,8 +1276,7 @@ public class UnsolvedSymbolGenerator {
             && unsolved.usesGeneratedName()) {
           Set<MemberType> potentialReturns = new LinkedHashSet<>();
           for (int i = 0; i < generatedMethod.getNumberOfTypeVariables(); i++) {
-            potentialReturns.add(
-                new SolvedMemberType(JavaParserUtil.getGeneratedTypeParameterName(i)));
+            potentialReturns.add(new SolvedMemberType(generatedMethod.getTypeVariableName(i)));
           }
 
           generatedMethod.replaceReturnType(unsolved, potentialReturns);
@@ -1389,6 +1399,7 @@ public class UnsolvedSymbolGenerator {
       }
 
       generatedMethod.setNumberOfTypeVariables(totalNumberOfTypeParametersNeeded);
+      generatedMethod.declareTypeVariables(callerTypeVariablesToDeclare);
 
       if (hasNullInSignature) {
         methodsWithNullInSignature.add(generatedMethod);
@@ -1486,6 +1497,9 @@ public class UnsolvedSymbolGenerator {
    * @param constructorName The name of the constructor
    * @param arguments The arguments of the constructor call
    * @param numberOfTypeParams The number of type parameters of the constructor only
+   * @param callSite The constructor call, used to find the calling context's type variables
+   * @param instantiatedType The type being instantiated, which supplies the declaring type's type
+   *     arguments at this call site
    * @param result The result of inferContext
    */
   private void handleConstructorCall(
@@ -1493,6 +1507,8 @@ public class UnsolvedSymbolGenerator {
       String constructorName,
       List<Expression> arguments,
       int numberOfTypeParams,
+      Node callSite,
+      FullyQualifiedNameSet instantiatedType,
       List<UnsolvedSymbolAlternates<?>> result) {
     Map<Expression, Set<FullyQualifiedNameSet>> argumentToParameterPotentialFQNs = new HashMap<>();
 
@@ -1524,6 +1540,13 @@ public class UnsolvedSymbolGenerator {
       simpleNames.add(simpleNamesForThisArgumentType);
       argumentToParameterPotentialFQNs.put(argument, fqns);
     }
+
+    // Type variables of the calling context can reach this signature through the argument types,
+    // but are not in scope in the synthetic declaration, so the constructor has to declare them
+    // itself.
+    List<String> callerTypeVariablesToDeclare =
+        typeVariablesToDeclareFromCaller(
+            callSite, typeVariableNamesSubstitutedByReceiver(instantiatedType));
 
     Set<String> potentialFQNs = new LinkedHashSet<>();
 
@@ -1563,9 +1586,185 @@ public class UnsolvedSymbolGenerator {
       addNewSymbolToGeneratedSymbolsMap(generatedMethod);
 
       generatedMethod.setNumberOfTypeVariables(numberOfTypeParams);
+      generatedMethod.declareTypeVariables(callerTypeVariablesToDeclare);
 
       result.add(generatedMethod);
     }
+  }
+
+  /**
+   * Returns the type variable names that the parameterization at this call site substitutes into
+   * the declaring type's type parameters, and which a member generated here may therefore keep
+   * referring to. See {@link #typeVariableNamesSubstitutedByReceiver} for why that is the
+   * criterion.
+   *
+   * @param methodCall the call site
+   * @param potentialScopeFQNs the types that could declare this method
+   * @return the substituted type variable names, or an empty set if there is no such
+   *     parameterization
+   */
+  private Set<String> typeVariableNamesSubstitutedAtCallSite(
+      MethodCallExpr methodCall, Collection<Set<String>> potentialScopeFQNs) {
+    if (methodCall.hasScope()
+        && !methodCall.getScope().get().isThisExpr()
+        && !methodCall.getScope().get().isSuperExpr()) {
+      Set<FullyQualifiedNameSet> scopeTypes =
+          fullyQualifiedNameGenerator.getFQNsForExpressionType(methodCall.getScope().get());
+
+      // With several possibilities there is no single parameterization to read a substitution off
+      // of, so report nothing and let every caller type variable be declared on the member; that is
+      // always compilable, only less precise.
+      return scopeTypes.size() == 1
+          ? typeVariableNamesSubstitutedByReceiver(scopeTypes.iterator().next())
+          : Set.of();
+    }
+
+    // For this, super, and unqualified calls the member is declared in an ancestor, and the
+    // parameterization that JLS 4.5.2 substitutes through is the one written in this type's extends
+    // or implements clause.
+    TypeDeclaration<?> enclosing = JavaParserUtil.getEnclosingClassLikeOptional(methodCall);
+
+    if (enclosing == null || !enclosing.isClassOrInterfaceDeclaration()) {
+      return Set.of();
+    }
+
+    ClassOrInterfaceDeclaration enclosingClass = enclosing.asClassOrInterfaceDeclaration();
+    List<ClassOrInterfaceType> ancestors = new ArrayList<>(enclosingClass.getExtendedTypes());
+    ancestors.addAll(enclosingClass.getImplementedTypes());
+
+    Set<String> substituted = new LinkedHashSet<>();
+    for (ClassOrInterfaceType ancestor : ancestors) {
+      FullyQualifiedNameSet ancestorFQNs = fullyQualifiedNameGenerator.getFQNsFromType(ancestor);
+
+      // Only ancestors that could declare this method: another ancestor's parameterization says
+      // nothing about the type this method actually lands in.
+      if (potentialScopeFQNs.stream()
+          .noneMatch(scope -> !Collections.disjoint(scope, ancestorFQNs.erasedFqns()))) {
+        continue;
+      }
+
+      substituted.addAll(typeVariableNamesSubstitutedByReceiver(ancestorFQNs));
+    }
+    System.err.println(
+        "DBG call="
+            + methodCall
+            + " ancestors="
+            + ancestors
+            + " scopes="
+            + potentialScopeFQNs
+            + " substituted="
+            + substituted);
+    return substituted;
+  }
+
+  /**
+   * Returns the type variables of the calling context that a synthetic member generated from this
+   * call site must declare itself.
+   *
+   * <p>A synthetic member's parameter and return types are built out of the types of the
+   * expressions at a call site, and those types may mention type variables bound by the calling
+   * method or class. Such a name means nothing in the synthetic declaration (JLS 6.3): depending on
+   * what happens to be declared there it is either unresolvable or, worse, silently captured by an
+   * unrelated declaration of the same name. Declaring it on the member binds it, and costs no
+   * precision, because invocation type inference (JLS 18.5) instantiates it back to the caller's
+   * type variable at this call site.
+   *
+   * <p>The exception is a name that reaches the signature through the declaring type's own type
+   * parameter, which {@code substitutedByReceiver} identifies; see {@link
+   * #typeVariableNamesSubstitutedByReceiver}. Declaring such a name on the member would shadow the
+   * declaring type's type parameter and sever that substitution.
+   *
+   * <p>Names that no signature ends up mentioning are harmless to include, since {@link
+   * UnsolvedMethod} prints only the type variables its signature actually uses.
+   *
+   * @param callSite the call site the signature is being derived from
+   * @param substitutedByReceiver names that must not be declared, because the receiver substitutes
+   *     them into the declaring type's type parameters
+   * @return the type variable names to declare, innermost enclosing declaration first
+   */
+  private List<String> typeVariablesToDeclareFromCaller(
+      Node callSite, Set<String> substitutedByReceiver) {
+    List<String> toDeclare = new ArrayList<>();
+    for (String name : JavaParserUtil.getTypeParameterNamesInScope(callSite)) {
+      if (!substitutedByReceiver.contains(name)) {
+        toDeclare.add(name);
+      }
+    }
+    return toDeclare;
+  }
+
+  /**
+   * Returns the type variable names that a synthetic member may keep referring to because the
+   * receiver at the call site substitutes them into its declaring type's type parameters.
+   *
+   * <p>By JLS 4.5.2 the type of a member of {@code C<A1..An>} is its type in {@code C} with the
+   * class's type parameters replaced by {@code A1..An}. So a name written at position {@code i} of
+   * the signature denotes {@code Ai} at this call site, and keeping the caller's name there is
+   * correct exactly when the class's {@code i}th type parameter is spelled the same as the caller's
+   * type variable and the receiver instantiates it to that very type variable. Any other case --
+   * notably a static member, where JLS 8.1.2 forbids referring to the class's type parameters at
+   * all, and a receiver that instantiates the parameter to something else -- has no such channel.
+   *
+   * <p>A member accessed through a type name rather than an instance needs no special case: the
+   * type of such a scope carries no type arguments, so nothing is reported as substitutable.
+   *
+   * @param receiverType the receiver's type at the call site, or the instantiated type for a
+   *     constructor; null if there is no receiver
+   * @return the type variable names that the receiver substitutes into the declaring type
+   */
+  private Set<String> typeVariableNamesSubstitutedByReceiver(
+      @Nullable FullyQualifiedNameSet receiverType) {
+    if (receiverType == null || receiverType.typeArguments().isEmpty()) {
+      return Set.of();
+    }
+
+    if (!(findExistingAndUpdateFQNs(receiverType.erasedFqns())
+        instanceof UnsolvedClassOrInterfaceAlternates declaringType)) {
+      return Set.of();
+    }
+
+    List<String> classTypeParams = declaringType.getTypeVariables();
+    List<FullyQualifiedNameSet> typeArgs = receiverType.typeArguments();
+
+    Set<String> substituted = new LinkedHashSet<>();
+    for (int i = 0; i < typeArgs.size(); i++) {
+      String typeArgName = getTypeVariableNameIfBare(typeArgs.get(i));
+
+      if (typeArgName == null) {
+        continue;
+      }
+
+      // The declaring type may not have been given its type parameter names yet. When that is so,
+      // this parameterization is the one that will name them, since handleClassOrInterfaceType
+      // prefers the call site's type variable names and the first parameterization to arrive wins.
+      if (classTypeParams.isEmpty()
+          || (i < classTypeParams.size() && typeArgName.equals(classTypeParams.get(i)))) {
+        substituted.add(typeArgName);
+      }
+    }
+    return substituted;
+  }
+
+  /**
+   * Returns the name this FQN set holds if it is a bare name -- one with no package, no type
+   * arguments and no wildcard, which is how {@link FullyQualifiedNameGenerator} represents a type
+   * variable -- and null otherwise.
+   *
+   * @param fqnSet the FQN set to inspect
+   * @return the bare name, or null if this FQN set does not hold one
+   */
+  private static @Nullable String getTypeVariableNameIfBare(FullyQualifiedNameSet fqnSet) {
+    if (fqnSet.wildcard() != null
+        || !fqnSet.typeArguments().isEmpty()
+        || fqnSet.erasedFqns().size() != 1) {
+      return null;
+    }
+
+    String name = fqnSet.erasedFqns().iterator().next();
+    if (name.indexOf('.') >= 0 || name.indexOf('[') >= 0 || JavaLangUtils.isPrimitive(name)) {
+      return null;
+    }
+    return name;
   }
 
   /**
@@ -2860,6 +3059,21 @@ public class UnsolvedSymbolGenerator {
       }
 
       if (rhsType.isEmpty()) {
+        UnsolvedMethodAlternates rhsMethod =
+            rhs.isMethodCallExpr()
+                ? findGeneratedMethodFromMethodCall(rhs.asMethodCallExpr())
+                : null;
+
+        // A generated method that returns one of its own type variables reports no type at this
+        // call site at all (see
+        // FullyQualifiedNameGenerator#getExpressionTypesIfRepresentsGenerated)
+        // because the call site does not constrain it. There is then no placeholder return type for
+        // the code below to reconcile with the LHS, so there is nothing to do here.
+        if (rhsMethod != null
+            && rhsMethod.getReturnTypes().stream().allMatch(rhsMethod::isOwnTypeVariable)) {
+          return UnsolvedGenerationResult.EMPTY;
+        }
+
         throw new RuntimeException("Type has not been generated for the RHS of " + node);
       }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -1676,7 +1676,7 @@ public class UnsolvedSymbolGenerator {
   private List<String> typeVariablesToDeclareFromCaller(
       Node callSite, Set<String> substitutedByReceiver) {
     List<String> toDeclare = new ArrayList<>();
-    for (String name : JavaParserUtil.getTypeParameterNamesInScope(callSite)) {
+    for (String name : JavaParserUtil.getReferenceableTypeParameterNames(callSite)) {
       if (!substitutedByReceiver.contains(name)) {
         toDeclare.add(name);
       }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -1645,15 +1645,6 @@ public class UnsolvedSymbolGenerator {
 
       substituted.addAll(typeVariableNamesSubstitutedByReceiver(ancestorFQNs));
     }
-    System.err.println(
-        "DBG call="
-            + methodCall
-            + " ancestors="
-            + ancestors
-            + " scopes="
-            + potentialScopeFQNs
-            + " substituted="
-            + substituted);
     return substituted;
   }
 

--- a/src/test/java/org/checkerframework/specimin/StaticTypeVarFromCallerTest.java
+++ b/src/test/java/org/checkerframework/specimin/StaticTypeVarFromCallerTest.java
@@ -1,0 +1,37 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * When a synthetic <em>static</em> method's signature is derived from an argument whose type
+ * mentions a type variable of the <em>calling</em> method, that type variable is not in scope in
+ * the synthetic class, so the synthetic method must declare its own.
+ *
+ * <p>This is the other cause of the non-compiling output reported in <a
+ * href="https://github.com/njit-jerse/specimin/issues/442">issue #442</a>. Here {@code
+ * Simple#target} has a type variable {@code T} and passes a {@code Src<T>} to the static {@code
+ * Box.from}. Specimin copies {@code T} verbatim into the generated signature; because {@code Box}
+ * separately acquires a class-level type parameter also named {@code T} (from the {@code Box<T>}
+ * return type at the use site), the {@code T} in {@code from}'s signature silently binds to the
+ * class's type parameter, and javac rejects the output with "non-static type variable T cannot be
+ * referenced from a static context".
+ *
+ * <p>In the issue's own input this shows up as {@code reactor.core.publisher.Flux} getting {@code
+ * public static ReactorCorePublisherFluxFromReturnType from(Publisher<T> parameter0)}.
+ *
+ * <p>The expected output declares the type variable on the method. Any compilable signature that is
+ * as precise would do — for instance naming it {@code T1} instead of shadowing the class's {@code
+ * T}. What the expected output rules out is a signature that either does not compile or erases the
+ * relationship between the argument's element type and the return's, since {@code Box<?>} would not
+ * be assignable to the target's declared {@code Box<T>}.
+ */
+public class StaticTypeVarFromCallerTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "statictypevarfromcaller",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Src<T>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerBareReturnTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerBareReturnTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A calling method's type variable that reaches a synthetic method as its entire return type,
+ * rather than nested inside one.
+ *
+ * <p>This is the same leak as {@link TypeVarFromCallerInstanceTest} -- {@code Holder} is not
+ * generic, so there is no JLS 4.5.2 substitution channel and the copied {@code T} is unbound -- but
+ * it exercises a distinct path once the method declares the type variable itself. A generated
+ * method whose return type is one of its own type variables reports no type at all at a call site,
+ * since the call site does not constrain it; that is deliberate, and {@link
+ * org.checkerframework.specimin.unsolved.UnsolvedMethodAlternates#isOwnTypeVariable} exists to say
+ * so. Code that reconciles a return statement with its method's declared return type has to
+ * tolerate learning nothing, rather than treating it as a missing type.
+ */
+public class TypeVarFromCallerBareReturnTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallerbarereturn",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Holder)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerCtorSubstitutedTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerCtorSubstitutedTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The constructor counterpart of {@link TypeVarFromCallerSubstitutedTest}: a calling method's type
+ * variable that must be left alone in a synthetic constructor's signature.
+ *
+ * <p>{@code new Box<T>(src)} supplies the class's type argument explicitly, so JLS 4.5.2 applies to
+ * the constructor exactly as it does to a method of a parameterized type, and the caller's {@code
+ * T} reaches the parameter through the class's type parameter rather than by an out-of-scope name.
+ * Rewriting it to a constructor-level type variable would compile but would sever the returned
+ * {@code Box}'s element type from the argument's.
+ */
+public class TypeVarFromCallerCtorSubstitutedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallerctorsubstituted",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Src<T>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerCtorTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerCtorTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The same leak as {@link StaticTypeVarFromCallerTest}, but through a synthetic
+ * <em>constructor</em> rather than a method.
+ *
+ * <p>Constructor parameter types are built from the argument types at the call site by the same
+ * path that method parameter types are, so a calling method's type variable reaches a generated
+ * constructor's signature the same way. {@code Holder} is not generic, so there is no substitution
+ * channel (JLS 4.5.2) and the name is unbound.
+ *
+ * <p>The remedy is a generic constructor (JLS 8.8.4), which is why this fixture is worth keeping
+ * separate: it is the only one whose expected output exercises a type parameter section on a
+ * declaration that has no return type.
+ */
+public class TypeVarFromCallerCtorTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallerctor",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Src<T>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerInheritedTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerInheritedTest.java
@@ -1,0 +1,26 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Calls to inherited synthetic methods through {@code this} and through no scope at all, where the
+ * enclosing class's type variables must be left alone.
+ *
+ * <p>{@link TypeVarMatchingTest} covers the same situation for {@code super}. All three reach the
+ * declaring type the same way -- the member is inherited, so the parameterization JLS 4.5.2
+ * substitutes through is the one written in the {@code extends} clause, not one carried by a
+ * receiver expression -- but only {@code super} was exercised. A rule that recognized the
+ * substitution for {@code super} alone would declare {@code E} and {@code V} on these two methods,
+ * shadowing {@code SimpleParent}'s own type parameters and severing the relationship between the
+ * argument and return types.
+ */
+public class TypeVarFromCallerInheritedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallerinherited",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#get(E)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerInnerClassTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerInnerClassTest.java
@@ -1,0 +1,31 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A type variable of the enclosing class, reached from a non-static inner class, which the
+ * synthetic method must declare.
+ *
+ * <p>This is the fixture that pins down {@link
+ * org.checkerframework.specimin.JavaParserUtil#getReferenceableTypeParameterNames} in the direction
+ * that can produce non-compiling output. {@code Inner} is not static, so JLS 8.1.2 does not forbid
+ * naming {@code Simple}'s {@code C} inside it, and {@code C} genuinely appears in {@code target}'s
+ * signature. A walk that treated any nested type as a static boundary would leave {@code C} out of
+ * the referenceable set, {@code Box.from} would not declare it, and the output would fail with
+ * "non- static type variable C cannot be referenced from a static context".
+ *
+ * <p>The other two fixtures added with this one ({@link TypeVarFromCallerStaticScopeTest} and
+ * {@link TypeVarFromCallerInterfaceMemberTest}) cover the static cases, where the excluded names
+ * are ones no type at the call site could mention anyway, so they can only guard against dropping a
+ * type variable that is still usable.
+ */
+public class TypeVarFromCallerInnerClassTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallerinnerclass",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple.Inner#target(Src<C>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerInstanceTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerInstanceTest.java
@@ -1,0 +1,28 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A type variable of the calling method leaks into a synthetic <em>instance</em> method whose
+ * declaring type has no type parameter at all.
+ *
+ * <p>This is the same defect as {@link StaticTypeVarFromCallerTest}, but on the branch where the
+ * leaked name has nothing to bind to: {@code Holder} is not generic, so the {@code T} that Specimin
+ * copies out of {@code Simple#target} is simply an unresolvable name in {@code Holder}'s body
+ * rather than a static-context violation. Per JLS 6.3 a type variable's scope is the declaration
+ * that binds it, so the name was never meaningful here; the differing diagnostic is incidental.
+ *
+ * <p>Because {@code Holder} has no type parameter, JLS 4.5.2 offers no substitution channel from
+ * the call site to the signature, so the relationship between the argument's element type and the
+ * return's can only be expressed by a type variable that the method itself declares.
+ */
+public class TypeVarFromCallerInstanceTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallerinstance",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Src<T>, Holder)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerInterfaceMemberTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerInterfaceMemberTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The implicitly static case: a member class of an interface.
+ *
+ * <p>{@code Helper} carries no {@code static} modifier, but a member type of an interface is
+ * implicitly static (JLS 9.1.1.3), so {@code Simple}'s {@code C} is not nameable inside it. That
+ * distinction is invisible to {@code isStatic()}, which reports only the written modifier, so this
+ * fixture covers the branch that has to recognise it. As with {@link
+ * TypeVarFromCallerStaticScopeTest}, what it can actually catch is dropping {@code target}'s own
+ * {@code T}.
+ */
+public class TypeVarFromCallerInterfaceMemberTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallerinterfacemember",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple.Helper#target(Src<T>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerMismatchTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerMismatchTest.java
@@ -1,0 +1,38 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A synthetic instance method whose declaring type <em>does</em> have a type parameter of the
+ * leaked name, but where the receiver at this call site instantiates that type parameter to
+ * something else.
+ *
+ * <p>This is the case that makes "the declaring type has a type parameter of this name, and the
+ * member is not static" too weak a test. Here {@code src} has type {@code Src<String>}, so by JLS
+ * 4.5.2 the type of {@code put} as a member of {@code Src<String>} is obtained by substituting
+ * {@code String} for the class's type parameter. Leaving the caller's {@code T} in the signature
+ * therefore does not mean "the argument's type" -- it means {@code String} -- and the call {@code
+ * src.put(item)} passing a {@code T} does not compile.
+ *
+ * <p>The collision here does not come from Specimin preferring the call site's type variable name
+ * for the class's type parameter: {@code Src<String>} contributes no type variable name, and the
+ * class's parameter is named {@code T} simply because that is the first generated name. So the
+ * clash arises from both sources independently, and a fix must key on whether the caller's type
+ * variable actually occupies that position in the receiver's type, not on the name.
+ *
+ * <p>The call's result is discarded, so {@code put}'s return type is the invented placeholder
+ * {@code PutReturnType}. That is unrelated to what this fixture pins down, but it is deliberate:
+ * constraining the return instead (by assigning the call to a {@code String}) makes Specimin give
+ * {@code put} an unconstrained type variable return type, which then captures the leaked parameter
+ * name by coincidence and hides the defect under test.
+ */
+public class TypeVarFromCallerMismatchTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallermismatch",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Src<String>, T)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerStaticScopeTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerStaticScopeTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A static method's own type variable, inside a generic class whose type parameter it may not name.
+ *
+ * <p>By JLS 8.1.2 the call site cannot refer to {@code Simple}'s {@code C}, but {@code target}'s
+ * own {@code T} is unaffected -- JLS 8.4.4 puts a method's type parameters in scope throughout its
+ * declaration, static or not. This guards the obvious way to get JLS 8.1.2 wrong: stopping the walk
+ * at a static method rather than excluding only the enclosing type's parameters. Doing that would
+ * drop {@code T}, and {@code Box.from} would be left referring to a type variable it does not
+ * declare.
+ */
+public class TypeVarFromCallerStaticScopeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallerstaticscope",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Src<T>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerSubstitutedTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerSubstitutedTest.java
@@ -1,0 +1,29 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The case in which a calling method's type variable may legitimately stay in a synthetic
+ * signature, and must not be rewritten.
+ *
+ * <p>{@code src.wrap()} has receiver type {@code Src<T>}, and the synthetic {@code Src} acquires a
+ * class-level type parameter named after that very type variable. The {@code T} in {@code wrap}'s
+ * return type is therefore not a stray copy of the caller's name: it is a substitution site. By JLS
+ * 4.5.2 the type of a member of {@code Src<T>} is the member's type with the class's type parameter
+ * replaced by the receiver's type argument, so the call yields {@code Box<T>} precisely because the
+ * class type parameter is instantiated to the caller's {@code T}.
+ *
+ * <p>This is the negative half of the fix for {@link StaticTypeVarFromCallerTest}: a rule that
+ * rewrote every caller type variable would emit {@code <T1> Box<T1> wrap()} here, which still
+ * compiles but discards a relationship that the class type parameter was already carrying exactly.
+ */
+public class TypeVarFromCallerSubstitutedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallersubstituted",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Src<T>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerThrowsTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerThrowsTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
  * <p>Learning that the method throws replaces its alternates with copies. The goal of this test
  * case is to ensure that these copies are faithful. The name of the type variable in the input
  * therefore has to differ from Specimin's default generated name: with a calling type variable
- * named {@code T}, as in the other fixtures in this group, the reconstruction would only happen
- * to agree.
+ * named {@code T}, as in the other fixtures in this group, the reconstruction would only happen to
+ * agree.
  */
 public class TypeVarFromCallerThrowsTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/TypeVarFromCallerThrowsTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarFromCallerThrowsTest.java
@@ -1,0 +1,25 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The same leak as {@link StaticTypeVarFromCallerTest}, on a method that also acquires a {@code
+ * throws} clause, and with a calling type variable whose name is not the one Specimin would have
+ * generated.
+ *
+ * <p>Learning that the method throws replaces its alternates with copies. The goal of this test
+ * case is to ensure that these copies are faithful. The name of the type variable in the input
+ * therefore has to differ from Specimin's default generated name: with a calling type variable
+ * named {@code T}, as in the other fixtures in this group, the reconstruction would only happen
+ * to agree.
+ */
+public class TypeVarFromCallerThrowsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarfromcallerthrows",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Src<V>)"});
+  }
+}

--- a/src/test/resources/statictypevarfromcaller/expected/com/example/Simple.java
+++ b/src/test/resources/statictypevarfromcaller/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public class Simple {
+
+  public static <T> Box<T> target(Src<T> src) {
+    return Box.from(src);
+  }
+}

--- a/src/test/resources/statictypevarfromcaller/expected/com/example/other/Box.java
+++ b/src/test/resources/statictypevarfromcaller/expected/com/example/other/Box.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Box<T> {
+
+    public static <T> com.example.other.Box<T> from(com.example.other.Src<T> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/statictypevarfromcaller/expected/com/example/other/Src.java
+++ b/src/test/resources/statictypevarfromcaller/expected/com/example/other/Src.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class Src<T> {
+}

--- a/src/test/resources/statictypevarfromcaller/input/com/example/Simple.java
+++ b/src/test/resources/statictypevarfromcaller/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public class Simple {
+  public static <T> Box<T> target(Src<T> src) {
+    return Box.from(src);
+  }
+}

--- a/src/test/resources/typevarfromcallerbarereturn/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerbarereturn/expected/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.example.other.Holder;
+
+public class Simple {
+
+  public static <T> T target(Holder h) {
+    return h.get();
+  }
+}

--- a/src/test/resources/typevarfromcallerbarereturn/expected/com/example/other/Holder.java
+++ b/src/test/resources/typevarfromcallerbarereturn/expected/com/example/other/Holder.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Holder {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallerbarereturn/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerbarereturn/input/com/example/Simple.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import com.example.other.Holder;
+
+public class Simple {
+  public static <T> T target(Holder h) {
+    return h.get();
+  }
+}

--- a/src/test/resources/typevarfromcallerctor/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerctor/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.example.other.Holder;
+import com.example.other.Src;
+
+public class Simple {
+
+  public static <T> Holder target(Src<T> src) {
+    return new Holder(src);
+  }
+}

--- a/src/test/resources/typevarfromcallerctor/expected/com/example/other/Holder.java
+++ b/src/test/resources/typevarfromcallerctor/expected/com/example/other/Holder.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Holder {
+
+    public <T> Holder(com.example.other.Src<T> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallerctor/expected/com/example/other/Src.java
+++ b/src/test/resources/typevarfromcallerctor/expected/com/example/other/Src.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class Src<T> {
+}

--- a/src/test/resources/typevarfromcallerctor/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerctor/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.example.other.Holder;
+import com.example.other.Src;
+
+public class Simple {
+  public static <T> Holder target(Src<T> src) {
+    return new Holder(src);
+  }
+}

--- a/src/test/resources/typevarfromcallerctorsubstituted/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerctorsubstituted/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public class Simple {
+
+  public static <T> Box<T> target(Src<T> src) {
+    return new Box<T>(src);
+  }
+}

--- a/src/test/resources/typevarfromcallerctorsubstituted/expected/com/example/other/Box.java
+++ b/src/test/resources/typevarfromcallerctorsubstituted/expected/com/example/other/Box.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Box<T> {
+
+    public Box(com.example.other.Src<T> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallerctorsubstituted/expected/com/example/other/Src.java
+++ b/src/test/resources/typevarfromcallerctorsubstituted/expected/com/example/other/Src.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class Src<T> {
+}

--- a/src/test/resources/typevarfromcallerctorsubstituted/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerctorsubstituted/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public class Simple {
+  public static <T> Box<T> target(Src<T> src) {
+    return new Box<T>(src);
+  }
+}

--- a/src/test/resources/typevarfromcallerinherited/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerinherited/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.testing.SimpleParent;
+
+class Simple<E, V> extends SimpleParent<E, V> {
+
+  public V get(E input) {
+    V first = this.fetch(input);
+    return store(first);
+  }
+}

--- a/src/test/resources/typevarfromcallerinherited/expected/org/testing/SimpleParent.java
+++ b/src/test/resources/typevarfromcallerinherited/expected/org/testing/SimpleParent.java
@@ -1,0 +1,11 @@
+package org.testing;
+public class SimpleParent<E, V> {
+
+    public V store(V parameter0) {
+        throw new java.lang.Error();
+    }
+
+    public V fetch(E parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallerinherited/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerinherited/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.testing.SimpleParent;
+
+class Simple<E, V> extends SimpleParent<E, V> {
+    public V get(E input) {
+        V first = this.fetch(input);
+        return store(first);
+    }
+}

--- a/src/test/resources/typevarfromcallerinnerclass/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerinnerclass/expected/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public class Simple<C> {
+
+  class Inner {
+
+    public Box<C> target(Src<C> src) {
+      return Box.from(src);
+    }
+  }
+}

--- a/src/test/resources/typevarfromcallerinnerclass/expected/com/example/other/Box.java
+++ b/src/test/resources/typevarfromcallerinnerclass/expected/com/example/other/Box.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Box<C> {
+
+    public static <C> com.example.other.Box<C> from(com.example.other.Src<C> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallerinnerclass/expected/com/example/other/Src.java
+++ b/src/test/resources/typevarfromcallerinnerclass/expected/com/example/other/Src.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class Src<C> {
+}

--- a/src/test/resources/typevarfromcallerinnerclass/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerinnerclass/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public class Simple<C> {
+  class Inner {
+    public Box<C> target(Src<C> src) {
+      return Box.from(src);
+    }
+  }
+}

--- a/src/test/resources/typevarfromcallerinstance/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerinstance/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Holder;
+import com.example.other.Src;
+
+public class Simple {
+
+  public static <T> Box<T> target(Src<T> src, Holder h) {
+    return h.wrap(src);
+  }
+}

--- a/src/test/resources/typevarfromcallerinstance/expected/com/example/other/Box.java
+++ b/src/test/resources/typevarfromcallerinstance/expected/com/example/other/Box.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class Box<T> {
+}

--- a/src/test/resources/typevarfromcallerinstance/expected/com/example/other/Holder.java
+++ b/src/test/resources/typevarfromcallerinstance/expected/com/example/other/Holder.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Holder {
+
+    public <T> com.example.other.Box<T> wrap(com.example.other.Src<T> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallerinstance/expected/com/example/other/Src.java
+++ b/src/test/resources/typevarfromcallerinstance/expected/com/example/other/Src.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class Src<T> {
+}

--- a/src/test/resources/typevarfromcallerinstance/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerinstance/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Holder;
+import com.example.other.Src;
+
+public class Simple {
+  public static <T> Box<T> target(Src<T> src, Holder h) {
+    return h.wrap(src);
+  }
+}

--- a/src/test/resources/typevarfromcallerinterfacemember/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerinterfacemember/expected/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public interface Simple<C> {
+
+  class Helper {
+
+    public <T> Box<T> target(Src<T> src) {
+      return Box.from(src);
+    }
+  }
+}

--- a/src/test/resources/typevarfromcallerinterfacemember/expected/com/example/other/Box.java
+++ b/src/test/resources/typevarfromcallerinterfacemember/expected/com/example/other/Box.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Box<T> {
+
+    public static <T> com.example.other.Box<T> from(com.example.other.Src<T> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallerinterfacemember/expected/com/example/other/Src.java
+++ b/src/test/resources/typevarfromcallerinterfacemember/expected/com/example/other/Src.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class Src<T> {
+}

--- a/src/test/resources/typevarfromcallerinterfacemember/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerinterfacemember/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public interface Simple<C> {
+  class Helper {
+    public <T> Box<T> target(Src<T> src) {
+      return Box.from(src);
+    }
+  }
+}

--- a/src/test/resources/typevarfromcallermismatch/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallermismatch/expected/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.example.other.Src;
+
+public class Simple {
+
+  public static <T> void target(Src<String> src, T item) {
+    src.put(item);
+  }
+}

--- a/src/test/resources/typevarfromcallermismatch/expected/com/example/other/PutReturnType.java
+++ b/src/test/resources/typevarfromcallermismatch/expected/com/example/other/PutReturnType.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class PutReturnType {
+}

--- a/src/test/resources/typevarfromcallermismatch/expected/com/example/other/Src.java
+++ b/src/test/resources/typevarfromcallermismatch/expected/com/example/other/Src.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Src<T> {
+
+    public <T> com.example.other.PutReturnType put(T parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallermismatch/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallermismatch/input/com/example/Simple.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import com.example.other.Src;
+
+public class Simple {
+  public static <T> void target(Src<String> src, T item) {
+    src.put(item);
+  }
+}

--- a/src/test/resources/typevarfromcallerstaticscope/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerstaticscope/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public class Simple<C> {
+
+  public static <T> Box<T> target(Src<T> src) {
+    return Box.from(src);
+  }
+}

--- a/src/test/resources/typevarfromcallerstaticscope/expected/com/example/other/Box.java
+++ b/src/test/resources/typevarfromcallerstaticscope/expected/com/example/other/Box.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Box<T> {
+
+    public static <T> com.example.other.Box<T> from(com.example.other.Src<T> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallerstaticscope/expected/com/example/other/Src.java
+++ b/src/test/resources/typevarfromcallerstaticscope/expected/com/example/other/Src.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class Src<T> {
+}

--- a/src/test/resources/typevarfromcallerstaticscope/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerstaticscope/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public class Simple<C> {
+  public static <T> Box<T> target(Src<T> src) {
+    return Box.from(src);
+  }
+}

--- a/src/test/resources/typevarfromcallersubstituted/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallersubstituted/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public class Simple {
+
+  public static <T> Box<T> target(Src<T> src) {
+    return src.wrap();
+  }
+}

--- a/src/test/resources/typevarfromcallersubstituted/expected/com/example/other/Box.java
+++ b/src/test/resources/typevarfromcallersubstituted/expected/com/example/other/Box.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class Box<T> {
+}

--- a/src/test/resources/typevarfromcallersubstituted/expected/com/example/other/Src.java
+++ b/src/test/resources/typevarfromcallersubstituted/expected/com/example/other/Src.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Src<T> {
+
+    public com.example.other.Box<T> wrap() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallersubstituted/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallersubstituted/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+
+public class Simple {
+  public static <T> Box<T> target(Src<T> src) {
+    return src.wrap();
+  }
+}

--- a/src/test/resources/typevarfromcallerthrows/expected/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerthrows/expected/com/example/Simple.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+import java.io.IOException;
+
+public class Simple {
+
+  public static <V> Box<V> target(Src<V> src) {
+    try {
+      return Box.from(src);
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/src/test/resources/typevarfromcallerthrows/expected/com/example/other/Box.java
+++ b/src/test/resources/typevarfromcallerthrows/expected/com/example/other/Box.java
@@ -1,0 +1,7 @@
+package com.example.other;
+public class Box<V> {
+
+    public static <V> com.example.other.Box<V> from(com.example.other.Src<V> parameter0) throws java.io.IOException {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarfromcallerthrows/expected/com/example/other/Src.java
+++ b/src/test/resources/typevarfromcallerthrows/expected/com/example/other/Src.java
@@ -1,0 +1,3 @@
+package com.example.other;
+public class Src<V> {
+}

--- a/src/test/resources/typevarfromcallerthrows/input/com/example/Simple.java
+++ b/src/test/resources/typevarfromcallerthrows/input/com/example/Simple.java
@@ -1,0 +1,15 @@
+package com.example;
+
+import com.example.other.Box;
+import com.example.other.Src;
+import java.io.IOException;
+
+public class Simple {
+  public static <V> Box<V> target(Src<V> src) {
+    try {
+      return Box.from(src);
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
The non-compiling output from #442 showed that Specimin's rules for type variables were incomplete, and subsequent testing (most of which led to test cases in this PR) showed that non-compilable output was common. The underlying problem was that Specimin was treating type variable names just like type names, which is not correct in general; there were a few cases that were handled, but the majority of type variable substitution cases were not covered. The implementation in this PR is a lot more thorough, and should in general prevent type variables from "leaking" into calling contexts of various kinds.