### PR TITLE
Don't drop lambda return type constraints

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -447,6 +447,23 @@ public final class JavaLangUtils {
   }
 
   /**
+   * Could the given name be a type that no generated class can be made a subtype of, judged from
+   * the name alone? Answers only for names this class knows about; a name that belongs to the
+   * project under analysis needs its declaration inspected, which {@link
+   * JavaParserUtil#isNonExtendableTypeName} does on top of this.
+   *
+   * <p>Three kinds qualify. A primitive has no subtypes at all. An array type's only supertypes are
+   * {@code Object}, {@code Cloneable} and {@code Serializable} (JLS 4.10.3), and no class
+   * declaration can name one as a superclass. A final JDK class cannot be extended (JLS 8.1.1.2).
+   *
+   * @param name a simple or fully-qualified name
+   * @return true if the input might name a type that cannot be extended
+   */
+  public static boolean isNonExtendableJdkTypeName(String name) {
+    return isPrimitive(name) || name.endsWith("[]") || isFinalJdkClass(name);
+  }
+
+  /**
    * Is the given name java.lang.String? String is worth asking about on its own because it is the
    * only type that changes what an operator means: a {@code +} with a String operand is a string
    * concatenation rather than an addition (JLS 15.18.1), and a concatenation places no constraint

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -1956,6 +1956,45 @@ public class JavaParserUtil {
   }
 
   /**
+   * Can no generated class be made a subtype of the type with this name? Callers that are about to
+   * name a type as the supertype of a synthetic class, or that need to know whether a synthetic
+   * placeholder type could stand in for it, should ask this first.
+   *
+   * <p>Beyond the JDK and primitive cases that {@link JavaLangUtils#isNonExtendableJdkTypeName}
+   * settles, a declaration in the project qualifies when it is a final class, an enum (implicitly
+   * final unless a constant has a class body, JLS 8.9), a record (implicitly final, JLS 8.10), or
+   * an annotation type. A non-final class or an interface can take a generated subtype, and so does
+   * not qualify; neither does a name Specimin will synthesize a type for, since Specimin writes
+   * that declaration itself and does not make it final.
+   *
+   * @param fqn a fully-qualified name
+   * @param fqnToCompilationUnits A map of fully-qualified type names to their compilation units
+   * @return true if no generated class could be made a subtype of the named type
+   */
+  public static boolean isNonExtendableTypeName(
+      String fqn, Map<String, CompilationUnit> fqnToCompilationUnits) {
+    if (fqn.startsWith("?")) {
+      // A wildcard names a bound rather than a type. A type satisfying the bound may well be
+      // extendable, so this says nothing.
+      return false;
+    }
+
+    if (JavaLangUtils.isNonExtendableJdkTypeName(fqn)) {
+      return true;
+    }
+
+    TypeDeclaration<?> decl = getTypeFromQualifiedName(fqn, fqnToCompilationUnits);
+
+    if (decl instanceof ClassOrInterfaceDeclaration classOrInterface) {
+      return !classOrInterface.isInterface() && classOrInterface.isFinal();
+    }
+
+    // An enum, record, or annotation declaration in the project; none can be extended. Null means
+    // the name is not in the project at all, which says nothing either way.
+    return decl != null;
+  }
+
+  /**
    * Given an AssociableToAST that could give a detached node, find its attached equivalent. This
    * method is only necessary when you need to call resolve() or calculateResolvedType() on its
    * children. Throws if the result is null; use {@link #tryFindAttachedNode(AssociableToAST, Map)}
@@ -2600,6 +2639,30 @@ public class JavaParserUtil {
    * @return the first return statement belonging to {@code lambda}, or null if it has none
    */
   public static @Nullable ReturnStmt findOwnReturnStmt(LambdaExpr lambda) {
+    List<ReturnStmt> ownReturns = findOwnReturnStmts(lambda);
+    return ownReturns.isEmpty() ? null : ownReturns.get(0);
+  }
+
+  /**
+   * Returns every return statement in the given lambda's block body that belongs to that lambda, in
+   * source order.
+   *
+   * <p>A return may be nested arbitrarily deep inside the body, so the search is recursive. It is
+   * therefore frequent for a return reached to belong to a nested lambda, or to a method of an
+   * anonymous or local class declared in the body; such a return belongs to that construct rather
+   * than to this lambda, and is skipped.
+   *
+   * <p>Callers that reason about one property shared by all of a legal body's returns -- their
+   * voidness, say -- can use {@link #findOwnReturnStmt(LambdaExpr)} instead, but callers that
+   * constrain the returned expressions need all of them, since each is a separate expression with
+   * its own type.
+   *
+   * @param lambda a lambda expression whose body is a block statement
+   * @return every return statement belonging to {@code lambda}; empty if it has none of its own
+   */
+  public static List<ReturnStmt> findOwnReturnStmts(LambdaExpr lambda) {
+    List<ReturnStmt> ownReturns = new ArrayList<>();
+
     for (ReturnStmt returnStmt : lambda.getBody().asBlockStmt().findAll(ReturnStmt.class)) {
       // Reference equality is intentional: we need to know whether this exact return statement
       // belongs to this lambda, not whether some structurally-equal return statement does (a
@@ -2609,10 +2672,11 @@ public class JavaParserUtil {
       @SuppressWarnings({"ReferenceEquality", "not.interned"})
       boolean belongsToThisLambda = findClosestMethodOrLambdaAncestor(returnStmt) == lambda;
       if (belongsToThisLambda) {
-        return returnStmt;
+        ownReturns.add(returnStmt);
       }
     }
-    return null;
+
+    return ownReturns;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -1562,6 +1562,68 @@ public class FullyQualifiedNameGenerator {
   }
 
   /**
+   * Given a lambda expression, return the FQNs of the type its result expressions must have: the
+   * return type of the functional method of the lambda's target type. By JLS 15.27.3 each result
+   * expression of a lambda congruent with a function type sits in an assignment context whose
+   * target type is that function type's result, so this is the same kind of constraint that a
+   * variable initializer or a {@code return} in a method body imposes.
+   *
+   * <p>Note that this reads the lambda's *target* type, from {@link
+   * #getFQNsFromSurroundingContextType(Expression)}, rather than the lambda's own type from {@link
+   * #getFQNsForLambdaType(LambdaExpr)}: the latter is synthesized from the lambda's arity and
+   * voidness alone and so never carries a result type worth constraining anything with.
+   *
+   * @param lambda The lambda expression
+   * @return The FQNs of the required type of the lambda's result expressions, or null if the target
+   *     type does not constrain them
+   */
+  public @Nullable Set<FullyQualifiedNameSet> getFQNsForLambdaResultType(LambdaExpr lambda) {
+    if (!lambda.hasParentNode()) {
+      return null;
+    }
+
+    Set<FullyQualifiedNameSet> targetTypes = getFQNsFromSurroundingContextType(lambda);
+
+    if (targetTypes == null) {
+      return null;
+    }
+
+    Set<FullyQualifiedNameSet> result = new LinkedHashSet<>();
+
+    for (FullyQualifiedNameSet targetType : targetTypes) {
+      if (targetType.erasedFqns().size() != 1) {
+        // Which functional interface this is has to be known before its functional method's return
+        // type can be read off.
+        return null;
+      }
+
+      if (targetType.typeArguments().isEmpty()
+          && targetType.erasedFqns().iterator().next().startsWith("java.util.function.")) {
+        // A raw java.util.function type. Its result type is whatever the raw type erases it to,
+        // which constrains nothing; bail out before normalization, which indexes type arguments.
+        return null;
+      }
+
+      FullyQualifiedNameSet resultType =
+          FunctionalInterfaceHelper.getReturnTypeFromNormalizedFunctionalInterface(
+              FunctionalInterfaceHelper.convertToNormalFunctionalInterface(targetType));
+
+      if (resultType == null || resultType.wildcard() != null) {
+        // Either the functional method is void or the interface is not one whose result type can be
+        // read off its type arguments (both give null), or the result is a wildcard, as it is for
+        // the Supplier<?>/Function<?, ?> that Specimin synthesizes for a lambda passed to an
+        // unsolved method. None of these constrain the result expressions at all, and per the rule
+        // that a guess is worse than silence, saying nothing is the right answer.
+        return null;
+      }
+
+      result.add(resultType);
+    }
+
+    return result.isEmpty() ? null : result;
+  }
+
+  /**
    * Given an expression that can be resolved (but calculateResolvedType() fails), return the best
    * shot at its type based on a resolved declaration. May return null if a type cannot be found
    * from the resolved declaration.
@@ -1936,10 +1998,21 @@ public class FullyQualifiedNameGenerator {
         }
       }
     } else if (parentNode instanceof ReturnStmt returnStmt) {
-      if (JavaParserUtil.findClosestMethodOrLambdaAncestor(returnStmt)
-          instanceof MethodDeclaration methodDecl) {
+      Node methodOrLambda = JavaParserUtil.findClosestMethodOrLambdaAncestor(returnStmt);
+
+      if (methodOrLambda instanceof MethodDeclaration methodDecl) {
         return Set.of(getFQNsFromType(methodDecl.getType()));
+      } else if (methodOrLambda instanceof LambdaExpr lambda) {
+        return getFQNsForLambdaResultType(lambda);
       }
+    } else if (parentNode instanceof ExpressionStmt exprStmt
+        && exprStmt.getParentNode().orElse(null) instanceof LambdaExpr lambda
+        && lambda.getExpressionBody().isPresent()
+        && lambda.getExpressionBody().get().equals(expr)) {
+      // An expression-bodied lambda has no ReturnStmt to hang the constraint on. Its body is stored
+      // as an ExpressionStmt, which getExpressionBody() unwraps, so the result expression's parent
+      // is that statement rather than the lambda.
+      return getFQNsForLambdaResultType(lambda);
     } else if (parentNode instanceof ForEachStmt forEachStmt) {
 
       if (forEachStmt.getIterable().equals(expr)) {

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -1608,12 +1608,15 @@ public class FullyQualifiedNameGenerator {
           FunctionalInterfaceHelper.getReturnTypeFromNormalizedFunctionalInterface(
               FunctionalInterfaceHelper.convertToNormalFunctionalInterface(targetType));
 
-      if (resultType == null || resultType.wildcard() != null) {
-        // Either the functional method is void or the interface is not one whose result type can be
-        // read off its type arguments (both give null), or the result is a wildcard, as it is for
-        // the Supplier<?>/Function<?, ?> that Specimin synthesizes for a lambda passed to an
-        // unsolved method. None of these constrain the result expressions at all, and per the rule
-        // that a guess is worse than silence, saying nothing is the right answer.
+      if (resultType == null
+          || resultType.wildcard() != null
+          || SpeciminGenerationUtils.isATypeVariable(resultType)) {
+        // Nothing usable. Either the functional method is void or the interface is not one whose
+        // result type can be read off its type arguments (both give null); or the result is a
+        // wildcard, as it is for the Supplier<?>/Function<?, ?> that Specimin synthesizes for a
+        // lambda passed to an unsolved method; or it is a type variable of some enclosing
+        // declaration, which names no type at all and is not even in scope where the constrained
+        // symbol would be generated.
         return null;
       }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/SpeciminGenerationUtils.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/SpeciminGenerationUtils.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import org.checkerframework.specimin.JavaLangUtils;
 import org.checkerframework.specimin.JavaParserUtil;
 
@@ -58,16 +59,39 @@ public class SpeciminGenerationUtils {
    * @return True if the MemberType is a type variable, false otherwise
    */
   public static boolean isATypeVariable(MemberType memberType) {
-    if (memberType.getFullyQualifiedNames().size() != 1) {
+    return isATypeVariable(
+        memberType.getFullyQualifiedNames(), memberType.getTypeArguments().isEmpty());
+  }
+
+  /**
+   * Determine if a FullyQualifiedNameSet is a type variable. Same heuristic as {@link
+   * #isATypeVariable(MemberType)}.
+   *
+   * @param fqnSet The FullyQualifiedNameSet to check
+   * @return True if the FullyQualifiedNameSet is a type variable, false otherwise
+   */
+  public static boolean isATypeVariable(FullyQualifiedNameSet fqnSet) {
+    return fqnSet.wildcard() == null
+        && isATypeVariable(fqnSet.erasedFqns(), fqnSet.typeArguments().isEmpty());
+  }
+
+  /**
+   * Shared implementation of the type-variable heuristic: a type variable is named by a single name
+   * that is already simple, is not a primitive, and carries no type arguments.
+   *
+   * @param names the candidate names of the type
+   * @param hasNoTypeArguments whether the type has no type arguments
+   * @return True if this is a type variable, false otherwise
+   */
+  private static boolean isATypeVariable(Set<String> names, boolean hasNoTypeArguments) {
+    if (names.size() != 1) {
       return false;
     }
 
-    String name = memberType.getFullyQualifiedNames().iterator().next();
+    String name = names.iterator().next();
     String simple = JavaParserUtil.getSimpleNameFromQualifiedName(JavaParserUtil.erase(name));
 
-    return name.equals(simple)
-        && memberType.getTypeArguments().isEmpty()
-        && !JavaLangUtils.isPrimitive(simple);
+    return name.equals(simple) && hasNoTypeArguments && !JavaLangUtils.isPrimitive(simple);
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -3027,7 +3027,7 @@ public class UnsolvedSymbolGenerator {
                 fullyQualifiedNameGenerator.getFQNsForExpressionType(rhs));
         // The result type is known only by name here, so there is no ResolvedType to hand over.
         // This is a supported input: it selects addSuperType over forceSuperClass/
-        // forceSuperInterface, and finalityOfLHS below falls back to deciding by name.
+        // forceSuperInterface, and isFinalClass below falls back to deciding by name.
         getResolvedTypeOfLHS = () -> null;
       } else {
         throw new RuntimeException(
@@ -4258,6 +4258,13 @@ public class UnsolvedSymbolGenerator {
    * unconstrained-return-type fallback it would reach for the equivalent assignment or {@code
    * return} statement, instead of going on to demand an impossible subtype.
    *
+   * <p>When deciding by name, {@code lhsTypes} is a disjunction: several candidate types, and
+   * within each, several candidate names, exactly one of which the left-hand side really is. Every
+   * candidate must be a final class before this returns true, because a single non-final candidate
+   * is a reading under which a subtype is still possible. Note that false is not a safe default to
+   * approximate with when the answer is unclear: both answers can cost compilability, since the
+   * unconstrained return type that true leads to strands any member access on the result.
+   *
    * @param resolvedLHSType the resolved type of the left-hand side, or null if it is not resolvable
    * @param lhsTypes the type(s) of the left-hand side
    * @return true if the left-hand side is known to be a final class
@@ -4285,19 +4292,36 @@ public class UnsolvedSymbolGenerator {
           && ((ClassOrInterfaceDeclaration) decl.toAst().get()).isFinal();
     }
 
-    // A single type with a single name, or there is no one type to ask about.
-    if (lhsTypes.size() != 1) {
+    // No candidates says nothing about finality, so do not let the loops below pass vacuously.
+    if (lhsTypes.isEmpty()) {
       return false;
     }
 
-    Set<String> fqns = lhsTypes.iterator().next().getFullyQualifiedNames();
+    for (MemberType lhsType : lhsTypes) {
+      Set<String> fqns = lhsType.getFullyQualifiedNames();
 
-    if (fqns.size() != 1) {
-      return false;
+      if (fqns.isEmpty()) {
+        return false;
+      }
+
+      for (String fqn : fqns) {
+        if (!isFinalClassName(fqn)) {
+          return false;
+        }
+      }
     }
 
-    String fqn = fqns.iterator().next();
+    return true;
+  }
 
+  /**
+   * Does this fully-qualified name name a final class? Names that Specimin will synthesize a type
+   * for are not final: Specimin chooses those types' modifiers, and never makes them final here.
+   *
+   * @param fqn a fully-qualified name
+   * @return true if the name is that of a final class
+   */
+  private boolean isFinalClassName(String fqn) {
     if (JavaLangUtils.isFinalJdkClass(fqn)) {
       return true;
     }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2932,26 +2932,19 @@ public class UnsolvedSymbolGenerator {
         || (node instanceof ReturnStmt returnStmt && returnStmt.getExpression().isPresent())
         || node instanceof LambdaExpr) {
       Set<MemberType> lhsType;
-      Set<MemberType> rhsType;
 
       Supplier<@Nullable ResolvedType> getResolvedTypeOfLHS;
 
-      // There is a chance we find a final LHS type below. In this case, we cannot make the RHS a
-      // subtype. This can happen when the RHS is an unsolved method and we created a synthetic
-      // type for its return type, but we need to modify that return type to use a generic
-      // unconstrained type variable instead.
-      Expression rhs;
-      UnsolvedMethodAlternates methodWithPotentiallyUnconstrainedReturnType = null;
+      // A lambda has one result expression per return statement of its own, and each is separately
+      // constrained by the target type; every other kind of node here has exactly one.
+      List<Expression> rhsExpressions;
 
       if (node instanceof AssignExpr assignExpr) {
         Expression lhs = assignExpr.getTarget();
-        rhs = assignExpr.getValue();
+        rhsExpressions = List.of(assignExpr.getValue());
         lhsType =
             getMemberTypesAndExpectNonNullFromFQNSets(
                 fullyQualifiedNameGenerator.getFQNsForExpressionType(lhs));
-        rhsType =
-            getMemberTypesAndExpectNonNullFromFQNSets(
-                fullyQualifiedNameGenerator.getFQNsForExpressionType(rhs));
 
         getResolvedTypeOfLHS = () -> Resolver.calculateResolvedType(lhs);
       } else if (node instanceof VariableDeclarator varDecl) {
@@ -2961,13 +2954,10 @@ public class UnsolvedSymbolGenerator {
           return UnsolvedGenerationResult.EMPTY;
         }
 
-        rhs = varDecl.getInitializer().get();
+        rhsExpressions = List.of(varDecl.getInitializer().get());
         MemberType lhsMemberType =
             getMemberTypeFromFQNs(fullyQualifiedNameGenerator.getFQNsFromType(lhs), false);
         lhsType = lhsMemberType == null ? Set.of() : Set.of(lhsMemberType);
-        rhsType =
-            getMemberTypesAndExpectNonNullFromFQNSets(
-                fullyQualifiedNameGenerator.getFQNsForExpressionType(rhs));
 
         getResolvedTypeOfLHS = () -> Resolver.resolve(lhs);
       } else if (node instanceof ReturnStmt returnStmt) {
@@ -2975,13 +2965,10 @@ public class UnsolvedSymbolGenerator {
 
         if (methodOrLambda instanceof MethodDeclaration methodDecl) {
           Type lhs = methodDecl.getType();
-          rhs = returnStmt.getExpression().get();
+          rhsExpressions = List.of(returnStmt.getExpression().get());
           MemberType lhsMemberType =
               getMemberTypeFromFQNs(fullyQualifiedNameGenerator.getFQNsFromType(lhs), false);
           lhsType = lhsMemberType == null ? Set.of() : Set.of(lhsMemberType);
-          rhsType =
-              getMemberTypesAndExpectNonNullFromFQNSets(
-                  fullyQualifiedNameGenerator.getFQNsForExpressionType(rhs));
           getResolvedTypeOfLHS = () -> Resolver.resolve(lhs);
         } else {
           // Do not handle here: handle when we encounter the ancestor LambdaExpr node
@@ -3001,15 +2988,22 @@ public class UnsolvedSymbolGenerator {
         }
 
         if (lambdaExpr.getExpressionBody().isPresent()) {
-          rhs = lambdaExpr.getExpressionBody().get();
+          rhsExpressions = List.of(lambdaExpr.getExpressionBody().get());
         } else {
-          ReturnStmt returnStmt = JavaParserUtil.findOwnReturnStmt(lambdaExpr);
+          // Every one of the lambda's own returns is a separate result expression that the target
+          // type constrains, so all of them are collected: constraining only the first would leave
+          // the rest free to keep a placeholder type the target type cannot accept.
+          rhsExpressions = new ArrayList<>();
 
-          if (returnStmt == null || returnStmt.getExpression().isEmpty()) {
-            return UnsolvedGenerationResult.EMPTY;
+          for (ReturnStmt returnStmt : JavaParserUtil.findOwnReturnStmts(lambdaExpr)) {
+            if (returnStmt.getExpression().isPresent()) {
+              rhsExpressions.add(returnStmt.getExpression().get());
+            }
           }
 
-          rhs = returnStmt.getExpression().get();
+          if (rhsExpressions.isEmpty()) {
+            return UnsolvedGenerationResult.EMPTY;
+          }
         }
 
         Set<MemberType> resultTypes = new LinkedHashSet<>();
@@ -3022,12 +3016,9 @@ public class UnsolvedSymbolGenerator {
         }
 
         lhsType = resultTypes;
-        rhsType =
-            getMemberTypesAndExpectNonNullFromFQNSets(
-                fullyQualifiedNameGenerator.getFQNsForExpressionType(rhs));
         // The result type is known only by name here, so there is no ResolvedType to hand over.
         // This is a supported input: it selects addSuperType over forceSuperClass/
-        // forceSuperInterface, and isFinalClass below falls back to deciding by name.
+        // forceSuperInterface, and isNonExtendableType below falls back to deciding by name.
         getResolvedTypeOfLHS = () -> null;
       } else {
         throw new RuntimeException(
@@ -3036,63 +3027,69 @@ public class UnsolvedSymbolGenerator {
                 + " instead!");
       }
 
-      if (rhsType.isEmpty()) {
-        UnsolvedMethodAlternates rhsMethod =
-            rhs.isMethodCallExpr()
-                ? findGeneratedMethodFromMethodCall(rhs.asMethodCallExpr())
-                : null;
-
-        // A generated method that returns one of its own type variables reports no type at this
-        // call site at all (see
-        // FullyQualifiedNameGenerator#getExpressionTypesIfRepresentsGenerated)
-        // because the call site does not constrain it. There is then no placeholder return type for
-        // the code below to reconcile with the LHS, so there is nothing to do here.
-        if (rhsMethod != null
-            && rhsMethod.getReturnTypes().stream().allMatch(rhsMethod::isOwnTypeVariable)) {
-          return UnsolvedGenerationResult.EMPTY;
-        }
-
-        throw new RuntimeException("Type has not been generated for the RHS of " + node);
-      }
-
       if (lhsType.isEmpty()) {
         throw new RuntimeException("Type has not been generated for the LHS of " + node);
       }
 
-      if (rhs.isMethodCallExpr()) {
-        methodWithPotentiallyUnconstrainedReturnType =
-            findGeneratedMethodFromMethodCall(rhs.asMethodCallExpr());
-      }
+      for (Expression rhs : rhsExpressions) {
+        Set<MemberType> rhsType =
+            getMemberTypesAndExpectNonNullFromFQNSets(
+                fullyQualifiedNameGenerator.getFQNsForExpressionType(rhs));
 
-      boolean handledAsFinalClass = false;
-      if (methodWithPotentiallyUnconstrainedReturnType != null
-          && isFinalClass(getResolvedTypeOfLHS.get(), lhsType)) {
-        Set<UnsolvedClassOrInterfaceAlternates> symbolsToRemove = new HashSet<>();
-        for (MemberType returnType :
-            methodWithPotentiallyUnconstrainedReturnType.getReturnTypes()) {
-          if (returnType instanceof UnsolvedMemberType unsolvedReturnType
-              && unsolvedReturnType.usesGeneratedName()) {
-            // Check to see if it is unused everywhere (no methods or fields)
-            if (findAllMembers(unsolvedReturnType.getUnsolvedType()).isEmpty()) {
-              symbolsToRemove.add(unsolvedReturnType.getUnsolvedType());
+        // There is a chance the LHS type cannot be extended. In that case, we cannot make the RHS
+        // a subtype. This can happen when the RHS is an unsolved method and we created a synthetic
+        // type for its return type, but we need to modify that return type to use a generic
+        // unconstrained type variable instead.
+        UnsolvedMethodAlternates methodWithPotentiallyUnconstrainedReturnType =
+            rhs.isMethodCallExpr()
+                ? findGeneratedMethodFromMethodCall(rhs.asMethodCallExpr())
+                : null;
+
+        if (rhsType.isEmpty()) {
+          // A generated method that returns one of its own type variables reports no type at this
+          // call site at all (see
+          // FullyQualifiedNameGenerator#getExpressionTypesIfRepresentsGenerated)
+          // because the call site does not constrain it. There is then no placeholder return type
+          // for the code below to reconcile with the LHS, so there is nothing to do here.
+          if (methodWithPotentiallyUnconstrainedReturnType != null
+              && methodWithPotentiallyUnconstrainedReturnType.getReturnTypes().stream()
+                  .allMatch(methodWithPotentiallyUnconstrainedReturnType::isOwnTypeVariable)) {
+            continue;
+          }
+
+          throw new RuntimeException("Type has not been generated for the RHS of " + node);
+        }
+
+        boolean handledAsNonExtendable = false;
+        if (methodWithPotentiallyUnconstrainedReturnType != null
+            && isNonExtendableType(getResolvedTypeOfLHS.get(), lhsType)) {
+          Set<UnsolvedClassOrInterfaceAlternates> symbolsToRemove = new HashSet<>();
+          for (MemberType returnType :
+              methodWithPotentiallyUnconstrainedReturnType.getReturnTypes()) {
+            if (returnType instanceof UnsolvedMemberType unsolvedReturnType
+                && unsolvedReturnType.usesGeneratedName()) {
+              // Check to see if it is unused everywhere (no methods or fields)
+              if (findAllMembers(unsolvedReturnType.getUnsolvedType()).isEmpty()) {
+                symbolsToRemove.add(unsolvedReturnType.getUnsolvedType());
+              }
             }
           }
+
+          methodWithPotentiallyUnconstrainedReturnType.setUnconstrainedReturnType();
+          for (UnsolvedClassOrInterfaceAlternates symbolToRemove : symbolsToRemove) {
+            removeTypeAndReplaceUses(
+                new UnsolvedMemberType(symbolToRemove, 0, List.of(), false),
+                new SolvedMemberType("java.lang.Object"));
+          }
+
+          toRemove.addAll(symbolsToRemove);
+
+          handledAsNonExtendable = true;
         }
 
-        methodWithPotentiallyUnconstrainedReturnType.setUnconstrainedReturnType();
-        for (UnsolvedClassOrInterfaceAlternates symbolToRemove : symbolsToRemove) {
-          removeTypeAndReplaceUses(
-              new UnsolvedMemberType(symbolToRemove, 0, List.of(), false),
-              new SolvedMemberType("java.lang.Object"));
+        if (!handledAsNonExtendable) {
+          handleLHSAndRHSRelationship(lhsType, rhsType, getResolvedTypeOfLHS);
         }
-
-        toRemove.addAll(symbolsToRemove);
-
-        handledAsFinalClass = true;
-      }
-
-      if (!handledAsFinalClass) {
-        handleLHSAndRHSRelationship(lhsType, rhsType, getResolvedTypeOfLHS);
       }
     } else if (node instanceof MethodCallExpr
         || node instanceof ObjectCreationExpr
@@ -4248,9 +4245,15 @@ public class UnsolvedSymbolGenerator {
   }
 
   /**
-   * Is the left-hand side of an assignment a final class? Nothing can be made a subtype of one, so
-   * a generated method whose result is assigned to it cannot be given a generated placeholder
-   * return type.
+   * Can no generated class be made a subtype of the left-hand side of an assignment? If so, a
+   * generated method whose result is assigned to it cannot be given a generated placeholder return
+   * type, and must fall back to an unconstrained type variable instead.
+   *
+   * <p>Final classes are the obvious case, but they are not the only one. A primitive and an array
+   * type have no declarable subtypes at all; an enum is implicitly final unless it has constant
+   * bodies, none of which a generated class could be (JLS 8.9); a record is implicitly final (JLS
+   * 8.10); and an annotation type cannot be extended. Only a non-final class or an interface can
+   * take a generated subtype.
    *
    * <p>The resolved type is preferred when there is one, but the left-hand side is sometimes known
    * only by name -- a lambda's result type, for instance, is derived from the lambda's target type
@@ -4260,16 +4263,17 @@ public class UnsolvedSymbolGenerator {
    *
    * <p>When deciding by name, {@code lhsTypes} is a disjunction: several candidate types, and
    * within each, several candidate names, exactly one of which the left-hand side really is. Every
-   * candidate must be a final class before this returns true, because a single non-final candidate
-   * is a reading under which a subtype is still possible. Note that false is not a safe default to
-   * approximate with when the answer is unclear: both answers can cost compilability, since the
-   * unconstrained return type that true leads to strands any member access on the result.
+   * candidate must be non-extendable before this returns true, because a single extendable
+   * candidate is a reading under which a subtype is still possible. Note that false is not a safe
+   * default to approximate with when the answer is unclear: both answers can cost compilability,
+   * since the unconstrained return type that true leads to strands any member access on the result.
    *
    * @param resolvedLHSType the resolved type of the left-hand side, or null if it is not resolvable
    * @param lhsTypes the type(s) of the left-hand side
-   * @return true if the left-hand side is known to be a final class
+   * @return true if no generated class could be made a subtype of the left-hand side
    */
-  private boolean isFinalClass(@Nullable ResolvedType resolvedLHSType, Set<MemberType> lhsTypes) {
+  private boolean isNonExtendableType(
+      @Nullable ResolvedType resolvedLHSType, Set<MemberType> lhsTypes) {
     if (resolvedLHSType != null) {
       if (!resolvedLHSType.isReferenceType()
           || resolvedLHSType.asReferenceType().getTypeDeclaration().isEmpty()) {
@@ -4292,7 +4296,7 @@ public class UnsolvedSymbolGenerator {
           && ((ClassOrInterfaceDeclaration) decl.toAst().get()).isFinal();
     }
 
-    // No candidates says nothing about finality, so do not let the loops below pass vacuously.
+    // No candidates says nothing either way, so do not let the loops below pass vacuously.
     if (lhsTypes.isEmpty()) {
       return false;
     }
@@ -4305,31 +4309,13 @@ public class UnsolvedSymbolGenerator {
       }
 
       for (String fqn : fqns) {
-        if (!isFinalClassName(fqn)) {
+        if (!JavaParserUtil.isNonExtendableTypeName(fqn, fqnsToCompilationUnits)) {
           return false;
         }
       }
     }
 
     return true;
-  }
-
-  /**
-   * Does this fully-qualified name name a final class? Names that Specimin will synthesize a type
-   * for are not final: Specimin chooses those types' modifiers, and never makes them final here.
-   *
-   * @param fqn a fully-qualified name
-   * @return true if the name is that of a final class
-   */
-  private boolean isFinalClassName(String fqn) {
-    if (JavaLangUtils.isFinalJdkClass(fqn)) {
-      return true;
-    }
-
-    return JavaParserUtil.getTypeFromQualifiedName(fqn, fqnsToCompilationUnits)
-            instanceof ClassOrInterfaceDeclaration ast
-        && !ast.isInterface()
-        && ast.isFinal();
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2988,39 +2988,21 @@ public class UnsolvedSymbolGenerator {
           return UnsolvedGenerationResult.EMPTY;
         }
       } else {
-        LambdaExpr lambdaExpr =
-            (LambdaExpr)
-                node; // See if the lambda expression type is available. If not, we can't get a
-        // relationship
+        LambdaExpr lambdaExpr = (LambdaExpr) node;
 
-        ResolvedType solvableTypeFromLambda;
-        ResolvedType functionalInterface = Resolver.calculateResolvedType(lambdaExpr);
+        // The lambda's result type is read from its target type rather than from
+        // Resolver#calculateResolvedType, which cannot type a lambda at all when its body is
+        // unsolved: JavaParser's TypeExtractor resolves the body in order to infer the functional
+        // interface's type arguments, and that is exactly the case this constraint exists to fix.
+        Set<FullyQualifiedNameSet> resultTypeFQNs =
+            fullyQualifiedNameGenerator.getFQNsForLambdaResultType(lambdaExpr);
 
-        if (functionalInterface == null
-            || !functionalInterface.isReferenceType()
-            || functionalInterface.asReferenceType().getTypeDeclaration().isEmpty()) {
+        if (resultTypeFQNs == null) {
           return UnsolvedGenerationResult.EMPTY;
         }
-
-        ResolvedReferenceTypeDeclaration functionalInterfaceDecl =
-            functionalInterface.asReferenceType().getTypeDeclaration().get();
-
-        if (!functionalInterfaceDecl.isFunctionalInterface()) {
-          return UnsolvedGenerationResult.EMPTY;
-        }
-
-        solvableTypeFromLambda =
-            functionalInterfaceDecl.getAllMethods().iterator().next().returnType();
 
         if (lambdaExpr.getExpressionBody().isPresent()) {
-          MemberType lhsMemberType =
-              getMemberTypeFromFQNs(
-                  fullyQualifiedNameGenerator.getFQNsForResolvedType(solvableTypeFromLambda),
-                  false);
-          lhsType = lhsMemberType == null ? Set.of() : Set.of(lhsMemberType);
-
           rhs = lambdaExpr.getExpressionBody().get();
-
         } else {
           ReturnStmt returnStmt = JavaParserUtil.findOwnReturnStmt(lambdaExpr);
 
@@ -3028,18 +3010,26 @@ public class UnsolvedSymbolGenerator {
             return UnsolvedGenerationResult.EMPTY;
           }
 
-          MemberType lhsMemberType =
-              getMemberTypeFromFQNs(
-                  fullyQualifiedNameGenerator.getFQNsForResolvedType(solvableTypeFromLambda),
-                  false);
-          lhsType = lhsMemberType == null ? Set.of() : Set.of(lhsMemberType);
-
           rhs = returnStmt.getExpression().get();
         }
+
+        Set<MemberType> resultTypes = new LinkedHashSet<>();
+        for (FullyQualifiedNameSet resultTypeFQN : resultTypeFQNs) {
+          MemberType resultType = getMemberTypeFromFQNs(resultTypeFQN, false);
+
+          if (resultType != null) {
+            resultTypes.add(resultType);
+          }
+        }
+
+        lhsType = resultTypes;
         rhsType =
             getMemberTypesAndExpectNonNullFromFQNSets(
                 fullyQualifiedNameGenerator.getFQNsForExpressionType(rhs));
-        getResolvedTypeOfLHS = () -> solvableTypeFromLambda;
+        // The result type is known only by name here, so there is no ResolvedType to hand over.
+        // This is a supported input: it selects addSuperType over forceSuperClass/
+        // forceSuperInterface, and finalityOfLHS below falls back to deciding by name.
+        getResolvedTypeOfLHS = () -> null;
       }
 
       if (rhsType.isEmpty()) {
@@ -3071,53 +3061,30 @@ public class UnsolvedSymbolGenerator {
       }
 
       boolean handledAsFinalClass = false;
-      if (methodWithPotentiallyUnconstrainedReturnType != null) {
-        ResolvedType resolvedLHSType = getResolvedTypeOfLHS.get();
-
-        if (resolvedLHSType != null
-            && resolvedLHSType.isReferenceType()
-            && resolvedLHSType.asReferenceType().getTypeDeclaration().isPresent()) {
-          ResolvedReferenceTypeDeclaration decl =
-              resolvedLHSType.asReferenceType().getTypeDeclaration().get();
-          boolean isFinal = false;
-
-          // If LHS is solvable, there is only one
-          if (decl.isClass()) {
-            isFinal = JavaLangUtils.isFinalJdkClass(decl.getQualifiedName());
-
-            if (!isFinal) {
-              if (decl.toAst().isPresent()) {
-                ClassOrInterfaceDeclaration ast = (ClassOrInterfaceDeclaration) decl.toAst().get();
-                isFinal = ast.isFinal();
-              }
+      if (methodWithPotentiallyUnconstrainedReturnType != null
+          && isFinalClass(getResolvedTypeOfLHS.get(), lhsType)) {
+        Set<UnsolvedClassOrInterfaceAlternates> symbolsToRemove = new HashSet<>();
+        for (MemberType returnType :
+            methodWithPotentiallyUnconstrainedReturnType.getReturnTypes()) {
+          if (returnType instanceof UnsolvedMemberType unsolvedReturnType
+              && unsolvedReturnType.usesGeneratedName()) {
+            // Check to see if it is unused everywhere (no methods or fields)
+            if (findAllMembers(unsolvedReturnType.getUnsolvedType()).isEmpty()) {
+              symbolsToRemove.add(unsolvedReturnType.getUnsolvedType());
             }
-          }
-
-          if (isFinal) {
-            Set<UnsolvedClassOrInterfaceAlternates> symbolsToRemove = new HashSet<>();
-            for (MemberType returnType :
-                methodWithPotentiallyUnconstrainedReturnType.getReturnTypes()) {
-              if (returnType instanceof UnsolvedMemberType unsolvedReturnType
-                  && unsolvedReturnType.usesGeneratedName()) {
-                // Check to see if it is unused everywhere (no methods or fields)
-                if (findAllMembers(unsolvedReturnType.getUnsolvedType()).isEmpty()) {
-                  symbolsToRemove.add(unsolvedReturnType.getUnsolvedType());
-                }
-              }
-            }
-
-            methodWithPotentiallyUnconstrainedReturnType.setUnconstrainedReturnType();
-            for (UnsolvedClassOrInterfaceAlternates symbolToRemove : symbolsToRemove) {
-              removeTypeAndReplaceUses(
-                  new UnsolvedMemberType(symbolToRemove, 0, List.of(), false),
-                  new SolvedMemberType("java.lang.Object"));
-            }
-
-            toRemove.addAll(symbolsToRemove);
-
-            handledAsFinalClass = true;
           }
         }
+
+        methodWithPotentiallyUnconstrainedReturnType.setUnconstrainedReturnType();
+        for (UnsolvedClassOrInterfaceAlternates symbolToRemove : symbolsToRemove) {
+          removeTypeAndReplaceUses(
+              new UnsolvedMemberType(symbolToRemove, 0, List.of(), false),
+              new SolvedMemberType("java.lang.Object"));
+        }
+
+        toRemove.addAll(symbolsToRemove);
+
+        handledAsFinalClass = true;
       }
 
       if (!handledAsFinalClass) {
@@ -4274,6 +4241,67 @@ public class UnsolvedSymbolGenerator {
     }
 
     return null;
+  }
+
+  /**
+   * Is the left-hand side of an assignment a final class? Nothing can be made a subtype of one, so
+   * a generated method whose result is assigned to it cannot be given a generated placeholder
+   * return type.
+   *
+   * <p>The resolved type is preferred when there is one, but the left-hand side is sometimes known
+   * only by name -- a lambda's result type, for instance, is derived from the lambda's target type
+   * rather than resolved. Deciding by name in that case is what lets the caller reach the same
+   * unconstrained-return-type fallback it would reach for the equivalent assignment or {@code
+   * return} statement, instead of going on to demand an impossible subtype.
+   *
+   * @param resolvedLHSType the resolved type of the left-hand side, or null if it is not resolvable
+   * @param lhsTypes the type(s) of the left-hand side
+   * @return true if the left-hand side is known to be a final class
+   */
+  private boolean isFinalClass(@Nullable ResolvedType resolvedLHSType, Set<MemberType> lhsTypes) {
+    if (resolvedLHSType != null) {
+      if (!resolvedLHSType.isReferenceType()
+          || resolvedLHSType.asReferenceType().getTypeDeclaration().isEmpty()) {
+        return false;
+      }
+
+      // If LHS is solvable, there is only one
+      ResolvedReferenceTypeDeclaration decl =
+          resolvedLHSType.asReferenceType().getTypeDeclaration().get();
+
+      if (!decl.isClass()) {
+        return false;
+      }
+
+      if (JavaLangUtils.isFinalJdkClass(decl.getQualifiedName())) {
+        return true;
+      }
+
+      return decl.toAst().isPresent()
+          && ((ClassOrInterfaceDeclaration) decl.toAst().get()).isFinal();
+    }
+
+    // A single type with a single name, or there is no one type to ask about.
+    if (lhsTypes.size() != 1) {
+      return false;
+    }
+
+    Set<String> fqns = lhsTypes.iterator().next().getFullyQualifiedNames();
+
+    if (fqns.size() != 1) {
+      return false;
+    }
+
+    String fqn = fqns.iterator().next();
+
+    if (JavaLangUtils.isFinalJdkClass(fqn)) {
+      return true;
+    }
+
+    return JavaParserUtil.getTypeFromQualifiedName(fqn, fqnsToCompilationUnits)
+            instanceof ClassOrInterfaceDeclaration ast
+        && !ast.isInterface()
+        && ast.isFinal();
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2987,8 +2987,7 @@ public class UnsolvedSymbolGenerator {
           // Do not handle here: handle when we encounter the ancestor LambdaExpr node
           return UnsolvedGenerationResult.EMPTY;
         }
-      } else {
-        LambdaExpr lambdaExpr = (LambdaExpr) node;
+      } else if (node instanceof LambdaExpr lambdaExpr) {
 
         // The lambda's result type is read from its target type rather than from
         // Resolver#calculateResolvedType, which cannot type a lambda at all when its body is
@@ -3030,6 +3029,11 @@ public class UnsolvedSymbolGenerator {
         // This is a supported input: it selects addSuperType over forceSuperClass/
         // forceSuperInterface, and finalityOfLHS below falls back to deciding by name.
         getResolvedTypeOfLHS = () -> null;
+      } else {
+        throw new RuntimeException(
+            "Expected an assignment, variable declarator, return expression, or lambda; got "
+                + node.getClass()
+                + " instead!");
       }
 
       if (rhsType.isEmpty()) {

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2989,9 +2989,9 @@ public class UnsolvedSymbolGenerator {
         }
       } else if (node instanceof LambdaExpr lambdaExpr) {
 
-        // The lambda's result type is read from its target type rather than from
-        // Resolver#calculateResolvedType, which cannot type a lambda at all when its body is
-        // unsolved: JavaParser's TypeExtractor resolves the body in order to infer the functional
+        // Must not call Resolver#calculateResolvedType on a lambda when its body is
+        // unsolved, because JavaParser's TypeExtractor creates a circular dependency: it resolves
+        // the body in order to infer the functional
         // interface's type arguments, and that is exactly the case this constraint exists to fix.
         Set<FullyQualifiedNameSet> resultTypeFQNs =
             fullyQualifiedNameGenerator.getFQNsForLambdaResultType(lambdaExpr);

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedArgumentTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedArgumentTest.java
@@ -1,0 +1,23 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A variant of {@link LambdaResultUnsolvedTest} in which the lambda's target type comes from the
+ * declared parameter type of the method it is passed to, rather than from a variable declaration.
+ *
+ * <p>The functional interface has more than one type argument, so this also pins down that the
+ * result type is the *last* type argument of the (normalized) functional interface and not the
+ * first: {@code BiFunction<String, Integer, Payload>} constrains the lambda's result to {@code
+ * Payload}, not to {@code String}.
+ */
+public class LambdaResultUnsolvedArgumentTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedargument",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedArrayTargetTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedArrayTargetTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A lambda result type need not be a final class to rule out a generated placeholder type. An array
+ * type has no declarable subtypes at all: by JLS 4.10.3 its only supertypes are {@code Object},
+ * {@code Cloneable} and {@code Serializable}, and no class declaration can name it as a superclass.
+ *
+ * <p>Two lambdas here demand incompatible result types from the same unsolved call, so no concrete
+ * return type satisfies both and the unconstrained type variable is the only option. Without
+ * recognizing {@code String[]} as non-extendable, the {@code Payload} constraint wins and the
+ * output stops compiling.
+ */
+public class LambdaResultUnsolvedArrayTargetTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedarraytarget",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedArrayTargetTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedArrayTargetTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * A lambda result type need not be a final class to rule out a generated placeholder type. An array
- * type has no declarable subtypes at all: by JLS 4.10.3 its only supertypes are {@code Object},
+ * type has no declarable subtypes at all: by JLS 4.10.3 its only non-array supertypes are {@code Object},
  * {@code Cloneable} and {@code Serializable}, and no class declaration can name it as a superclass.
  *
  * <p>Two lambdas here demand incompatible result types from the same unsolved call, so no concrete

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedArrayTargetTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedArrayTargetTest.java
@@ -5,8 +5,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * A lambda result type need not be a final class to rule out a generated placeholder type. An array
- * type has no declarable subtypes at all: by JLS 4.10.3 its only non-array supertypes are {@code Object},
- * {@code Cloneable} and {@code Serializable}, and no class declaration can name it as a superclass.
+ * type has no declarable subtypes at all: by JLS 4.10.3 its only non-array supertypes are {@code
+ * Object}, {@code Cloneable} and {@code Serializable}, and no class declaration can name it as a
+ * superclass.
  *
  * <p>Two lambdas here demand incompatible result types from the same unsolved call, so no concrete
  * return type satisfies both and the unconstrained type variable is the only option. Without

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedEnumTargetTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedEnumTargetTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The enum counterpart of {@link LambdaResultUnsolvedArrayTargetTest}. An enum declaration whose
+ * constants have no class bodies is implicitly final (JLS 8.9), so nothing Specimin generates can
+ * be made a subtype of it, and the result type must fall back to an unconstrained type variable
+ * rather than to a synthetic subtype of the other lambda's target.
+ *
+ * <p>The enum is declared with no constants so that the test turns only on the declaration's kind.
+ * Specimin prunes unreferenced members, so an enum carrying constants would make the expected
+ * output depend on pruning behavior that has nothing to do with what is under test here.
+ */
+public class LambdaResultUnsolvedEnumTargetTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedenumtarget",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedExprBodyTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedExprBodyTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The expression-body counterpart of {@link LambdaResultUnsolvedTest}. An expression-bodied lambda
+ * has no {@code ReturnStmt} at all -- the result expression's parent is the {@code LambdaExpr}
+ * itself -- so the target type must reach it by a different route, even though JLS 15.27.3 puts it
+ * in the same assignment context.
+ *
+ * <p>The target type is also a non-final class here rather than {@code String}, so the result type
+ * appears in the output as itself rather than through the unconstrained-type-variable fallback that
+ * a final target type triggers.
+ */
+public class LambdaResultUnsolvedExprBodyTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedexprbody",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedLaterReturnTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedLaterReturnTest.java
@@ -1,0 +1,25 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The same unsolved call is the result of two lambdas with incompatible target types, and in one of
+ * them it is reached through a return statement that is not the lambda's first. Constraining only
+ * the first result expression would miss it entirely, because that lambda's first return is a
+ * string literal, which constrains nothing.
+ *
+ * <p>No concrete return type works: {@code String} and {@code Payload} are unrelated, and a
+ * synthetic subtype of {@code Payload} cannot also be a subtype of {@code String}, which is final
+ * (JLS 8.1.1.2). The return type must therefore be an unconstrained type variable, which each
+ * lambda instantiates to its own target type.
+ */
+public class LambdaResultUnsolvedLaterReturnTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedlaterreturn",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item, boolean)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedMixedTargetsTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedMixedTargetsTest.java
@@ -1,0 +1,34 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Like {@link LambdaResultUnsolvedTwoTargetsTest}, but only one of the two target types is final.
+ * That combination forces the unconstrained-type-variable fallback more sharply than two final
+ * targets do, because here no concrete return type works at all:
+ *
+ * <ul>
+ *   <li>{@code String} is not assignable to {@code Payload}, and {@code Payload} is not assignable
+ *       to {@code String}, so neither target type can serve as the return type;
+ *   <li>a synthetic subtype of {@code Payload} would satisfy the second lambda but cannot also be a
+ *       subtype of {@code String}, which is final (JLS 8.1.1.2).
+ * </ul>
+ *
+ * <p>The equivalent non-lambda program produces {@code <T> T getPayload()} today, and does so
+ * regardless of which of the two declarations comes first. The non-final target is written first
+ * here so that the two multi-target tests between them cover both orders.
+ *
+ * <p>Provisional on the same terms as {@link LambdaResultUnsolvedTwoTargetsTest}: both depend on
+ * routing the lambda's result-type constraint through {@code
+ * UnsolvedSymbolGenerator#addInformation} rather than through symbol generation alone.
+ */
+public class LambdaResultUnsolvedMixedTargetsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedmixedtargets",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedMultipleReturnsTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedMultipleReturnsTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A block-bodied lambda has one result expression per return statement of its own, and the target
+ * type constrains every one of them, not just the first (JLS 15.27.3 puts each result expression in
+ * an assignment context). Both calls here must therefore be constrained by {@code
+ * Supplier<String>}.
+ *
+ * <p>{@code String} is final, so neither call can be given a placeholder return type and both fall
+ * back to an unconstrained type variable, which each call site instantiates to {@code String}.
+ *
+ * <p>The two calls deliberately have different receivers, so that each generated class declares
+ * exactly one method; putting both on one receiver would make the test depend on the order in which
+ * members of a generated class are emitted, which is not what it is trying to pin down.
+ */
+public class LambdaResultUnsolvedMultipleReturnsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedmultiplereturns",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item, Other, boolean)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedRecordTargetTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedRecordTargetTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The record counterpart of {@link LambdaResultUnsolvedArrayTargetTest}. A record declaration is
+ * implicitly final (JLS 8.10), so nothing Specimin generates can be made a subtype of it, and the
+ * result type must fall back to an unconstrained type variable.
+ *
+ * <p>The record is declared with no components for the reason given in {@link
+ * LambdaResultUnsolvedEnumTargetTest}: Specimin prunes unreferenced record components (see the
+ * {@code records} fixture), so components would make the expected output depend on pruning behavior
+ * unrelated to what is under test.
+ */
+public class LambdaResultUnsolvedRecordTargetTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedrecordtarget",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedReturnedTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedReturnedTest.java
@@ -1,0 +1,23 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A variant of {@link LambdaResultUnsolvedTest} in which the lambda is itself the operand of a
+ * {@code return}, so its target type is the enclosing method's declared return type.
+ *
+ * <p>Two {@code return}s are nested here and they mean different things: the outer one is
+ * constrained by {@code Simple#bar}'s declared type, and the inner one by the result type of the
+ * functional interface that type names. Reading the lambda's target type has to walk out through
+ * the outer {@code return} to find it.
+ */
+public class LambdaResultUnsolvedReturnedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedreturned",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedSyntheticTargetTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedSyntheticTargetTest.java
@@ -1,0 +1,23 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The lambda's target result type is itself unsolved, so the type the result expression is
+ * constrained to is one Specimin synthesizes rather than one it can look up. The constraint still
+ * has to survive the trip from a set of candidate names back to the generated symbol; if it did
+ * not, the lambda would be left with no left-hand side type at all.
+ *
+ * <p>{@code Foo} is a generated class and so is not final, which means the constraint applies
+ * directly and no unconstrained-type-variable fallback is involved.
+ */
+public class LambdaResultUnsolvedSyntheticTargetTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedsynthetictarget",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedTest.java
@@ -12,6 +12,13 @@ import org.junit.jupiter.api.Test;
  *
  * <p>The lambda's target type here comes from a local variable declaration, and the result
  * expression is reached through an explicit {@code return} in a block body.
+ *
+ * <p>The result type is {@code String}, which is final, so the constraint arrives as the
+ * unconstrained-type-variable fallback rather than as {@code String} itself: nothing can be made a
+ * subtype of a final class, so a placeholder return type is impossible and {@code <T> T} is what
+ * satisfies the call site. That is the same output the equivalent non-lambda program produces for
+ * {@code String s = item.getPayload();}, and the reason the constraint is applied in {@code
+ * UnsolvedSymbolGenerator#addInformation} and not only during symbol generation.
  */
 public class LambdaResultUnsolvedTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The lambda in this test targets {@code Supplier<String>}, so by JLS 15.27.3 its result expression
+ * sits in an assignment context whose target type is {@code String}. That constraint must reach the
+ * unsolved call that produces the result: without it, Specimin gives {@code getPayload} a synthetic
+ * placeholder return type, which cannot be converted to {@code String}, and the output does not
+ * compile. See https://github.com/njit-jerse/specimin/issues/502.
+ *
+ * <p>The lambda's target type here comes from a local variable declaration, and the result
+ * expression is reached through an explicit {@code return} in a block body.
+ */
+public class LambdaResultUnsolvedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolved",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedTwoTargetsTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaResultUnsolvedTwoTargetsTest.java
@@ -1,0 +1,32 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The same unsolved call supplies the result of two lambdas with different final target types. No
+ * single concrete return type satisfies both, so the return type has to become an unconstrained
+ * type variable, which each call site then infers separately (JLS 18.5.2 propagates the target type
+ * of a lambda's result expression into the inference for a generic method invocation there).
+ *
+ * <p>This is what the equivalent non-lambda program already does: {@code String s =
+ * item.getPayload(); Integer i = item.getPayload();} produces {@code <T> T getPayload()} today. The
+ * fallback lives in {@code UnsolvedSymbolGenerator#addInformation}, which recognizes a final
+ * left-hand side and calls {@code setUnconstrainedReturnType}, so this test is what forces the
+ * lambda case to route its constraint through that code and not only through generation.
+ *
+ * <p>This test is provisional. If routing the constraint through {@code addInformation} turns out
+ * to be disproportionately involved, it should be removed and refiled as its own issue; the
+ * generation-only fix alone still makes the single-target cases (the other {@code
+ * LambdaResultUnsolved*} tests) compile, which is the bug that
+ * https://github.com/njit-jerse/specimin/issues/502 reports.
+ */
+public class LambdaResultUnsolvedTwoTargetsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdaresultunsolvedtwotargets",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/resources/lambdaresultunsolved/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolved/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+
+    void bar(Item item) {
+        Supplier<String> supplier = () -> { return item.getPayload(); };
+    }
+}

--- a/src/test/resources/lambdaresultunsolved/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolved/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public java.lang.String getPayload() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolved/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolved/expected/org/example/Item.java
@@ -2,7 +2,7 @@ package org.example;
 
 public class Item {
 
-    public java.lang.String getPayload() {
+    public <T> T getPayload() {
         throw new java.lang.Error();
     }
 }

--- a/src/test/resources/lambdaresultunsolved/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolved/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Supplier<String> supplier = () -> { return item.getPayload(); };
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedargument/expected/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedargument/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedargument/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedargument/expected/com/example/Simple.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import java.util.function.BiFunction;
+
+import org.example.Item;
+
+class Simple {
+
+    void bar(Item item) {
+        apply((key, count) -> { return item.getPayload(); });
+    }
+
+    void apply(BiFunction<String, Integer, Payload> f) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedargument/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedargument/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public com.example.Payload getPayload() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedargument/input/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedargument/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedargument/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedargument/input/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import java.util.function.BiFunction;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        apply((key, count) -> { return item.getPayload(); });
+    }
+
+    void apply(BiFunction<String, Integer, Payload> f) {}
+}

--- a/src/test/resources/lambdaresultunsolvedarraytarget/expected/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedarraytarget/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedarraytarget/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedarraytarget/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    void bar(Item item) {
+        Supplier<String[]> asArray = () -> item.get();
+        Supplier<Payload> asPayload = () -> item.get();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedarraytarget/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedarraytarget/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedarraytarget/input/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedarraytarget/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedarraytarget/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedarraytarget/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Supplier<String[]> asArray = () -> item.get();
+        Supplier<Payload> asPayload = () -> item.get();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedenumtarget/expected/com/example/Color.java
+++ b/src/test/resources/lambdaresultunsolvedenumtarget/expected/com/example/Color.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public enum Color {}

--- a/src/test/resources/lambdaresultunsolvedenumtarget/expected/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedenumtarget/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedenumtarget/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedenumtarget/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    void bar(Item item) {
+        Supplier<Color> asColor = () -> item.get();
+        Supplier<Payload> asPayload = () -> item.get();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedenumtarget/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedenumtarget/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedenumtarget/input/com/example/Color.java
+++ b/src/test/resources/lambdaresultunsolvedenumtarget/input/com/example/Color.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public enum Color {}

--- a/src/test/resources/lambdaresultunsolvedenumtarget/input/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedenumtarget/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedenumtarget/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedenumtarget/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Supplier<Color> asColor = () -> item.get();
+        Supplier<Payload> asPayload = () -> item.get();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedexprbody/expected/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedexprbody/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedexprbody/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedexprbody/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+
+    void bar(Item item) {
+        Supplier<Payload> supplier = () -> item.getPayload();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedexprbody/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedexprbody/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public com.example.Payload getPayload() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedexprbody/input/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedexprbody/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedexprbody/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedexprbody/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Supplier<Payload> supplier = () -> item.getPayload();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedlaterreturn/expected/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedlaterreturn/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedlaterreturn/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedlaterreturn/expected/com/example/Simple.java
@@ -1,0 +1,17 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    void bar(Item item, boolean flag) {
+        Supplier<String> asString = () -> {
+            if (flag) {
+                return "";
+            }
+            return item.get();
+        };
+        Supplier<Payload> asPayload = () -> item.get();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedlaterreturn/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedlaterreturn/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedlaterreturn/input/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedlaterreturn/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedlaterreturn/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedlaterreturn/input/com/example/Simple.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item, boolean flag) {
+        Supplier<String> asString = () -> {
+            if (flag) {
+                return "";
+            }
+            return item.get();
+        };
+        Supplier<Payload> asPayload = () -> item.get();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedmixedtargets/expected/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedmixedtargets/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedmixedtargets/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedmixedtargets/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+
+    void bar(Item item) {
+        Supplier<Payload> p = () -> { return item.getPayload(); };
+        Supplier<String> s = () -> { return item.getPayload(); };
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedmixedtargets/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedmixedtargets/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public <T> T getPayload() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedmixedtargets/input/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedmixedtargets/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedmixedtargets/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedmixedtargets/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Supplier<Payload> p = () -> { return item.getPayload(); };
+        Supplier<String> s = () -> { return item.getPayload(); };
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedmultiplereturns/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedmultiplereturns/expected/com/example/Simple.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+import org.example.Other;
+
+class Simple {
+
+    Supplier<String> bar(Item item, Other other, boolean flag) {
+        return () -> {
+            if (flag) {
+                return item.get();
+            }
+            return other.get();
+        };
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedmultiplereturns/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedmultiplereturns/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedmultiplereturns/expected/org/example/Other.java
+++ b/src/test/resources/lambdaresultunsolvedmultiplereturns/expected/org/example/Other.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Other {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedmultiplereturns/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedmultiplereturns/input/com/example/Simple.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+import org.example.Other;
+
+class Simple {
+    // Target method.
+    Supplier<String> bar(Item item, Other other, boolean flag) {
+        return () -> {
+            if (flag) {
+                return item.get();
+            }
+            return other.get();
+        };
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedrecordtarget/expected/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedrecordtarget/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedrecordtarget/expected/com/example/Point.java
+++ b/src/test/resources/lambdaresultunsolvedrecordtarget/expected/com/example/Point.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public record Point() {}

--- a/src/test/resources/lambdaresultunsolvedrecordtarget/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedrecordtarget/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    void bar(Item item) {
+        Supplier<Point> asPoint = () -> item.get();
+        Supplier<Payload> asPayload = () -> item.get();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedrecordtarget/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedrecordtarget/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedrecordtarget/input/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedrecordtarget/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedrecordtarget/input/com/example/Point.java
+++ b/src/test/resources/lambdaresultunsolvedrecordtarget/input/com/example/Point.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public record Point() {}

--- a/src/test/resources/lambdaresultunsolvedrecordtarget/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedrecordtarget/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Supplier<Point> asPoint = () -> item.get();
+        Supplier<Payload> asPayload = () -> item.get();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedreturned/expected/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedreturned/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedreturned/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedreturned/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+
+    Supplier<Payload> bar(Item item) {
+        return () -> { return item.getPayload(); };
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedreturned/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedreturned/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public com.example.Payload getPayload() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedreturned/input/com/example/Payload.java
+++ b/src/test/resources/lambdaresultunsolvedreturned/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/lambdaresultunsolvedreturned/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedreturned/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    Supplier<Payload> bar(Item item) {
+        return () -> { return item.getPayload(); };
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedsynthetictarget/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedsynthetictarget/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Foo;
+import org.example.Item;
+
+class Simple {
+    void bar(Item item) {
+        Supplier<Foo> s = () -> item.get();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedsynthetictarget/expected/org/example/Foo.java
+++ b/src/test/resources/lambdaresultunsolvedsynthetictarget/expected/org/example/Foo.java
@@ -1,0 +1,4 @@
+package org.example;
+
+public class Foo {
+}

--- a/src/test/resources/lambdaresultunsolvedsynthetictarget/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedsynthetictarget/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public org.example.Foo get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedsynthetictarget/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedsynthetictarget/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Foo;
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Supplier<Foo> s = () -> item.get();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedtwotargets/expected/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedtwotargets/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+
+    void bar(Item item) {
+        Supplier<String> s = () -> { return item.getPayload(); };
+        Supplier<Integer> i = () -> { return item.getPayload(); };
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedtwotargets/expected/org/example/Item.java
+++ b/src/test/resources/lambdaresultunsolvedtwotargets/expected/org/example/Item.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Item {
+
+    public <T> T getPayload() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/lambdaresultunsolvedtwotargets/input/com/example/Simple.java
+++ b/src/test/resources/lambdaresultunsolvedtwotargets/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.function.Supplier;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Supplier<String> s = () -> { return item.getPayload(); };
+        Supplier<Integer> i = () -> { return item.getPayload(); };
+    }
+}


### PR DESCRIPTION
Fixes #502. A lambda's target functional interface constrains the type of its result expressions (JLS 15.27.3 puts each one in an assignment context whose target type is the function type's result), but Specimin dropped that constraint precisely when it mattered (when the result expression was itself unsolved).