### PR TITLE
Extend the "don't extend a final class" rule to cover other non-extendable type kinds: records, primitives, arrays, enums, type variables, etc

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -3,6 +3,7 @@ package org.checkerframework.specimin;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
@@ -1956,16 +1957,28 @@ public class JavaParserUtil {
   }
 
   /**
+   * Is this declaration sealed, so that only the types its {@code permits} clause names may extend
+   * or implement it (JLS 8.1.1.2 for classes, 9.1.1.4 for interfaces)?
+   *
+   * @param decl a type declaration
+   * @return true if the declaration is sealed
+   */
+  public static boolean isSealed(TypeDeclaration<?> decl) {
+    return decl.hasModifier(Modifier.Keyword.SEALED);
+  }
+
+  /**
    * Can no generated class be made a subtype of the type with this name? Callers that are about to
    * name a type as the supertype of a synthetic class, or that need to know whether a synthetic
    * placeholder type could stand in for it, should ask this first.
    *
    * <p>Beyond the JDK and primitive cases that {@link JavaLangUtils#isNonExtendableJdkTypeName}
    * settles, a declaration in the project qualifies when it is a final class, an enum (implicitly
-   * final unless a constant has a class body, JLS 8.9), a record (implicitly final, JLS 8.10), or
-   * an annotation type. A non-final class or an interface can take a generated subtype, and so does
-   * not qualify; neither does a name Specimin will synthesize a type for, since Specimin writes
-   * that declaration itself and does not make it final.
+   * final unless a constant has a class body, JLS 8.9), a record (implicitly final, JLS 8.10), an
+   * annotation type, or {@linkplain #isSealed sealed}. A non-final, non-sealed class or interface
+   * can take a generated subtype, and so does not qualify; neither does a name Specimin will
+   * synthesize a type for, since Specimin writes that declaration itself and does not make it
+   * final.
    *
    * @param fqn a fully-qualified name
    * @param fqnToCompilationUnits A map of fully-qualified type names to their compilation units
@@ -1986,7 +1999,8 @@ public class JavaParserUtil {
     TypeDeclaration<?> decl = getTypeFromQualifiedName(fqn, fqnToCompilationUnits);
 
     if (decl instanceof ClassOrInterfaceDeclaration classOrInterface) {
-      return !classOrInterface.isInterface() && classOrInterface.isFinal();
+      return isSealed(classOrInterface)
+          || (!classOrInterface.isInterface() && classOrInterface.isFinal());
     }
 
     // An enum, record, or annotation declaration in the project; none can be extended. Null means

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterfaceAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterfaceAlternates.java
@@ -299,9 +299,14 @@ public class UnsolvedClassOrInterfaceAlternates
    *       declaration. A class declaration is not in the scope of any method's type parameters, so
    *       naming one here cannot compile. This is a heuristic, because it might also reject names
    *       in the default package.
-   *   <li>A final JDK class, which nothing is permitted to extend.
+   *   <li>A type no declaration can extend: a primitive, an array type, or a final JDK class.
    *   <li>{@code java.lang.Object}, which every class already extends implicitly.
    * </ul>
+   *
+   * <p>The non-extendable test is the one that can be made from a name and the JDK alone. An enum,
+   * record or final class declared in the project under analysis is equally unextendable but is not
+   * recognized here, because that needs the compilation units, which this class does not have;
+   * callers that do have them are expected to have checked already.
    *
    * <p>Dropping a supertype only leaves the generated class less constrained, which is always safe,
    * whereas naming either of the former two is never safe. This is intended as a defensive
@@ -317,7 +322,8 @@ public class UnsolvedClassOrInterfaceAlternates
 
     return superType.equals(SolvedMemberType.JAVA_LANG_OBJECT)
         || SpeciminGenerationUtils.isATypeVariable(superType)
-        || superType.getFullyQualifiedNames().stream().anyMatch(JavaLangUtils::isFinalJdkClass);
+        || superType.getFullyQualifiedNames().stream()
+            .anyMatch(JavaLangUtils::isNonExtendableJdkTypeName);
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterfaceAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterfaceAlternates.java
@@ -303,10 +303,10 @@ public class UnsolvedClassOrInterfaceAlternates
    *   <li>{@code java.lang.Object}, which every class already extends implicitly.
    * </ul>
    *
-   * <p>The non-extendable test is the one that can be made from a name and the JDK alone. An enum,
-   * record or final class declared in the project under analysis is equally unextendable but is not
-   * recognized here, because that needs the compilation units, which this class does not have;
-   * callers that do have them are expected to have checked already.
+   * <p>The non-extendable test is based on the name and the JDK alone. An enum, record or final
+   * class declared in the project under analysis is also unextendable but is not recognized here,
+   * because that needs the compilation units, which this class does not have; callers that do have
+   * them are expected to have checked already.
    *
    * <p>Dropping a supertype only leaves the generated class less constrained, which is always safe,
    * whereas naming either of the former two is never safe. This is intended as a defensive

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -3064,35 +3064,31 @@ public class UnsolvedSymbolGenerator {
           throw new RuntimeException("Type has not been generated for the RHS of " + node);
         }
 
-        // Does this site's target type reject what the method currently returns? See
-        // isNonExtendableType, which uses this to decide the kinds of target for which the
-        // fallback is worth what it costs in precision.
-        boolean returnTypeConflictsWithLHS = !lhsType.containsAll(rhsType);
+        // Could this site's target type reject what the method currently returns? See
+        // isNonExtendableType, which uses this to decide when to fall back to an unconstrained
+        // type variable to satisfy all use sites.
+        boolean returnTypeCanConflictWithLHS = !lhsType.containsAll(rhsType);
 
         boolean handledAsNonExtendable = false;
         if (methodWithPotentiallyUnconstrainedReturnType != null
             && isNonExtendableType(
-                getResolvedTypeOfLHS.get(), lhsType, returnTypeConflictsWithLHS)) {
+                getResolvedTypeOfLHS.get(), lhsType, returnTypeCanConflictWithLHS)) {
           toRemove.addAll(useUnconstrainedReturnType(methodWithPotentiallyUnconstrainedReturnType));
 
           handledAsNonExtendable = true;
         }
 
         if (!handledAsNonExtendable) {
-          // A conflict that handleLHSAndRHSRelationship cannot repair. It works by making the
-          // return type a subtype of the left-hand side, which it can only do to a type Specimin
-          // generated; when every possible return type is one that already exists, there is
-          // nothing it can change, and it would silently leave the site broken. An unconstrained
-          // return type is then the repair, and making it here is what lets the non-extendable
-          // check above be gated on a conflict this site can see: the site that cannot see one is
-          // covered from the other direction.
+          // This tests checks for conflicts that making the LHS a supertype of the RHS cannot
+          // repair.
+          // An unconstrained return type is used instead.
           if (methodWithPotentiallyUnconstrainedReturnType != null
-              && returnTypeConflictsWithLHS
+              && returnTypeCanConflictWithLHS
               && rhsType.stream().allMatch(type -> type instanceof SolvedMemberType)) {
             toRemove.addAll(
                 useUnconstrainedReturnType(methodWithPotentiallyUnconstrainedReturnType));
           } else {
-            handleLHSAndRHSRelationship(lhsType, rhsType, getResolvedTypeOfLHS);
+            makeLHSSupertypeOfRHS(lhsType, rhsType, getResolvedTypeOfLHS);
           }
         }
       }
@@ -3184,7 +3180,7 @@ public class UnsolvedSymbolGenerator {
                 "Type has not been generated for the LHS of parameter " + i + " of " + node);
           }
 
-          handleLHSAndRHSRelationship(Set.of(lhsType), rhsType, getResolvedTypeOfLHS);
+          makeLHSSupertypeOfRHS(Set.of(lhsType), rhsType, getResolvedTypeOfLHS);
         }
       } else {
         List<? extends NodeWithParameters<?>> withUnresolvableArgs =
@@ -3293,7 +3289,7 @@ public class UnsolvedSymbolGenerator {
                   "Type has not been generated for the LHS of parameter " + i + " of " + node);
             }
 
-            handleLHSAndRHSRelationship(lhsType, rhsType, getResolvedTypeOfLHS);
+            makeLHSSupertypeOfRHS(lhsType, rhsType, getResolvedTypeOfLHS);
           }
         } else {
           for (int i = 0; i < nodeWithArgs.getArguments().size(); i++) {
@@ -3343,7 +3339,7 @@ public class UnsolvedSymbolGenerator {
                   "Type has not been generated for the LHS of parameter " + i + " of " + node);
             }
 
-            handleLHSAndRHSRelationship(lhsType, rhsType, getResolvedTypeOfLHS);
+            makeLHSSupertypeOfRHS(lhsType, rhsType, getResolvedTypeOfLHS);
           }
         }
       }
@@ -4334,19 +4330,19 @@ public class UnsolvedSymbolGenerator {
    *
    * <p>Every one of those kinds is reported only when {@code conflicting} says the method's current
    * return type is one the left-hand side rejects. A non-extendable left-hand side is not on its
-   * own a reason to weaken a return type: {@code int x = item.get();} on its own already gets
-   * {@code int get()}, which satisfies it exactly, and answering true there would trade that for
-   * {@code <T> T} and buy nothing. It is the second, incompatible use site that makes the type
-   * variable the only answer that compiles, and that is what {@code conflicting} reports.
+   * own a reason to weaken a return type: for {@code int x = item.get();}, {@code int} is the right
+   * return type for {@code get}. It is only when there is a second, incompatible use site that an
+   * unconstrained type variable is required; {@code conflicting} should be {@code true} whenever
+   * there might be a second, incompatible use site.
    *
-   * <p>The gate is safe only because this is not the only place the fallback can be reached. A
-   * conflict is not always visible from the site that is able to act on it -- given {@code Payload
-   * p = item.get(); String s = item.get();} the return type settles on {@code String}, and the
-   * {@code String} assignment sees nothing wrong -- so {@code addInformation} also falls back when
-   * a site sees a conflict it cannot repair by adding a supertype, and {@link
+   * <p>This is not the only place the unconstrained type variable fallback can be generated. A
+   * conflict is not always visible from the site that can act on it -- given {@code Payload p =
+   * item.get(); String s = item.get();} the return type settles on {@code String}, and the {@code
+   * String} assignment sees nothing wrong -- so {@code addInformation} also falls back when a site
+   * sees a conflict it cannot repair by adding a supertype, and {@link
    * #makeSyntheticTypeASubtypeOfExpressionType} does the same when a cast or instanceof cannot get
    * the subtype it needs. Between them, whichever site can see the problem is the one that fixes
-   * it, so no kind of left-hand side needs to be exempted from the gate here.
+   * it.
    *
    * <p>The resolved type is preferred when there is one, but the left-hand side is sometimes known
    * only by name -- a lambda's result type, for instance, is derived from the lambda's target type
@@ -4363,9 +4359,9 @@ public class UnsolvedSymbolGenerator {
    *
    * @param resolvedLHSType the resolved type of the left-hand side, or null if it is not resolvable
    * @param lhsTypes the type(s) of the left-hand side
-   * @param conflicting whether what the method currently returns is a type the left-hand side
-   *     rejects. Only a resolved primitive, array, enum, record, annotation type or type variable
-   *     consults this; see above.
+   * @param conflicting whether the assignment context may confilct with the existing type of the
+   *     left-hand side. Only a resolved primitive, array, enum, record, annotation type or type
+   *     variable consults this; see above.
    * @return true if no generated class could be made a subtype of the left-hand side
    */
   private boolean isNonExtendableType(
@@ -4406,7 +4402,7 @@ public class UnsolvedSymbolGenerator {
           && ((ClassOrInterfaceDeclaration) decl.toAst().get()).isFinal();
     }
 
-    // No candidates says nothing either way, so do not let the loops below pass vacuously.
+    // "No candidates" says nothing either way, so do not let the loops below pass vacuously.
     if (lhsTypes.isEmpty()) {
       return false;
     }
@@ -4437,7 +4433,7 @@ public class UnsolvedSymbolGenerator {
    * @param getResolvedTypeOfLHS A supplier for the resolved type of the LHS. Typically a call to
    *     resolve() or calculateResolvedType().
    */
-  private void handleLHSAndRHSRelationship(
+  private void makeLHSSupertypeOfRHS(
       Set<MemberType> lhsTypes,
       Set<MemberType> rhsTypes,
       Supplier<@Nullable ResolvedType> getResolvedTypeOfLHS) {
@@ -4534,7 +4530,7 @@ public class UnsolvedSymbolGenerator {
                   "Null member type wildcard bound when resolved wildcard bound is not null");
             }
 
-            handleLHSAndRHSRelationship(Set.of(memberTypeBound), rhsTypeParameters, () -> bound);
+            makeLHSSupertypeOfRHS(Set.of(memberTypeBound), rhsTypeParameters, () -> bound);
           } else {
             // If the LHS were unsolved, we would make it extend every single class in the RHS; but
             // since the LHS is solved, we can't do this
@@ -4617,10 +4613,10 @@ public class UnsolvedSymbolGenerator {
           // ? extends with ? extends; there is no ? extends with ? super
           if (isUpperBound) {
             // Foo<? extends Bound> = Foo<A> tells us that A is a subtype of Bound.
-            handleLHSAndRHSRelationship(Set.of(bound), rhsTypeParameters, () -> null);
+            makeLHSSupertypeOfRHS(Set.of(bound), rhsTypeParameters, () -> null);
           } else {
             // Foo<? super Bound> = Foo<A> tells us that Bound is a subtype of A.
-            handleLHSAndRHSRelationship(rhsTypeParameters, Set.of(bound), () -> null);
+            makeLHSSupertypeOfRHS(rhsTypeParameters, Set.of(bound), () -> null);
           }
         } else {
           for (MemberType rhsType : rhsTypes) {

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -76,7 +76,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.specimin.JavaLangUtils;
@@ -3062,9 +3061,15 @@ public class UnsolvedSymbolGenerator {
           throw new RuntimeException("Type has not been generated for the RHS of " + node);
         }
 
+        // Does this site's target type reject what the method currently returns? See
+        // isNonExtendableType, which uses this to decide the kinds of target for which the
+        // fallback is worth what it costs in precision.
+        boolean returnTypeConflictsWithLHS = !lhsType.containsAll(rhsType);
+
         boolean handledAsNonExtendable = false;
         if (methodWithPotentiallyUnconstrainedReturnType != null
-            && isNonExtendableType(getResolvedTypeOfLHS.get(), lhsType)) {
+            && isNonExtendableType(
+                getResolvedTypeOfLHS.get(), lhsType, returnTypeConflictsWithLHS)) {
           Set<UnsolvedClassOrInterfaceAlternates> symbolsToRemove = new HashSet<>();
           for (MemberType returnType :
               methodWithPotentiallyUnconstrainedReturnType.getReturnTypes()) {
@@ -4268,8 +4273,19 @@ public class UnsolvedSymbolGenerator {
    * <p>Final classes are the obvious case, but they are not the only one. A primitive and an array
    * type have no declarable subtypes at all; an enum is implicitly final unless it has constant
    * bodies, none of which a generated class could be (JLS 8.9); a record is implicitly final (JLS
-   * 8.10); and an annotation type cannot be extended. Only a non-final class or an interface can
+   * 8.10); an annotation type cannot be extended; and a type variable may not be named as a
+   * superclass or superinterface (JLS 8.1.4, 8.1.5). Only a non-final class or an interface can
    * take a generated subtype.
+   *
+   * <p>Those kinds beyond the final class are reported only when {@code conflicting} says the
+   * method's current return type is one the left-hand side rejects. A non-extendable left-hand side
+   * is not on its own a reason to weaken a return type: {@code int x = item.get();} on its own
+   * already gets {@code int get()}, which satisfies it exactly, and answering true there would
+   * trade that for {@code <T> T} and buy nothing. It is the second, incompatible use site that
+   * makes the type variable the only answer that compiles, and that is what {@code conflicting}
+   * reports. A final class is exempt from the gate: a placeholder return type that was named as the
+   * supertype of another generated type reaches this method already replaced by the final class, so
+   * the conflict its subtypes are in is no longer visible here.
    *
    * <p>The resolved type is preferred when there is one, but the left-hand side is sometimes known
    * only by name -- a lambda's result type, for instance, is derived from the lambda's target type
@@ -4286,11 +4302,23 @@ public class UnsolvedSymbolGenerator {
    *
    * @param resolvedLHSType the resolved type of the left-hand side, or null if it is not resolvable
    * @param lhsTypes the type(s) of the left-hand side
+   * @param conflicting whether what the method currently returns is a type the left-hand side
+   *     rejects. Only a resolved primitive, array, enum, record, annotation type or type variable
+   *     consults this; see above.
    * @return true if no generated class could be made a subtype of the left-hand side
    */
   private boolean isNonExtendableType(
-      @Nullable ResolvedType resolvedLHSType, Set<MemberType> lhsTypes) {
+      @Nullable ResolvedType resolvedLHSType, Set<MemberType> lhsTypes, boolean conflicting) {
     if (resolvedLHSType != null) {
+      // None of these is a reference type, so none of them reaches the declaration-keyed tests
+      // below. A type variable is included because a class declaration may not name one as a
+      // superclass or superinterface (JLS 8.1.4, 8.1.5).
+      if (resolvedLHSType.isPrimitive()
+          || resolvedLHSType.isArray()
+          || resolvedLHSType.isTypeVariable()) {
+        return conflicting;
+      }
+
       if (!resolvedLHSType.isReferenceType()
           || resolvedLHSType.asReferenceType().getTypeDeclaration().isEmpty()) {
         return false;
@@ -4299,6 +4327,10 @@ public class UnsolvedSymbolGenerator {
       // If LHS is solvable, there is only one
       ResolvedReferenceTypeDeclaration decl =
           resolvedLHSType.asReferenceType().getTypeDeclaration().get();
+
+      if (decl.isEnum() || decl.isRecord() || decl.isAnnotation()) {
+        return conflicting;
+      }
 
       if (!decl.isClass()) {
         return false;

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2874,7 +2874,9 @@ public class UnsolvedSymbolGenerator {
         return UnsolvedGenerationResult.EMPTY;
       }
 
-      makeSyntheticTypeASubtypeOfExpressionType(type, instanceOf.getExpression(), "instanceof");
+      toRemove.addAll(
+          makeSyntheticTypeASubtypeOfExpressionType(
+              type, instanceOf.getExpression(), "instanceof"));
     } else if (node instanceof CastExpr castExpr
         && !castExpr.getExpression().isLambdaExpr()
         && !castExpr.getExpression().isMethodReferenceExpr()) {
@@ -2897,7 +2899,8 @@ public class UnsolvedSymbolGenerator {
         return UnsolvedGenerationResult.EMPTY;
       }
 
-      makeSyntheticTypeASubtypeOfExpressionType(type, castExpr.getExpression(), "cast");
+      toRemove.addAll(
+          makeSyntheticTypeASubtypeOfExpressionType(type, castExpr.getExpression(), "cast"));
     }
 
     // This condition checks to see if the return type of a synthetic method definition
@@ -3070,32 +3073,27 @@ public class UnsolvedSymbolGenerator {
         if (methodWithPotentiallyUnconstrainedReturnType != null
             && isNonExtendableType(
                 getResolvedTypeOfLHS.get(), lhsType, returnTypeConflictsWithLHS)) {
-          Set<UnsolvedClassOrInterfaceAlternates> symbolsToRemove = new HashSet<>();
-          for (MemberType returnType :
-              methodWithPotentiallyUnconstrainedReturnType.getReturnTypes()) {
-            if (returnType instanceof UnsolvedMemberType unsolvedReturnType
-                && unsolvedReturnType.usesGeneratedName()) {
-              // Check to see if it is unused everywhere (no methods or fields)
-              if (findAllMembers(unsolvedReturnType.getUnsolvedType()).isEmpty()) {
-                symbolsToRemove.add(unsolvedReturnType.getUnsolvedType());
-              }
-            }
-          }
-
-          methodWithPotentiallyUnconstrainedReturnType.setUnconstrainedReturnType();
-          for (UnsolvedClassOrInterfaceAlternates symbolToRemove : symbolsToRemove) {
-            removeTypeAndReplaceUses(
-                new UnsolvedMemberType(symbolToRemove, 0, List.of(), false),
-                new SolvedMemberType("java.lang.Object"));
-          }
-
-          toRemove.addAll(symbolsToRemove);
+          toRemove.addAll(useUnconstrainedReturnType(methodWithPotentiallyUnconstrainedReturnType));
 
           handledAsNonExtendable = true;
         }
 
         if (!handledAsNonExtendable) {
-          handleLHSAndRHSRelationship(lhsType, rhsType, getResolvedTypeOfLHS);
+          // A conflict that handleLHSAndRHSRelationship cannot repair. It works by making the
+          // return type a subtype of the left-hand side, which it can only do to a type Specimin
+          // generated; when every possible return type is one that already exists, there is
+          // nothing it can change, and it would silently leave the site broken. An unconstrained
+          // return type is then the repair, and making it here is what lets the non-extendable
+          // check above be gated on a conflict this site can see: the site that cannot see one is
+          // covered from the other direction.
+          if (methodWithPotentiallyUnconstrainedReturnType != null
+              && returnTypeConflictsWithLHS
+              && rhsType.stream().allMatch(type -> type instanceof SolvedMemberType)) {
+            toRemove.addAll(
+                useUnconstrainedReturnType(methodWithPotentiallyUnconstrainedReturnType));
+          } else {
+            handleLHSAndRHSRelationship(lhsType, rhsType, getResolvedTypeOfLHS);
+          }
         }
       }
     } else if (node instanceof MethodCallExpr
@@ -3463,6 +3461,41 @@ public class UnsolvedSymbolGenerator {
   }
 
   /**
+   * Replaces a generated method's return type with an unconstrained type variable, for use when
+   * some requirement on the result of a call to that method cannot be met by any type Specimin
+   * could generate. A type variable can be instantiated separately at every call site, so it meets
+   * every such requirement at once, at the cost of saying nothing about the result.
+   *
+   * <p>A placeholder return type that this leaves with no remaining use is deleted rather than
+   * emitted as an unreferenced file.
+   *
+   * @param method the generated method whose return type cannot serve some use of its result
+   * @return the placeholder types that are no longer needed, for the caller to drop from the slice
+   */
+  private List<UnsolvedSymbolAlternates<?>> useUnconstrainedReturnType(
+      UnsolvedMethodAlternates method) {
+    Set<UnsolvedClassOrInterfaceAlternates> symbolsToRemove = new HashSet<>();
+    for (MemberType returnType : method.getReturnTypes()) {
+      if (returnType instanceof UnsolvedMemberType unsolvedReturnType
+          && unsolvedReturnType.usesGeneratedName()) {
+        // Check to see if it is unused everywhere (no methods or fields)
+        if (findAllMembers(unsolvedReturnType.getUnsolvedType()).isEmpty()) {
+          symbolsToRemove.add(unsolvedReturnType.getUnsolvedType());
+        }
+      }
+    }
+
+    method.setUnconstrainedReturnType();
+    for (UnsolvedClassOrInterfaceAlternates symbolToRemove : symbolsToRemove) {
+      removeTypeAndReplaceUses(
+          new UnsolvedMemberType(symbolToRemove, 0, List.of(), false),
+          new SolvedMemberType("java.lang.Object"));
+    }
+
+    return new ArrayList<>(symbolsToRemove);
+  }
+
+  /**
    * Records that a synthetic type must be a subtype of the type of the given expression.
    *
    * <p>Shared by the {@code instanceof} and cast cases of {@link #addInformation}, which impose the
@@ -3475,8 +3508,9 @@ public class UnsolvedSymbolGenerator {
    *     Specimin does not get to choose.
    * @param operand the operand of the instanceof or the cast
    * @param kind how to describe the construct in error messages, e.g. "cast"
+   * @return the placeholder types that are no longer needed, for the caller to drop from the slice
    */
-  private void makeSyntheticTypeASubtypeOfExpressionType(
+  private List<UnsolvedSymbolAlternates<?>> makeSyntheticTypeASubtypeOfExpressionType(
       Type syntheticType, Expression operand, String kind) {
     Set<MemberType> operandTypes =
         getMemberTypesAndExpectNonNullFromFQNSets(
@@ -3489,26 +3523,45 @@ public class UnsolvedSymbolGenerator {
       // nothing to make the synthetic type a subtype of, and nothing needs to be: the type
       // variable is instantiated to the synthetic type at this site, which makes the cast or
       // instanceof legal on its own.
-      return;
+      return List.of();
     }
 
-    // Nothing can be made a subtype of a final class. Note that these are the types Specimin
-    // inferred for the operand, which may be an over-approximation of its real type, so this is
-    // worth checking even though a cast or instanceof naming a synthetic supertype of a final
-    // class could not appear in a program that compiles. Dropping the supertype leaves the
-    // synthetic type unconstrained, which is no worse than not having tried; adding it would emit
-    // a class that extends a final class, which cannot compile in any context.
+    // Nothing can be made a subtype of a final class, or of any other non-extendable type. Note
+    // that these are the types Specimin inferred for the operand, which may be an
+    // over-approximation of its real type, so this is worth checking even though a cast or
+    // instanceof naming a synthetic supertype of such a type could not appear in a program that
+    // compiles. Adding the supertype would emit a class that extends a final class or a
+    // primitive, which cannot compile in any context.
     Set<MemberType> extendableOperandTypes =
         operandTypes.stream()
             .filter(
                 operandType ->
                     !(operandType instanceof SolvedMemberType)
                         || operandType.getFullyQualifiedNames().stream()
-                            .noneMatch(JavaLangUtils::isFinalJdkClass))
+                            .noneMatch(
+                                fqn ->
+                                    JavaParserUtil.isNonExtendableTypeName(
+                                        fqn, fqnsToCompilationUnits)))
             .collect(Collectors.toCollection(LinkedHashSet::new));
 
     if (extendableOperandTypes.isEmpty()) {
-      return;
+      // The requirement cannot be met by making the synthetic type a subtype, so it has to be met
+      // on the other side: if the operand is a call to a generated method, that method's return
+      // type is the thing standing in the way, and an unconstrained one accommodates this site
+      // along with every other. Repairing it here rather than leaving the requirement dropped is
+      // what makes the outcome independent of the order these sites are visited in -- the site
+      // that assigns the result elsewhere may already have been visited, and would then see a
+      // return type that satisfies it and no reason to act.
+      if (operand.isMethodCallExpr()) {
+        UnsolvedMethodAlternates generatedMethod =
+            findGeneratedMethodFromMethodCall(operand.asMethodCallExpr());
+
+        if (generatedMethod != null) {
+          return useUnconstrainedReturnType(generatedMethod);
+        }
+      }
+
+      return List.of();
     }
 
     UnsolvedClassOrInterfaceAlternates unsolvedSyntheticType =
@@ -3523,6 +3576,8 @@ public class UnsolvedSymbolGenerator {
               + syntheticType);
     }
     unsolvedSyntheticType.addSuperType(extendableOperandTypes);
+
+    return List.of();
   }
 
   /**
@@ -4277,15 +4332,21 @@ public class UnsolvedSymbolGenerator {
    * superclass or superinterface (JLS 8.1.4, 8.1.5). Only a non-final class or an interface can
    * take a generated subtype.
    *
-   * <p>Those kinds beyond the final class are reported only when {@code conflicting} says the
-   * method's current return type is one the left-hand side rejects. A non-extendable left-hand side
-   * is not on its own a reason to weaken a return type: {@code int x = item.get();} on its own
-   * already gets {@code int get()}, which satisfies it exactly, and answering true there would
-   * trade that for {@code <T> T} and buy nothing. It is the second, incompatible use site that
-   * makes the type variable the only answer that compiles, and that is what {@code conflicting}
-   * reports. A final class is exempt from the gate: a placeholder return type that was named as the
-   * supertype of another generated type reaches this method already replaced by the final class, so
-   * the conflict its subtypes are in is no longer visible here.
+   * <p>Every one of those kinds is reported only when {@code conflicting} says the method's current
+   * return type is one the left-hand side rejects. A non-extendable left-hand side is not on its
+   * own a reason to weaken a return type: {@code int x = item.get();} on its own already gets
+   * {@code int get()}, which satisfies it exactly, and answering true there would trade that for
+   * {@code <T> T} and buy nothing. It is the second, incompatible use site that makes the type
+   * variable the only answer that compiles, and that is what {@code conflicting} reports.
+   *
+   * <p>The gate is safe only because this is not the only place the fallback can be reached. A
+   * conflict is not always visible from the site that is able to act on it -- given {@code Payload
+   * p = item.get(); String s = item.get();} the return type settles on {@code String}, and the
+   * {@code String} assignment sees nothing wrong -- so {@code addInformation} also falls back when
+   * a site sees a conflict it cannot repair by adding a supertype, and {@link
+   * #makeSyntheticTypeASubtypeOfExpressionType} does the same when a cast or instanceof cannot get
+   * the subtype it needs. Between them, whichever site can see the problem is the one that fixes
+   * it, so no kind of left-hand side needs to be exempted from the gate here.
    *
    * <p>The resolved type is preferred when there is one, but the left-hand side is sometimes known
    * only by name -- a lambda's result type, for instance, is derived from the lambda's target type
@@ -4337,10 +4398,11 @@ public class UnsolvedSymbolGenerator {
       }
 
       if (JavaLangUtils.isFinalJdkClass(decl.getQualifiedName())) {
-        return true;
+        return conflicting;
       }
 
-      return decl.toAst().isPresent()
+      return conflicting
+          && decl.toAst().isPresent()
           && ((ClassOrInterfaceDeclaration) decl.toAst().get()).isFinal();
     }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2880,9 +2880,9 @@ public class UnsolvedSymbolGenerator {
     } else if (node instanceof CastExpr castExpr
         && !castExpr.getExpression().isLambdaExpr()
         && !castExpr.getExpression().isMethodReferenceExpr()) {
-      // A cast (T) e compiles only if a cast between e's type and T would be accepted, which is
-      // exactly the condition JLS 15.20.2 (quoted above) imposes on instanceof. A synthetic T is
-      // therefore handled the same way here as it is there.
+      // A cast (T) e compiles only if casting conversion accepts e's type to T (JLS 15.16, 5.5),
+      // which is exactly the condition JLS 15.20.2 (quoted above) carries over to instanceof. A
+      // synthetic T is therefore handled the same way here as it is there.
       //
       // Constraining e's type to make the cast legal would be wrong, because it would also degrade
       // the type inferred for e at its other use sites. Since Specimin chooses what T is, it can
@@ -3495,9 +3495,10 @@ public class UnsolvedSymbolGenerator {
    * Records that a synthetic type must be a subtype of the type of the given expression.
    *
    * <p>Shared by the {@code instanceof} and cast cases of {@link #addInformation}, which impose the
-   * same requirement for the same reason: JLS 15.20.2 gives {@code x instanceof T} and {@code (T)
-   * x} the same legality condition. When {@code T} is synthetic, Specimin chooses its supertypes,
-   * so it can satisfy that condition without constraining {@code x}'s type.
+   * same requirement for the same reason: the cast must be accepted by casting conversion (JLS
+   * 5.5), and JLS 15.20.2 gives {@code x instanceof T} that same legality condition. When {@code T}
+   * is synthetic, Specimin chooses its supertypes, so it can satisfy the condition without
+   * constraining {@code x}'s type.
    *
    * @param syntheticType the type named by the instanceof or the cast. Must not be resolvable; the
    *     caller is responsible for checking that, since a type that already exists has supertypes
@@ -4324,9 +4325,10 @@ public class UnsolvedSymbolGenerator {
    * <p>Final classes are the obvious case, but they are not the only one. A primitive and an array
    * type have no declarable subtypes at all; an enum is implicitly final unless it has constant
    * bodies, none of which a generated class could be (JLS 8.9); a record is implicitly final (JLS
-   * 8.10); an annotation type cannot be extended; and a type variable may not be named as a
-   * superclass or superinterface (JLS 8.1.4, 8.1.5). Only a non-final class or an interface can
-   * take a generated subtype.
+   * 8.10); an annotation type cannot be extended; a sealed class or interface admits only the
+   * subtypes its {@code permits} clause names, which a synthetic type never is; and a type variable
+   * may not be named as a superclass or superinterface (JLS 8.1.4, 8.1.5). Only a non-final,
+   * non-sealed class or interface can take a generated subtype.
    *
    * <p>Every one of those kinds is reported only when {@code mayConflict} says the method's current
    * return type may be one the left-hand side rejects. A non-extendable left-hand side is not on
@@ -4385,6 +4387,12 @@ public class UnsolvedSymbolGenerator {
           resolvedLHSType.asReferenceType().getTypeDeclaration().get();
 
       if (decl.isEnum() || decl.isRecord() || decl.isAnnotation()) {
+        return mayConflict;
+      }
+
+      // Checked before isClass() because sealed interface also cannot have synthetic subtypes.
+      if (decl.toAst().orElse(null) instanceof TypeDeclaration<?> ast
+          && JavaParserUtil.isSealed(ast)) {
         return mayConflict;
       }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -3079,9 +3079,9 @@ public class UnsolvedSymbolGenerator {
         }
 
         if (!handledAsNonExtendable) {
-          // This tests checks for conflicts that making the LHS a supertype of the RHS cannot
-          // repair.
-          // An unconstrained return type is used instead.
+          // This test checks for conflicts that making the LHS a supertype of the RHS cannot
+          // repair, because every candidate return type already exists and so there is no generated
+          // type to give a supertype to . An unconstrained return type is used instead.
           if (methodWithPotentiallyUnconstrainedReturnType != null
               && returnTypeCanConflictWithLHS
               && rhsType.stream().allMatch(type -> type instanceof SolvedMemberType)) {
@@ -4328,21 +4328,21 @@ public class UnsolvedSymbolGenerator {
    * superclass or superinterface (JLS 8.1.4, 8.1.5). Only a non-final class or an interface can
    * take a generated subtype.
    *
-   * <p>Every one of those kinds is reported only when {@code conflicting} says the method's current
-   * return type is one the left-hand side rejects. A non-extendable left-hand side is not on its
-   * own a reason to weaken a return type: for {@code int x = item.get();}, {@code int} is the right
-   * return type for {@code get}. It is only when there is a second, incompatible use site that an
-   * unconstrained type variable is required; {@code conflicting} should be {@code true} whenever
-   * there might be a second, incompatible use site.
+   * <p>Every one of those kinds is reported only when {@code mayConflict} says the method's current
+   * return type may be one the left-hand side rejects. A non-extendable left-hand side is not on
+   * its own a reason to weaken a return type: for {@code int x = item.get();}, {@code int} is the
+   * right return type for {@code get}. It is only when there is a second, incompatible use site
+   * that an unconstrained type variable is required; {@code mayConflict} should be {@code true}
+   * whenever there might be a second, incompatible use site.
    *
-   * <p>This is not the only place the unconstrained type variable fallback can be generated. A
-   * conflict is not always visible from the site that can act on it -- given {@code Payload p =
-   * item.get(); String s = item.get();} the return type settles on {@code String}, and the {@code
+   * <p>A conflict is not always visible from the site that can act on it -- given {@code Payload p
+   * = item.get(); String s = item.get();} the return type settles on {@code String}, and the {@code
    * String} assignment sees nothing wrong -- so {@code addInformation} also falls back when a site
    * sees a conflict it cannot repair by adding a supertype, and {@link
    * #makeSyntheticTypeASubtypeOfExpressionType} does the same when a cast or instanceof cannot get
    * the subtype it needs. Between them, whichever site can see the problem is the one that fixes
-   * it.
+   * it. All of these sites are needed for soundness: removing any one of them would lead to
+   * non-compilable output.
    *
    * <p>The resolved type is preferred when there is one, but the left-hand side is sometimes known
    * only by name -- a lambda's result type, for instance, is derived from the lambda's target type
@@ -4359,13 +4359,13 @@ public class UnsolvedSymbolGenerator {
    *
    * @param resolvedLHSType the resolved type of the left-hand side, or null if it is not resolvable
    * @param lhsTypes the type(s) of the left-hand side
-   * @param conflicting whether the assignment context may confilct with the existing type of the
-   *     left-hand side. Only a resolved primitive, array, enum, record, annotation type or type
+   * @param mayConflict whether the assignment context may confilct with the existing type of the
+   *     right-hand side. Only a resolved primitive, array, enum, record, annotation type or type
    *     variable consults this; see above.
    * @return true if no generated class could be made a subtype of the left-hand side
    */
   private boolean isNonExtendableType(
-      @Nullable ResolvedType resolvedLHSType, Set<MemberType> lhsTypes, boolean conflicting) {
+      @Nullable ResolvedType resolvedLHSType, Set<MemberType> lhsTypes, boolean mayConflict) {
     if (resolvedLHSType != null) {
       // None of these is a reference type, so none of them reaches the declaration-keyed tests
       // below. A type variable is included because a class declaration may not name one as a
@@ -4373,7 +4373,7 @@ public class UnsolvedSymbolGenerator {
       if (resolvedLHSType.isPrimitive()
           || resolvedLHSType.isArray()
           || resolvedLHSType.isTypeVariable()) {
-        return conflicting;
+        return mayConflict;
       }
 
       if (!resolvedLHSType.isReferenceType()
@@ -4386,7 +4386,7 @@ public class UnsolvedSymbolGenerator {
           resolvedLHSType.asReferenceType().getTypeDeclaration().get();
 
       if (decl.isEnum() || decl.isRecord() || decl.isAnnotation()) {
-        return conflicting;
+        return mayConflict;
       }
 
       if (!decl.isClass()) {
@@ -4394,10 +4394,10 @@ public class UnsolvedSymbolGenerator {
       }
 
       if (JavaLangUtils.isFinalJdkClass(decl.getQualifiedName())) {
-        return conflicting;
+        return mayConflict;
       }
 
-      return conflicting
+      return mayConflict
           && decl.toAst().isPresent()
           && ((ClassOrInterfaceDeclaration) decl.toAst().get()).isFinal();
     }
@@ -4425,8 +4425,8 @@ public class UnsolvedSymbolGenerator {
   }
 
   /**
-   * Handles the relationship between the LHS and RHS types by making the type of the LHS a
-   * supertype of the type of the RHS, if the type of the RHS is unsolved.
+   * Makes the type of the LHS (of some pseudo-assignment) a supertype of the type of the RHS, if
+   * the type of the RHS is unsolved.
    *
    * @param lhsTypes The type(s) of the LHS
    * @param rhsTypes The type(s) of the RHS

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -3081,7 +3081,7 @@ public class UnsolvedSymbolGenerator {
         if (!handledAsNonExtendable) {
           // This test checks for conflicts that making the LHS a supertype of the RHS cannot
           // repair, because every candidate return type already exists and so there is no generated
-          // type to give a supertype to . An unconstrained return type is used instead.
+          // type to give a supertype to. An unconstrained return type is used instead.
           if (methodWithPotentiallyUnconstrainedReturnType != null
               && returnTypeCanConflictWithLHS
               && rhsType.stream().allMatch(type -> type instanceof SolvedMemberType)) {
@@ -4359,9 +4359,8 @@ public class UnsolvedSymbolGenerator {
    *
    * @param resolvedLHSType the resolved type of the left-hand side, or null if it is not resolvable
    * @param lhsTypes the type(s) of the left-hand side
-   * @param mayConflict whether the assignment context may confilct with the existing type of the
-   *     right-hand side. Only a resolved primitive, array, enum, record, annotation type or type
-   *     variable consults this; see above.
+   * @param mayConflict whether the assignment context may conflict with the existing type of the
+   *     right-hand side. Only a resolved LHS type consults this; the name-keyed path ignores it.
    * @return true if no generated class could be made a subtype of the left-hand side
    */
   private boolean isNonExtendableType(

--- a/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandPrimitiveTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandPrimitiveTest.java
@@ -4,14 +4,15 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 /**
- * A cast to a synthetic type is made to compile by making that type a subtype of the operand's type
- * (JLS 15.20.2), but here the operand's type is {@code int}, which has no subtypes at all. The
- * requirement cannot be met on the synthetic type's side, so it is met on the other: the generated
- * method's return type becomes an unconstrained type variable, which {@code T} instantiates to
- * {@code Baz} at the cast and to {@code Integer} at the assignment.
+ * A cast to a synthetic type is made to compile by making that type a subtype of the operand's
+ * type, which is what casting conversion requires of the pair (JLS 5.5). Here the operand's type is
+ * {@code int}, which has no subtypes at all. The requirement cannot be met on the synthetic type's
+ * side, so it is met on the other: the generated method's return type becomes an unconstrained type
+ * variable, which {@code T} instantiates to {@code Baz} at the cast and to {@code Integer} at the
+ * assignment.
  *
- * <p>{@link
- * NonExtendableCastOperandReversedTest} is the same program with the two statements swapped.
+ * <p>{@link NonExtendableCastOperandReversedTest} is the same program with the two statements
+ * swapped.
  */
 public class NonExtendableCastOperandPrimitiveTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandPrimitiveTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandPrimitiveTest.java
@@ -1,0 +1,29 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A cast to a synthetic type is made to compile by making that type a subtype of the operand's type
+ * (JLS 15.20.2), but here the operand's type is {@code int}, which has no subtypes at all. The
+ * requirement cannot be met on the synthetic type's side, so it is met on the other: the generated
+ * method's return type becomes an unconstrained type variable, which {@code T} instantiates to
+ * {@code Baz} at the cast and to {@code Integer} at the assignment.
+ *
+ * <p>Before this was handled, the dropped requirement left {@code Baz} declared as {@code extends
+ * int}, which is not a Java program at all.
+ *
+ * <p>The repair happens at the cast rather than at the assignment because only the cast can see the
+ * problem: by the time the assignment is examined, the return type may already be {@code int},
+ * which satisfies the assignment and gives it no reason to act. {@link
+ * NonExtendableCastOperandReversedTest} is the same program with the two statements swapped.
+ */
+public class NonExtendableCastOperandPrimitiveTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nonextendablecastoperandprimitive",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandPrimitiveTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandPrimitiveTest.java
@@ -10,12 +10,7 @@ import org.junit.jupiter.api.Test;
  * method's return type becomes an unconstrained type variable, which {@code T} instantiates to
  * {@code Baz} at the cast and to {@code Integer} at the assignment.
  *
- * <p>Before this was handled, the dropped requirement left {@code Baz} declared as {@code extends
- * int}, which is not a Java program at all.
- *
- * <p>The repair happens at the cast rather than at the assignment because only the cast can see the
- * problem: by the time the assignment is examined, the return type may already be {@code int},
- * which satisfies the assignment and gives it no reason to act. {@link
+ * <p>{@link
  * NonExtendableCastOperandReversedTest} is the same program with the two statements swapped.
  */
 public class NonExtendableCastOperandPrimitiveTest {

--- a/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandRecordTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandRecordTest.java
@@ -4,14 +4,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 /**
- * The record counterpart of {@link NonExtendableCastOperandPrimitiveTest}, which previously emitted
- * a class extending the record. A record is implicitly final (JLS 8.10), and unlike a primitive or
- * a final JDK class it can only be recognized by looking at its declaration, so this covers the
- * path through {@code JavaParserUtil#isNonExtendableTypeName} that consults the project's
- * compilation units.
- *
- * <p>The record is declared with no components so that the test turns only on the declaration's
- * kind; see {@link NonExtendableTargetEnumTest}.
+ * The record counterpart of {@link NonExtendableCastOperandPrimitiveTest}.
  */
 public class NonExtendableCastOperandRecordTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandRecordTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandRecordTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The record counterpart of {@link NonExtendableCastOperandPrimitiveTest}, which previously emitted
+ * a class extending the record. A record is implicitly final (JLS 8.10), and unlike a primitive or
+ * a final JDK class it can only be recognized by looking at its declaration, so this covers the
+ * path through {@code JavaParserUtil#isNonExtendableTypeName} that consults the project's
+ * compilation units.
+ *
+ * <p>The record is declared with no components so that the test turns only on the declaration's
+ * kind; see {@link NonExtendableTargetEnumTest}.
+ */
+public class NonExtendableCastOperandRecordTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nonextendablecastoperandrecord",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandRecordTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandRecordTest.java
@@ -3,9 +3,7 @@ package org.checkerframework.specimin;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
-/**
- * The record counterpart of {@link NonExtendableCastOperandPrimitiveTest}.
- */
+/** The record counterpart of {@link NonExtendableCastOperandPrimitiveTest}. */
 public class NonExtendableCastOperandRecordTest {
   @Test
   public void runTest() throws IOException {

--- a/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandReversedTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableCastOperandReversedTest.java
@@ -1,0 +1,25 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link NonExtendableCastOperandPrimitiveTest}'s program with its two statements swapped, so that
+ * the assignment to the {@code int} is examined first. Both orders must compile; this one is what
+ * guards the claim that the outcome does not depend on which statement comes first.
+ *
+ * <p>The two orders reach the same return type by different routes, so the rest of the output
+ * differs. Here the assignment is examined while the placeholder return type is still in place, so
+ * the assignment itself triggers the fallback and the cast then finds an unconstrained operand type
+ * and leaves {@code Baz} extending the placeholder. That keeps an otherwise empty class in the
+ * output, which is the usual trade: minimality is worth giving up for compilability.
+ */
+public class NonExtendableCastOperandReversedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nonextendablecastoperandreversed",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetArrayTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetArrayTest.java
@@ -4,9 +4,8 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 /**
- * The array counterpart of {@link NonExtendableTargetPrimitiveTest}. An array type's only
- * supertypes are {@code Object}, {@code Cloneable} and {@code Serializable} (JLS 4.10.3), and no
- * class declaration may name one as a superclass, so a generated type cannot be made to fit this
+ * The array counterpart of {@link NonExtendableTargetPrimitiveTest}. No
+ * class declaration may name an array type as a superclass, so a generated type cannot be made to fit this
  * assignment and the return type must fall back to an unconstrained type variable.
  */
 public class NonExtendableTargetArrayTest {

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetArrayTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetArrayTest.java
@@ -4,9 +4,9 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 /**
- * The array counterpart of {@link NonExtendableTargetPrimitiveTest}. No
- * class declaration may name an array type as a superclass, so a generated type cannot be made to fit this
- * assignment and the return type must fall back to an unconstrained type variable.
+ * The array counterpart of {@link NonExtendableTargetPrimitiveTest}. No class declaration may name
+ * an array type as a superclass, so a generated type cannot be made to fit this assignment and the
+ * return type must fall back to an unconstrained type variable.
  */
 public class NonExtendableTargetArrayTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetArrayTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetArrayTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The array counterpart of {@link NonExtendableTargetPrimitiveTest}. An array type's only
+ * supertypes are {@code Object}, {@code Cloneable} and {@code Serializable} (JLS 4.10.3), and no
+ * class declaration may name one as a superclass, so a generated type cannot be made to fit this
+ * assignment and the return type must fall back to an unconstrained type variable.
+ */
+public class NonExtendableTargetArrayTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nonextendabletargetarray",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetEnumTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetEnumTest.java
@@ -7,10 +7,6 @@ import org.junit.jupiter.api.Test;
  * The enum counterpart of {@link NonExtendableTargetPrimitiveTest}. An enum declaration whose
  * constants have no class bodies is implicitly final (JLS 8.9), so nothing Specimin generates can
  * be made a subtype of it.
- *
- * <p>The enum is declared with no constants so that the test turns only on the declaration's kind:
- * Specimin prunes unreferenced members, so constants would make the expected output depend on
- * pruning behavior that has nothing to do with what is under test.
  */
 public class NonExtendableTargetEnumTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetEnumTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetEnumTest.java
@@ -1,0 +1,23 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The enum counterpart of {@link NonExtendableTargetPrimitiveTest}. An enum declaration whose
+ * constants have no class bodies is implicitly final (JLS 8.9), so nothing Specimin generates can
+ * be made a subtype of it.
+ *
+ * <p>The enum is declared with no constants so that the test turns only on the declaration's kind:
+ * Specimin prunes unreferenced members, so constants would make the expected output depend on
+ * pruning behavior that has nothing to do with what is under test.
+ */
+public class NonExtendableTargetEnumTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nonextendabletargetenum",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetNoConflictTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetNoConflictTest.java
@@ -1,0 +1,25 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A non-extendable assignment target is not on its own a reason to weaken a synthetic method's
+ * return type. Each call here has exactly one use site, so the type that site asks for is the
+ * precise return type and it satisfies everything that has been asked; falling back to an
+ * unconstrained type variable, as {@link NonExtendableTargetPrimitiveTest} and its siblings must,
+ * would trade that precision for nothing.
+ *
+ * <p>Every kind of non-extendable target that {@code UnsolvedSymbolGenerator#isNonExtendableType}
+ * recognizes from a resolved type appears once, so that broadening that method again cannot quietly
+ * cost precision here.
+ */
+public class NonExtendableTargetNoConflictTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nonextendabletargetnoconflict",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetPrimitiveTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetPrimitiveTest.java
@@ -1,0 +1,30 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Two assignments of the same unsolved call compete: one to an {@code int} and one to a class
+ * Specimin generates a subtype for. A primitive has no subtypes at all, so no synthetic return type
+ * can serve both, and the only return type that satisfies both is an unconstrained type variable:
+ * {@code T} is inferred as {@code Integer} and unboxed at the first assignment (JLS 5.2), and as
+ * {@code Payload} at the second.
+ *
+ * <p>This is the assignment counterpart of {@link LambdaResultUnsolvedArrayTargetTest} and its
+ * siblings, which cover the same competition when the target types come from lambdas. Those reach
+ * the fallback by name; an assignment reaches it through the left-hand side's resolved type, which
+ * is a separate decision in {@code UnsolvedSymbolGenerator#isNonExtendableType}. See
+ * https://github.com/njit-jerse/specimin/issues/509.
+ *
+ * <p>{@link NonExtendableTargetNoConflictTest} covers the other half of that decision: a
+ * non-extendable target that no other use site competes with keeps its precise return type.
+ */
+public class NonExtendableTargetPrimitiveTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nonextendabletargetprimitive",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetRecordTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetRecordTest.java
@@ -6,9 +6,6 @@ import org.junit.jupiter.api.Test;
 /**
  * The record counterpart of {@link NonExtendableTargetPrimitiveTest}. A record declaration is
  * implicitly final (JLS 8.10), so nothing Specimin generates can be made a subtype of it.
- *
- * <p>The record is declared with no components for the reason {@link NonExtendableTargetEnumTest}
- * gives for its enum having no constants.
  */
 public class NonExtendableTargetRecordTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetRecordTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetRecordTest.java
@@ -1,0 +1,21 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The record counterpart of {@link NonExtendableTargetPrimitiveTest}. A record declaration is
+ * implicitly final (JLS 8.10), so nothing Specimin generates can be made a subtype of it.
+ *
+ * <p>The record is declared with no components for the reason {@link NonExtendableTargetEnumTest}
+ * gives for its enum having no constants.
+ */
+public class NonExtendableTargetRecordTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nonextendabletargetrecord",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetTypeVariableTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetTypeVariableTest.java
@@ -12,10 +12,6 @@ import org.junit.jupiter.api.Test;
  * <p>The target method's {@code U} is not in scope in the generated {@code Item}, so the generated
  * method binds a type variable of its own; the name it gets is whichever one is free, which is why
  * the expected output says {@code T1} rather than {@code T}.
- *
- * <p>Only this assignment form is fixed. The lambda form of the same program -- {@code Supplier<U>
- * s = () -> item.get();} -- still does not compile, because the constraint is unnameable at symbol
- * generation time; see issue 509.
  */
 public class NonExtendableTargetTypeVariableTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetTypeVariableTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetTypeVariableTest.java
@@ -1,0 +1,28 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The type-variable counterpart of {@link NonExtendableTargetPrimitiveTest}. A class declaration
+ * may not name a type variable as a superclass or superinterface (JLS 8.1.4, 8.1.5), and the only
+ * values assignable to an unbounded type variable are {@code null} and values already of that type,
+ * so an unconstrained type variable is again the only return type that satisfies both assignments.
+ *
+ * <p>The target method's {@code U} is not in scope in the generated {@code Item}, so the generated
+ * method binds a type variable of its own; the name it gets is whichever one is free, which is why
+ * the expected output says {@code T1} rather than {@code T}.
+ *
+ * <p>Only this assignment form is fixed. The lambda form of the same program -- {@code Supplier<U>
+ * s = () -> item.get();} -- still does not compile, because the constraint is unnameable at symbol
+ * generation time; see issue 509.
+ */
+public class NonExtendableTargetTypeVariableTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nonextendabletargettypevariable",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/UnrepairableConflictImpreciseTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnrepairableConflictImpreciseTest.java
@@ -1,0 +1,34 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This fixture deliberately pins imprecise output. {@code Dog get()} would be the better answer and
+ * it compiles: the return type settles on {@code Dog}, and a {@code Dog} is assignable to {@code
+ * Animal a} without conversion, so the earlier assignment needs no repair at all. Specimin emits
+ * {@code <T> T get()} anyway.
+ *
+ * <p>The reason is that the test for "this site is in conflict with the return type" is type
+ * equality, not assignability: {@code Dog} is not {@code Animal}, so the {@code Animal} assignment
+ * reports a conflict, finds that it cannot be repaired by adding a supertype -- {@code Dog} is a
+ * class from the input, so there is nothing of Specimin's to change -- and falls back. Deciding
+ * this properly needs {@code UnsolvedSymbolGenerator} to be able to ask whether one type is
+ * assignable to another, which needs a type solver it does not currently hold; equality is the
+ * approximation that is available, and it errs toward the answer that always compiles.
+ *
+ * <p><b>If a later change teaches that check about assignability, this expectation should be
+ * relaxed to {@code Dog get()}.</b> Doing so is safe and is an improvement, not a regression:
+ * nothing here depends on the type variable, and the swapped-statement version in {@link
+ * UnrepairableConflictSupertypeTest} -- where the conflict is genuine, because the return type is
+ * the supertype and cannot be assigned to the subtype -- is the one that must keep falling back.
+ */
+public class UnrepairableConflictImpreciseTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unrepairableconflictimprecise",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/UnrepairableConflictImpreciseTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnrepairableConflictImpreciseTest.java
@@ -11,17 +11,17 @@ import org.junit.jupiter.api.Test;
  *
  * <p>The reason is that the test for "this site is in conflict with the return type" is type
  * equality, not assignability: {@code Dog} is not {@code Animal}, so the {@code Animal} assignment
- * conservatively appears to be a conflict, and Specimin cannot be repair it by adding a supertype -- {@code Dog} is a
- * class from the input, so there is nothing of Specimin's to change -- and falls back. Deciding
- * this properly needs {@code UnsolvedSymbolGenerator} to be able to ask whether one type is
- * assignable to another, which needs a type solver; equality is the
- * approximation that is available, and it errs toward an answer that always compiles.
+ * conservatively appears to be a conflict, and Specimin cannot repair it by adding a supertype --
+ * {@code Dog} is a class from the input, so there is nothing of Specimin's to change -- and falls
+ * back. Deciding this properly needs {@code UnsolvedSymbolGenerator} to be able to ask whether one
+ * type is assignable to another, which needs a type solver; equality is the approximation that is
+ * available, and it errs toward an answer that always compiles.
  *
- * <p><b>If a later change can
- * relax this to {@code Dog get()}, it should. </b> Doing so is safe and is an improvement, not a regression:
- * nothing here depends on the type variable, and the swapped-statement version in {@link
- * UnrepairableConflictSupertypeTest} -- where the conflict is genuine, because the return type is
- * the supertype and cannot be assigned to the subtype -- is the one that must keep falling back.
+ * <p><b>If a later change can relax this to {@code Dog get()}, it should.</b> Doing so is safe and
+ * is an improvement, not a regression: nothing here depends on the type variable, and the
+ * swapped-statement version in {@link UnrepairableConflictSupertypeTest} -- where the conflict is
+ * genuine, because the return type is the supertype and cannot be assigned to the subtype -- is the
+ * one that must keep falling back.
  */
 public class UnrepairableConflictImpreciseTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/UnrepairableConflictImpreciseTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnrepairableConflictImpreciseTest.java
@@ -11,14 +11,14 @@ import org.junit.jupiter.api.Test;
  *
  * <p>The reason is that the test for "this site is in conflict with the return type" is type
  * equality, not assignability: {@code Dog} is not {@code Animal}, so the {@code Animal} assignment
- * reports a conflict, finds that it cannot be repaired by adding a supertype -- {@code Dog} is a
+ * conservatively appears to be a conflict, and Specimin cannot be repair it by adding a supertype -- {@code Dog} is a
  * class from the input, so there is nothing of Specimin's to change -- and falls back. Deciding
  * this properly needs {@code UnsolvedSymbolGenerator} to be able to ask whether one type is
- * assignable to another, which needs a type solver it does not currently hold; equality is the
- * approximation that is available, and it errs toward the answer that always compiles.
+ * assignable to another, which needs a type solver; equality is the
+ * approximation that is available, and it errs toward an answer that always compiles.
  *
- * <p><b>If a later change teaches that check about assignability, this expectation should be
- * relaxed to {@code Dog get()}.</b> Doing so is safe and is an improvement, not a regression:
+ * <p><b>If a later change can
+ * relax this to {@code Dog get()}, it should. </b> Doing so is safe and is an improvement, not a regression:
  * nothing here depends on the type variable, and the swapped-statement version in {@link
  * UnrepairableConflictSupertypeTest} -- where the conflict is genuine, because the return type is
  * the supertype and cannot be assigned to the subtype -- is the one that must keep falling back.

--- a/src/test/java/org/checkerframework/specimin/UnrepairableConflictPrimitiveTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnrepairableConflictPrimitiveTest.java
@@ -1,0 +1,31 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A conflict over a synthetic method's return type, seen from the site that cannot repair it. The
+ * return type settles on {@code Payload}, so the {@code int} assignment is the one it does not
+ * satisfy -- but that assignment's target is a primitive, and {@link
+ * NonExtendableTargetPrimitiveTest} covers the case where it acts. Here the order is reversed, and
+ * the {@code Payload} assignment is examined while the return type already is {@code Payload}: it
+ * sees a target it satisfies and has nothing to complain about.
+ *
+ * <p>What breaks the tie is the {@code int} assignment noticing that the conflict it does see
+ * cannot be fixed by making {@code Payload} a subtype of {@code int}. Nothing Specimin generated is
+ * involved on that side, so there is no supertype to add and the fallback is the only move left.
+ *
+ * <p>This is the fixture that lets {@code UnsolvedSymbolGenerator#isNonExtendableType} treat every
+ * non-extendable kind alike. A final class used to be answered for unconditionally, which papered
+ * over this shape for {@code String} while leaving it broken for a primitive; with the repair
+ * reachable from both directions, the exemption is unnecessary.
+ */
+public class UnrepairableConflictPrimitiveTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unrepairableconflictprimitive",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/UnrepairableConflictPrimitiveTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnrepairableConflictPrimitiveTest.java
@@ -14,11 +14,6 @@ import org.junit.jupiter.api.Test;
  * <p>What breaks the tie is the {@code int} assignment noticing that the conflict it does see
  * cannot be fixed by making {@code Payload} a subtype of {@code int}. Nothing Specimin generated is
  * involved on that side, so there is no supertype to add and the fallback is the only move left.
- *
- * <p>This is the fixture that lets {@code UnsolvedSymbolGenerator#isNonExtendableType} treat every
- * non-extendable kind alike. A final class used to be answered for unconditionally, which papered
- * over this shape for {@code String} while leaving it broken for a primitive; with the repair
- * reachable from both directions, the exemption is unnecessary.
  */
 public class UnrepairableConflictPrimitiveTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/UnrepairableConflictSupertypeTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnrepairableConflictSupertypeTest.java
@@ -1,0 +1,26 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Neither assignment target here is non-extendable, so nothing in this program is about finality:
+ * the return type settles on {@code Animal}, and {@code Dog d = item.get();} then asks for a
+ * narrowing reference conversion, which an assignment context does not perform (JLS 5.2). The
+ * conflict is real and there is no supertype to add -- {@code Animal} is a class from the input,
+ * not something Specimin generated -- so an unconstrained return type is what satisfies both
+ * assignments, with {@code T} inferred as {@code Dog} at the first and {@code Animal} at the
+ * second.
+ *
+ * <p>{@link UnrepairableConflictImpreciseTest} is this program with the two statements swapped,
+ * where the return type lands on the subtype instead and no repair is actually needed.
+ */
+public class UnrepairableConflictSupertypeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unrepairableconflictsupertype",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/resources/nonextendablecastoperandprimitive/expected/com/example/Simple.java
+++ b/src/test/resources/nonextendablecastoperandprimitive/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+
+  public void target(Foo f) {
+    Baz b = (Baz) f.get();
+    int x = f.get();
+    System.out.println(b + "" + x);
+  }
+}

--- a/src/test/resources/nonextendablecastoperandprimitive/expected/org/example/Baz.java
+++ b/src/test/resources/nonextendablecastoperandprimitive/expected/org/example/Baz.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Baz {
+}

--- a/src/test/resources/nonextendablecastoperandprimitive/expected/org/example/Foo.java
+++ b/src/test/resources/nonextendablecastoperandprimitive/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Foo {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/nonextendablecastoperandprimitive/input/com/example/Simple.java
+++ b/src/test/resources/nonextendablecastoperandprimitive/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+  public void target(Foo f) {
+    Baz b = (Baz) f.get();
+    int x = f.get();
+    System.out.println(b + "" + x);
+  }
+}

--- a/src/test/resources/nonextendablecastoperandrecord/expected/com/example/Point.java
+++ b/src/test/resources/nonextendablecastoperandrecord/expected/com/example/Point.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public record Point() {}

--- a/src/test/resources/nonextendablecastoperandrecord/expected/com/example/Simple.java
+++ b/src/test/resources/nonextendablecastoperandrecord/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+
+  public void target(Foo f) {
+    Baz b = (Baz) f.get();
+    Point p = f.get();
+    System.out.println(b + "" + p);
+  }
+}

--- a/src/test/resources/nonextendablecastoperandrecord/expected/org/example/Baz.java
+++ b/src/test/resources/nonextendablecastoperandrecord/expected/org/example/Baz.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Baz {
+}

--- a/src/test/resources/nonextendablecastoperandrecord/expected/org/example/Foo.java
+++ b/src/test/resources/nonextendablecastoperandrecord/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Foo {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/nonextendablecastoperandrecord/input/com/example/Point.java
+++ b/src/test/resources/nonextendablecastoperandrecord/input/com/example/Point.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public record Point() {}

--- a/src/test/resources/nonextendablecastoperandrecord/input/com/example/Simple.java
+++ b/src/test/resources/nonextendablecastoperandrecord/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+  public void target(Foo f) {
+    Baz b = (Baz) f.get();
+    Point p = f.get();
+    System.out.println(b + "" + p);
+  }
+}

--- a/src/test/resources/nonextendablecastoperandreversed/expected/com/example/Simple.java
+++ b/src/test/resources/nonextendablecastoperandreversed/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+
+  public void target(Foo f) {
+    int x = f.get();
+    Baz b = (Baz) f.get();
+    System.out.println(b + "" + x);
+  }
+}

--- a/src/test/resources/nonextendablecastoperandreversed/expected/org/example/Baz.java
+++ b/src/test/resources/nonextendablecastoperandreversed/expected/org/example/Baz.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Baz extends org.example.GetReturnType  {
+}

--- a/src/test/resources/nonextendablecastoperandreversed/expected/org/example/Foo.java
+++ b/src/test/resources/nonextendablecastoperandreversed/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Foo {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/nonextendablecastoperandreversed/expected/org/example/GetReturnType.java
+++ b/src/test/resources/nonextendablecastoperandreversed/expected/org/example/GetReturnType.java
@@ -1,0 +1,3 @@
+package org.example;
+public class GetReturnType {
+}

--- a/src/test/resources/nonextendablecastoperandreversed/input/com/example/Simple.java
+++ b/src/test/resources/nonextendablecastoperandreversed/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+  public void target(Foo f) {
+    int x = f.get();
+    Baz b = (Baz) f.get();
+    System.out.println(b + "" + x);
+  }
+}

--- a/src/test/resources/nonextendabletargetarray/expected/com/example/Payload.java
+++ b/src/test/resources/nonextendabletargetarray/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/nonextendabletargetarray/expected/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargetarray/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  void bar(Item item) {
+    String[] a = item.get();
+    Payload p = item.get();
+  }
+}

--- a/src/test/resources/nonextendabletargetarray/expected/org/example/Item.java
+++ b/src/test/resources/nonextendabletargetarray/expected/org/example/Item.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/nonextendabletargetarray/input/com/example/Payload.java
+++ b/src/test/resources/nonextendabletargetarray/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/nonextendabletargetarray/input/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargetarray/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        String[] a = item.get();
+        Payload p = item.get();
+    }
+}

--- a/src/test/resources/nonextendabletargetenum/expected/com/example/Color.java
+++ b/src/test/resources/nonextendabletargetenum/expected/com/example/Color.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public enum Color {}

--- a/src/test/resources/nonextendabletargetenum/expected/com/example/Payload.java
+++ b/src/test/resources/nonextendabletargetenum/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/nonextendabletargetenum/expected/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargetenum/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  void bar(Item item) {
+    Color c = item.get();
+    Payload p = item.get();
+  }
+}

--- a/src/test/resources/nonextendabletargetenum/expected/org/example/Item.java
+++ b/src/test/resources/nonextendabletargetenum/expected/org/example/Item.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/nonextendabletargetenum/input/com/example/Color.java
+++ b/src/test/resources/nonextendabletargetenum/input/com/example/Color.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public enum Color {}

--- a/src/test/resources/nonextendabletargetenum/input/com/example/Payload.java
+++ b/src/test/resources/nonextendabletargetenum/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/nonextendabletargetenum/input/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargetenum/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Color c = item.get();
+        Payload p = item.get();
+    }
+}

--- a/src/test/resources/nonextendabletargetnoconflict/expected/com/example/Color.java
+++ b/src/test/resources/nonextendabletargetnoconflict/expected/com/example/Color.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public enum Color {}

--- a/src/test/resources/nonextendabletargetnoconflict/expected/com/example/Point.java
+++ b/src/test/resources/nonextendabletargetnoconflict/expected/com/example/Point.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public record Point() {}

--- a/src/test/resources/nonextendabletargetnoconflict/expected/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargetnoconflict/expected/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  <U> void bar(Item item) {
+    int i = item.getInt();
+    String[] a = item.getArray();
+    Color c = item.getColor();
+    Point p = item.getPoint();
+    U u = item.getU();
+  }
+}

--- a/src/test/resources/nonextendabletargetnoconflict/expected/org/example/Item.java
+++ b/src/test/resources/nonextendabletargetnoconflict/expected/org/example/Item.java
@@ -1,0 +1,23 @@
+package org.example;
+public class Item {
+
+    public <U> U getU() {
+        throw new java.lang.Error();
+    }
+
+    public com.example.Point getPoint() {
+        throw new java.lang.Error();
+    }
+
+    public com.example.Color getColor() {
+        throw new java.lang.Error();
+    }
+
+    public java.lang.String[] getArray() {
+        throw new java.lang.Error();
+    }
+
+    public int getInt() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/nonextendabletargetnoconflict/input/com/example/Color.java
+++ b/src/test/resources/nonextendabletargetnoconflict/input/com/example/Color.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public enum Color {}

--- a/src/test/resources/nonextendabletargetnoconflict/input/com/example/Point.java
+++ b/src/test/resources/nonextendabletargetnoconflict/input/com/example/Point.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public record Point() {}

--- a/src/test/resources/nonextendabletargetnoconflict/input/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargetnoconflict/input/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    <U> void bar(Item item) {
+        int i = item.getInt();
+        String[] a = item.getArray();
+        Color c = item.getColor();
+        Point p = item.getPoint();
+        U u = item.getU();
+    }
+}

--- a/src/test/resources/nonextendabletargetprimitive/expected/com/example/Payload.java
+++ b/src/test/resources/nonextendabletargetprimitive/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/nonextendabletargetprimitive/expected/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargetprimitive/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  void bar(Item item) {
+    int x = item.get();
+    Payload p = item.get();
+  }
+}

--- a/src/test/resources/nonextendabletargetprimitive/expected/org/example/Item.java
+++ b/src/test/resources/nonextendabletargetprimitive/expected/org/example/Item.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/nonextendabletargetprimitive/input/com/example/Payload.java
+++ b/src/test/resources/nonextendabletargetprimitive/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/nonextendabletargetprimitive/input/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargetprimitive/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        int x = item.get();
+        Payload p = item.get();
+    }
+}

--- a/src/test/resources/nonextendabletargetrecord/expected/com/example/Payload.java
+++ b/src/test/resources/nonextendabletargetrecord/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/nonextendabletargetrecord/expected/com/example/Point.java
+++ b/src/test/resources/nonextendabletargetrecord/expected/com/example/Point.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public record Point() {}

--- a/src/test/resources/nonextendabletargetrecord/expected/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargetrecord/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  void bar(Item item) {
+    Point pt = item.get();
+    Payload p = item.get();
+  }
+}

--- a/src/test/resources/nonextendabletargetrecord/expected/org/example/Item.java
+++ b/src/test/resources/nonextendabletargetrecord/expected/org/example/Item.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/nonextendabletargetrecord/input/com/example/Payload.java
+++ b/src/test/resources/nonextendabletargetrecord/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/nonextendabletargetrecord/input/com/example/Point.java
+++ b/src/test/resources/nonextendabletargetrecord/input/com/example/Point.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public record Point() {}

--- a/src/test/resources/nonextendabletargetrecord/input/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargetrecord/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Point pt = item.get();
+        Payload p = item.get();
+    }
+}

--- a/src/test/resources/nonextendabletargettypevariable/expected/com/example/Payload.java
+++ b/src/test/resources/nonextendabletargettypevariable/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/nonextendabletargettypevariable/expected/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargettypevariable/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  <U> void bar(Item item) {
+    U u = item.get();
+    Payload p = item.get();
+  }
+}

--- a/src/test/resources/nonextendabletargettypevariable/expected/org/example/Item.java
+++ b/src/test/resources/nonextendabletargettypevariable/expected/org/example/Item.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Item {
+
+    public <T1> T1 get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/nonextendabletargettypevariable/input/com/example/Payload.java
+++ b/src/test/resources/nonextendabletargettypevariable/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/nonextendabletargettypevariable/input/com/example/Simple.java
+++ b/src/test/resources/nonextendabletargettypevariable/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    <U> void bar(Item item) {
+        U u = item.get();
+        Payload p = item.get();
+    }
+}

--- a/src/test/resources/unrepairableconflictimprecise/expected/com/example/Animal.java
+++ b/src/test/resources/unrepairableconflictimprecise/expected/com/example/Animal.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Animal {}

--- a/src/test/resources/unrepairableconflictimprecise/expected/com/example/Dog.java
+++ b/src/test/resources/unrepairableconflictimprecise/expected/com/example/Dog.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Dog extends Animal {}

--- a/src/test/resources/unrepairableconflictimprecise/expected/com/example/Simple.java
+++ b/src/test/resources/unrepairableconflictimprecise/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  void bar(Item item) {
+    Animal a = item.get();
+    Dog d = item.get();
+    System.out.println(d + "" + a);
+  }
+}

--- a/src/test/resources/unrepairableconflictimprecise/expected/org/example/Item.java
+++ b/src/test/resources/unrepairableconflictimprecise/expected/org/example/Item.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/unrepairableconflictimprecise/input/com/example/Animal.java
+++ b/src/test/resources/unrepairableconflictimprecise/input/com/example/Animal.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Animal {}

--- a/src/test/resources/unrepairableconflictimprecise/input/com/example/Dog.java
+++ b/src/test/resources/unrepairableconflictimprecise/input/com/example/Dog.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Dog extends Animal {}

--- a/src/test/resources/unrepairableconflictimprecise/input/com/example/Simple.java
+++ b/src/test/resources/unrepairableconflictimprecise/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Animal a = item.get();
+        Dog d = item.get();
+        System.out.println(d + "" + a);
+    }
+}

--- a/src/test/resources/unrepairableconflictprimitive/expected/com/example/Payload.java
+++ b/src/test/resources/unrepairableconflictprimitive/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/unrepairableconflictprimitive/expected/com/example/Simple.java
+++ b/src/test/resources/unrepairableconflictprimitive/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  void bar(Item item) {
+    Payload p = item.get();
+    int x = item.get();
+    System.out.println(p + "" + x);
+  }
+}

--- a/src/test/resources/unrepairableconflictprimitive/expected/org/example/Item.java
+++ b/src/test/resources/unrepairableconflictprimitive/expected/org/example/Item.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/unrepairableconflictprimitive/input/com/example/Payload.java
+++ b/src/test/resources/unrepairableconflictprimitive/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/unrepairableconflictprimitive/input/com/example/Simple.java
+++ b/src/test/resources/unrepairableconflictprimitive/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Payload p = item.get();
+        int x = item.get();
+        System.out.println(p + "" + x);
+    }
+}

--- a/src/test/resources/unrepairableconflictsupertype/expected/com/example/Animal.java
+++ b/src/test/resources/unrepairableconflictsupertype/expected/com/example/Animal.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Animal {}

--- a/src/test/resources/unrepairableconflictsupertype/expected/com/example/Dog.java
+++ b/src/test/resources/unrepairableconflictsupertype/expected/com/example/Dog.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Dog extends Animal {}

--- a/src/test/resources/unrepairableconflictsupertype/expected/com/example/Simple.java
+++ b/src/test/resources/unrepairableconflictsupertype/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  void bar(Item item) {
+    Dog d = item.get();
+    Animal a = item.get();
+    System.out.println(d + "" + a);
+  }
+}

--- a/src/test/resources/unrepairableconflictsupertype/expected/org/example/Item.java
+++ b/src/test/resources/unrepairableconflictsupertype/expected/org/example/Item.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Item {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/unrepairableconflictsupertype/input/com/example/Animal.java
+++ b/src/test/resources/unrepairableconflictsupertype/input/com/example/Animal.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Animal {}

--- a/src/test/resources/unrepairableconflictsupertype/input/com/example/Dog.java
+++ b/src/test/resources/unrepairableconflictsupertype/input/com/example/Dog.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Dog extends Animal {}

--- a/src/test/resources/unrepairableconflictsupertype/input/com/example/Simple.java
+++ b/src/test/resources/unrepairableconflictsupertype/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Dog d = item.get();
+        Animal a = item.get();
+        System.out.println(d + "" + a);
+    }
+}


### PR DESCRIPTION
Fixes #509.

This fix is pretty involved: a naive implementation leads to either order-dependency between sites that impose constraints or to applying the `<T> T` fix to a return type everywhere, which breaks a lot of existing tests (including in problematic ways, when other type variables are involved).