### PR TITLE
Add new helper for finding the enclosing class-like of a node that may also return the node; use it on the crashing path in #514

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -247,6 +247,22 @@ public class JavaParserUtil {
   }
 
   /**
+   * Wrapper for {@link #getEnclosingClassLike(Node)} that returns the input node if it itself is
+   * class-like. Use this instead of {@link #getEnclosingClassLike(Node)} when the input node might
+   * be an enum's implicit {@code values} or {@code valueOf} method, because JavaParser represents
+   * those with the enum itself's AST node.
+   *
+   * @param node a class-like node, or a node contained in a class-like structure
+   * @return the node itself if it is class-like, otherwise its nearest enclosing class-like node
+   */
+  public static TypeDeclaration<?> getClassLikeOrEnclosing(Node node) {
+    if (node instanceof TypeDeclaration<?> typeDecl) {
+      return typeDecl;
+    }
+    return getEnclosingClassLike(node);
+  }
+
+  /**
    * Gets the super class of a node. If one does not exist, this method will throw.
    *
    * @param node The node to find the super class of
@@ -2046,7 +2062,10 @@ public class JavaParserUtil {
       return null;
     }
 
-    TypeDeclaration<?> declaration = getEnclosingClassLike(detachedNode);
+    // Not getEnclosingClassLike: a resolved declaration's AST is sometimes the type declaration
+    // itself rather than a member of one. JavaParser models an enum's implicitly declared values()
+    // and valueOf(String) (JLS 8.9.3) this way, since neither has an AST node of its own.
+    TypeDeclaration<?> declaration = getClassLikeOrEnclosing(detachedNode);
 
     TypeDeclaration<?> attached =
         getTypeFromQualifiedName(

--- a/src/test/java/org/checkerframework/specimin/ImplicitEnumMethodsTest.java
+++ b/src/test/java/org/checkerframework/specimin/ImplicitEnumMethodsTest.java
@@ -1,0 +1,26 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that Specimin can handle calls to an enum's implicitly declared {@code values()}
+ * and {@code valueOf(String)} methods (JLS 8.9.3), including on a top-level enum. Neither method
+ * has an AST node of its own, so JavaParser reports the enum declaration itself as their AST;
+ * Specimin used to crash (<a href="https://github.com/njit-jerse/specimin/issues/514">#514</a>) when
+ * it tried to find the class-like element enclosing that AST, because a top-level enum has none.
+ *
+ * <p>The enum constants are dropped from the expected output: no typing judgment about the target
+ * depends on which constants exist, since the signatures of {@code values()} and {@code
+ * valueOf(String)} do not mention them. The resulting {@code valueOf} call would fail at run time,
+ * but Specimin preserves compile-time behavior only.
+ */
+public class ImplicitEnumMethodsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "implicitenummethods",
+        new String[] {"p/UsesEnums.java"},
+        new String[] {"p.UsesEnums#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/ImplicitEnumMethodsTest.java
+++ b/src/test/java/org/checkerframework/specimin/ImplicitEnumMethodsTest.java
@@ -7,8 +7,9 @@ import org.junit.jupiter.api.Test;
  * This test checks that Specimin can handle calls to an enum's implicitly declared {@code values()}
  * and {@code valueOf(String)} methods (JLS 8.9.3), including on a top-level enum. Neither method
  * has an AST node of its own, so JavaParser reports the enum declaration itself as their AST;
- * Specimin used to crash (<a href="https://github.com/njit-jerse/specimin/issues/514">#514</a>) when
- * it tried to find the class-like element enclosing that AST, because a top-level enum has none.
+ * Specimin used to crash (<a href="https://github.com/njit-jerse/specimin/issues/514">#514</a>)
+ * when it tried to find the class-like element enclosing that AST, because a top-level enum has
+ * none.
  *
  * <p>The enum constants are dropped from the expected output: no typing judgment about the target
  * depends on which constants exist, since the signatures of {@code values()} and {@code

--- a/src/test/resources/implicitenummethods/expected/p/Outer.java
+++ b/src/test/resources/implicitenummethods/expected/p/Outer.java
@@ -1,0 +1,6 @@
+package p;
+
+class Outer {
+
+  enum Nested {}
+}

--- a/src/test/resources/implicitenummethods/expected/p/RenderType.java
+++ b/src/test/resources/implicitenummethods/expected/p/RenderType.java
@@ -1,0 +1,3 @@
+package p;
+
+enum RenderType {}

--- a/src/test/resources/implicitenummethods/expected/p/UsesEnums.java
+++ b/src/test/resources/implicitenummethods/expected/p/UsesEnums.java
@@ -1,0 +1,10 @@
+package p;
+
+class UsesEnums {
+
+  void target() {
+    RenderType[] all = RenderType.values();
+    RenderType one = RenderType.valueOf("DEFAULT");
+    Outer.Nested[] nested = Outer.Nested.values();
+  }
+}

--- a/src/test/resources/implicitenummethods/input/p/Outer.java
+++ b/src/test/resources/implicitenummethods/input/p/Outer.java
@@ -1,0 +1,7 @@
+package p;
+
+class Outer {
+  enum Nested {
+    A
+  }
+}

--- a/src/test/resources/implicitenummethods/input/p/RenderType.java
+++ b/src/test/resources/implicitenummethods/input/p/RenderType.java
@@ -1,0 +1,5 @@
+package p;
+
+enum RenderType {
+  DEFAULT
+}

--- a/src/test/resources/implicitenummethods/input/p/UsesEnums.java
+++ b/src/test/resources/implicitenummethods/input/p/UsesEnums.java
@@ -1,0 +1,9 @@
+package p;
+
+class UsesEnums {
+  void target() {
+    RenderType[] all = RenderType.values();
+    RenderType one = RenderType.valueOf("DEFAULT");
+    Outer.Nested[] nested = Outer.Nested.values();
+  }
+}


### PR DESCRIPTION
Fixes #514.

The underlying problem is how JavaParser represents the implicit enum methods: their AST is just the enum declaration itself (which is already class-like), so the crash was caused by Specimin searching _up_ in the AST above the enum itself for the enum's declaration.