### PR TITLE
Treat types inferred from context as upper bounds on a method's return type instead of directly installing them as return types directly

### DIFF
--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -144,6 +144,14 @@ public class Slicer {
 
     slicer.buildSlice();
 
+    // Every use site has now been seen, so a placeholder return type that no use site put a
+    // member on can be recognized as saying nothing and replaced by the bound it stands for.
+    // This must run before supertype relationships are expanded into alternates, so that the
+    // placeholders it removes are not first turned into alternates of other types.
+    unsolvedSymbolGenerator
+        .collapseMemberlessPlaceholderReturnTypes()
+        .forEach(slicer.generatedSymbolSlice::remove);
+
     unsolvedSymbolGenerator.generateAllAlternatesBasedOnSuperTypeRelationships();
 
     Set<Node> dependentSlice = new HashSet<>();

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -106,6 +106,9 @@ public class FullyQualifiedNameGenerator {
   /** Whether to check generated symbols when getting expression types. */
   private boolean shouldCheckGeneratedSymbols = true;
 
+  /** Whether an expression's surrounding context may supply its type. */
+  private boolean shouldUseSurroundingContextType = true;
+
   /**
    * Create a new instance. Needs a map of type FQNs to compilation units for symbol resolution.
    *
@@ -142,6 +145,30 @@ public class FullyQualifiedNameGenerator {
    */
   public boolean getShouldCheckGeneratedSymbols() {
     return shouldCheckGeneratedSymbols;
+  }
+
+  /**
+   * Sets whether an expression's surrounding context may supply its type. Default is true; ensure
+   * that this is set back to true after your operation is done if you set it to false.
+   *
+   * <p>A context type is an upper bound on the expression's type, not the type itself: JLS 5.2 asks
+   * only that the expression be assignable to it. Set this to false to ask what the expression's
+   * type is on its own, so that the bound can be recorded as a bound instead of being mistaken for
+   * the answer.
+   *
+   * @param shouldUseSurroundingContextType Whether surrounding context may supply expression types
+   */
+  public void setShouldUseSurroundingContextType(boolean shouldUseSurroundingContextType) {
+    this.shouldUseSurroundingContextType = shouldUseSurroundingContextType;
+  }
+
+  /**
+   * Returns whether an expression's surrounding context may supply its type.
+   *
+   * @return Whether this FullyQualifiedNameGenerator consults surrounding context
+   */
+  public boolean getShouldUseSurroundingContextType() {
+    return shouldUseSurroundingContextType;
   }
 
   /**
@@ -635,7 +662,7 @@ public class FullyQualifiedNameGenerator {
     }
 
     // Handle the cases where the type of the expression can be inferred from surrounding context
-    if (expr.hasParentNode()) {
+    if (shouldUseSurroundingContextType && expr.hasParentNode()) {
       @Nullable Set<FullyQualifiedNameSet> fromLHS = getFQNsFromSurroundingContextType(expr);
       if (fromLHS != null) {
         return fromLHS;

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterfaceAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterfaceAlternates.java
@@ -865,6 +865,30 @@ public class UnsolvedClassOrInterfaceAlternates
   }
 
   /**
+   * Returns this type's single supertype, if it has exactly one. Useful to decide whether this type
+   * can be replaced by its supertype everywhere.
+   *
+   * @return the sole supertype of this type, or null if it does not have exactly one
+   */
+  public @Nullable MemberType getSoleSuperType() {
+    if (superTypeRelationships.size() != 1) {
+      return null;
+    }
+
+    Set<MemberType> onlySet = superTypeRelationships.keySet().iterator().next();
+    return onlySet.size() == 1 ? onlySet.iterator().next() : null;
+  }
+
+  /**
+   * Returns the number of distinct supertype constraints recorded for this type.
+   *
+   * @return how many separate supertypes this type has been required to have
+   */
+  public int getSuperTypeCount() {
+    return superTypeRelationships.size();
+  }
+
+  /**
    * Checks to see if the given superType is in any mutually exclusive set key of the
    * superTypeRelationships map.
    *

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -3487,26 +3487,34 @@ public class UnsolvedSymbolGenerator {
 
     FullyQualifiedNameSet placeholderFQNs = placeholderToInterposeOn(methodCall, withContext);
 
-    if (placeholderFQNs == null) {
-      return withContext.stream()
-          .map(this::getOrCreateMemberTypeFromFQNs)
-          .collect(Collectors.toCollection(LinkedHashSet::new));
+    if (placeholderFQNs != null) {
+      MemberType placeholder = getOrCreateMemberTypeFromFQNs(placeholderFQNs);
+
+      // Interposing is only safe if the placeholder came back as a type this class can hang the
+      // bound on. A placeholder named by a single dotless name -- which is what a scope in the
+      // default package produces -- is read as a type variable by getMemberTypeFromFQNs and comes
+      // back solved, with no synthetic type behind it and so nowhere to record the bound. Adopting
+      // the bound directly is what Specimin did before placeholders existed, so falling back to it
+      // is never worse than not interposing at all. Nothing is leaked by having asked: the branch
+      // that returns a solved type creates no symbol.
+      if (placeholder instanceof UnsolvedMemberType unsolvedPlaceholder) {
+        // The bound is only remembered, not installed as a supertype here. Installing it would lock
+        // in the bound from whichever use site happened to be generated first, and block the more
+        // specific bound a later site may impose. Supertypes are merged by addInformation once
+        // every use site has been seen.
+        placeholderReturnTypeBounds.put(
+            unsolvedPlaceholder.getUnsolvedType(),
+            getOrCreateMemberTypeFromFQNs(withContext.iterator().next()));
+
+        Set<MemberType> returnTypes = new LinkedHashSet<>();
+        returnTypes.add(placeholder);
+        return returnTypes;
+      }
     }
 
-    MemberType placeholder = getOrCreateMemberTypeFromFQNs(placeholderFQNs);
-    MemberType bound = getOrCreateMemberTypeFromFQNs(withContext.iterator().next());
-
-    if (placeholder instanceof UnsolvedMemberType unsolvedPlaceholder) {
-      // Only remembered, not installed as a supertype here. Installing it would lock in the bound
-      // from whichever use site happened to be generated first, and block the more specific bound a
-      // later site may impose.
-      // Supertypes are merged by addInformation once every site has been seen.
-      placeholderReturnTypeBounds.put(unsolvedPlaceholder.getUnsolvedType(), bound);
-    }
-
-    Set<MemberType> returnTypes = new LinkedHashSet<>();
-    returnTypes.add(placeholder);
-    return returnTypes;
+    return withContext.stream()
+        .map(this::getOrCreateMemberTypeFromFQNs)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -3464,20 +3464,19 @@ public class UnsolvedSymbolGenerator {
   /**
    * Returns the type to give a synthetic method's return type when the method is first generated.
    *
-   * <p>The type a use site's context asks for is an upper bound on the return type, not the return
-   * type: JLS 5.2 requires only that the result be assignable to it. Adopting it as the return type
-   * throws away the difference, and with it any requirement a use site elsewhere places on the
+   * <p>The type a use site's context asks for is an upper bound on the return type, not the actual
+   * return type: JLS 5.2 requires only that the result be assignable to it. Adopting it directly as
+   * the return type may contradict another requirement that a use site elsewhere places on the
    * result, such as a member read off the result (which might come from a different subtype). Which
    * use site is generated first would then decide the output. So when the context is the only thing
-   * that knows a type, and the bound is a type Specimin cannot add members to, this returns the
-   * placeholder the method would get with no context at all, leaving every use site free to say
+   * that knows a type, and the bound is a type Specimin cannot add members to, this method returns
+   * the placeholder the method would get with no context at all, leaving every use site free to say
    * what it needs of the result.
    *
-   * <p>The bound is not thereby lost: it is remembered here, {@link #addInformation} records it as
-   * the placeholder's supertype along with whatever other use sites require, and {@link
-   * #collapseMemberlessPlaceholderReturnTypes} puts it back directly if nothing else does. That
-   * same pass collapses a placeholder no use site ever puts a member on, so this costs no
-   * minimality when the extra precision goes unused.
+   * <p>{@link #addInformation} will later record the bound as the placeholder's supertype along
+   * with whatever other use sites require, and {@link #collapseMemberlessPlaceholderReturnTypes}
+   * puts it back directly if nothing else does. That same pass collapses a placeholder no use site
+   * ever puts a member on, so this costs no minimality when the extra precision goes unused.
    *
    * @param methodCall the call to the method being generated
    * @return the return type(s) to give it

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -1283,7 +1283,8 @@ public class UnsolvedSymbolGenerator {
         if (generatedMethod.getNumberOfTypeVariables() > 0
             && generatedMethodReturnTypes.size() == 1
             && generatedMethodReturnTypes.iterator().next() instanceof UnsolvedMemberType unsolved
-            && unsolved.usesGeneratedName()) {
+            && unsolved.usesGeneratedName()
+            && !isInterposedPlaceholder(unsolved)) {
           Set<MemberType> potentialReturns = new LinkedHashSet<>();
           for (int i = 0; i < generatedMethod.getNumberOfTypeVariables(); i++) {
             potentialReturns.add(new SolvedMemberType(generatedMethod.getTypeVariableName(i)));
@@ -3466,10 +3467,10 @@ public class UnsolvedSymbolGenerator {
    * <p>The type a use site's context asks for is an upper bound on the return type, not the return
    * type: JLS 5.2 requires only that the result be assignable to it. Adopting it as the return type
    * throws away the difference, and with it any requirement a use site elsewhere places on the
-   * result, such as a member read off the result (which might come from a different subtype).
-   * Which use site is generated first would then decide the output. So when the context is the only
-   * thing that knows a type, and the bound is a type Specimin cannot add members to, this returns
-   * the placeholder the method would get with no context at all, leaving every use site free to say
+   * result, such as a member read off the result (which might come from a different subtype). Which
+   * use site is generated first would then decide the output. So when the context is the only thing
+   * that knows a type, and the bound is a type Specimin cannot add members to, this returns the
+   * placeholder the method would get with no context at all, leaving every use site free to say
    * what it needs of the result.
    *
    * <p>The bound is not thereby lost: it is remembered here, {@link #addInformation} records it as
@@ -3507,6 +3508,22 @@ public class UnsolvedSymbolGenerator {
     Set<MemberType> returnTypes = new LinkedHashSet<>();
     returnTypes.add(placeholder);
     return returnTypes;
+  }
+
+  /**
+   * Returns whether a type is a placeholder {@link #returnTypesForNewMethod} interposed on a bound.
+   *
+   * <p>Such a placeholder shares a symptom with the placeholder a method gets when nothing at all
+   * is known about its return type -- both carry a generated name -- but means something different.
+   * This one stands for a type that must be assignable to a bound Specimin has recorded, so
+   * replacing it with something unconstrained drops that bound. Code that keys off {@code
+   * usesGeneratedName} to mean "nothing is known here" has to exclude these.
+   *
+   * @param type a type appearing as a generated method's return type
+   * @return true if this type was interposed on a bound
+   */
+  private boolean isInterposedPlaceholder(UnsolvedMemberType type) {
+    return placeholderReturnTypeBounds.containsKey(type.getUnsolvedType());
   }
 
   /**
@@ -3552,7 +3569,8 @@ public class UnsolvedSymbolGenerator {
    * @return true if a placeholder must stand in front of this bound
    */
   private boolean needsAPlaceholderInFrontOfIt(FullyQualifiedNameSet fqns) {
-    // If the type is definitely synthetic, Specimin can edit it directly, so no placeholder is needed.
+    // If the type is definitely synthetic, Specimin can edit it directly, so no placeholder is
+    // needed.
     if (!doesOverlapWithKnownType(fqns.erasedFqns())) {
       return false;
     }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -128,6 +128,14 @@ public class UnsolvedSymbolGenerator {
   private final Map<String, UnsolvedSymbolAlternates<?>> generatedSymbols = new HashMap<>();
 
   /**
+   * The bound each placeholder return type was interposed on by {@link #returnTypesForNewMethod},
+   * so that {@link #collapseMemberlessPlaceholderReturnTypes} can put the bound back if no use site
+   * ever needed the placeholder.
+   */
+  private final Map<UnsolvedClassOrInterfaceAlternates, MemberType> placeholderReturnTypeBounds =
+      new LinkedHashMap<>();
+
+  /**
    * Gets all generated symbols.
    *
    * @return The map of fqns to generated symbols.
@@ -1377,10 +1385,7 @@ public class UnsolvedSymbolGenerator {
                   fullyQualifiedNameGenerator.getFQNsFromType(
                       declarationInThisTypeWithSameSignature.getType())));
         } else {
-          for (FullyQualifiedNameSet fqns :
-              fullyQualifiedNameGenerator.getFQNsForExpressionType(methodCall)) {
-            returnTypes.add(getOrCreateMemberTypeFromFQNs(fqns));
-          }
+          returnTypes.addAll(returnTypesForNewMethod(methodCall));
         }
 
         generatedMethod =
@@ -3456,6 +3461,135 @@ public class UnsolvedSymbolGenerator {
   }
 
   /**
+   * Returns the type to give a synthetic method's return type when the method is first generated.
+   *
+   * <p>The type a use site's context asks for is an upper bound on the return type, not the return
+   * type: JLS 5.2 requires only that the result be assignable to it. Adopting it as the return type
+   * throws away the difference, and with it any requirement a use site elsewhere places on the
+   * result, such as a member read off the result (which might come from a different subtype).
+   * Which use site is generated first would then decide the output. So when the context is the only
+   * thing that knows a type, and the bound is a type Specimin cannot add members to, this returns
+   * the placeholder the method would get with no context at all, leaving every use site free to say
+   * what it needs of the result.
+   *
+   * <p>The bound is not thereby lost: it is remembered here, {@link #addInformation} records it as
+   * the placeholder's supertype along with whatever other use sites require, and {@link
+   * #collapseMemberlessPlaceholderReturnTypes} puts it back directly if nothing else does. That
+   * same pass collapses a placeholder no use site ever puts a member on, so this costs no
+   * minimality when the extra precision goes unused.
+   *
+   * @param methodCall the call to the method being generated
+   * @return the return type(s) to give it
+   */
+  private Set<MemberType> returnTypesForNewMethod(MethodCallExpr methodCall) {
+    Set<FullyQualifiedNameSet> withContext =
+        fullyQualifiedNameGenerator.getFQNsForExpressionType(methodCall);
+
+    FullyQualifiedNameSet placeholderFQNs = placeholderToInterposeOn(methodCall, withContext);
+
+    if (placeholderFQNs == null) {
+      return withContext.stream()
+          .map(this::getOrCreateMemberTypeFromFQNs)
+          .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    MemberType placeholder = getOrCreateMemberTypeFromFQNs(placeholderFQNs);
+    MemberType bound = getOrCreateMemberTypeFromFQNs(withContext.iterator().next());
+
+    if (placeholder instanceof UnsolvedMemberType unsolvedPlaceholder) {
+      // Only remembered, not installed as a supertype here. Installing it would lock in the bound
+      // from whichever use site happened to be generated first, and block the more specific bound a
+      // later site may impose.
+      // Supertypes are merged by addInformation once every site has been seen.
+      placeholderReturnTypeBounds.put(unsolvedPlaceholder.getUnsolvedType(), bound);
+    }
+
+    Set<MemberType> returnTypes = new LinkedHashSet<>();
+    returnTypes.add(placeholder);
+    return returnTypes;
+  }
+
+  /**
+   * Decides whether a synthetic method being generated should be given a placeholder return type
+   * standing in front of the bound its use site's context imposes, and returns that placeholder.
+   *
+   * @param methodCall the call to the method being generated
+   * @param withContext the type the method call reports, with surrounding context consulted
+   * @return the FQNs of the placeholder to use as the return type, or null to adopt {@code
+   *     withContext} directly
+   */
+  private @Nullable FullyQualifiedNameSet placeholderToInterposeOn(
+      MethodCallExpr methodCall, Set<FullyQualifiedNameSet> withContext) {
+    // More than one candidate bound means Specimin does not know which type the result must be
+    // assignable to, so there is no single supertype to give a placeholder.
+    if (withContext.size() != 1 || !needsAPlaceholderInFrontOfIt(withContext.iterator().next())) {
+      return null;
+    }
+
+    boolean before = fullyQualifiedNameGenerator.getShouldUseSurroundingContextType();
+    fullyQualifiedNameGenerator.setShouldUseSurroundingContextType(false);
+    Set<FullyQualifiedNameSet> withoutContext;
+    try {
+      withoutContext = fullyQualifiedNameGenerator.getFQNsForExpressionType(methodCall);
+    } finally {
+      fullyQualifiedNameGenerator.setShouldUseSurroundingContextType(before);
+    }
+
+    // Only a placeholder is a stand-in for "not known yet". Anything else that survives without the
+    // context is a real answer, and is no less real than what the context asked for.
+    if (withoutContext.size() != 1 || !withoutContext.iterator().next().usesGeneratedName()) {
+      return null;
+    }
+
+    return withoutContext.iterator().next();
+  }
+
+  /**
+   * Returns whether a bound a use site imposes on a synthetic method's return type has to be
+   * carried by a placeholder subtype rather than adopted as the return type.
+   *
+   * @param fqns the FQNs of the bound
+   * @return true if a placeholder must stand in front of this bound
+   */
+  private boolean needsAPlaceholderInFrontOfIt(FullyQualifiedNameSet fqns) {
+    // If the type is definitely synthetic, Specimin can edit it directly, so no placeholder is needed.
+    if (!doesOverlapWithKnownType(fqns.erasedFqns())) {
+      return false;
+    }
+
+    return isExtendableBound(fqns);
+  }
+
+  /**
+   * Returns whether a type Specimin could infer for an expression is one that a synthetic type may
+   * be made a subtype of without losing anything the type says.
+   *
+   * <p>A type that fails this test is not merely a bound on the expression's type: nothing else is
+   * assignable to it, so it is the type, and a caller should adopt it rather than stand a
+   * placeholder in front of it.
+   *
+   * @param fqns the FQNs of the inferred type
+   * @return true if a synthetic subtype of it could exist and would say everything it says
+   */
+  private boolean isExtendableBound(FullyQualifiedNameSet fqns) {
+    // A wildcard cannot be named in an extends clause, so a placeholder standing in for one could
+    // only record the sanitized form of it as its supertype, silently widening `Baz<?>` to
+    // `Baz<Object>`. The same goes for a wildcard nested in a type argument.
+    if (fqns.wildcard() != null
+        || fqns.typeArguments().stream().anyMatch(arg -> !isExtendableBound(arg))) {
+      return false;
+    }
+
+    // `class X extends T` is not legal for a type variable T (JLS 8.1.4 requires a class type).
+    if (SpeciminGenerationUtils.isATypeVariable(fqns)) {
+      return false;
+    }
+
+    return fqns.erasedFqns().stream()
+        .noneMatch(fqn -> JavaParserUtil.isNonExtendableTypeName(fqn, fqnsToCompilationUnits));
+  }
+
+  /**
    * Replaces a generated method's return type with an unconstrained type variable, for use when
    * some requirement on the result of a call to that method cannot be met by any type Specimin
    * could generate. A type variable can be instantiated separately at every call site, so it meets
@@ -3469,25 +3603,127 @@ public class UnsolvedSymbolGenerator {
    */
   private List<UnsolvedSymbolAlternates<?>> useUnconstrainedReturnType(
       UnsolvedMethodAlternates method) {
-    Set<UnsolvedClassOrInterfaceAlternates> symbolsToRemove = new HashSet<>();
-    for (MemberType returnType : method.getReturnTypes()) {
-      if (returnType instanceof UnsolvedMemberType unsolvedReturnType
-          && unsolvedReturnType.usesGeneratedName()) {
-        // Check to see if it is unused everywhere (no methods or fields)
-        if (findAllMembers(unsolvedReturnType.getUnsolvedType()).isEmpty()) {
-          symbolsToRemove.add(unsolvedReturnType.getUnsolvedType());
-        }
-      }
-    }
+    Set<UnsolvedClassOrInterfaceAlternates> symbolsToRemove =
+        memberlessPlaceholderReturnTypes(method);
 
     method.setUnconstrainedReturnType();
     for (UnsolvedClassOrInterfaceAlternates symbolToRemove : symbolsToRemove) {
-      removeTypeAndReplaceUses(
-          new UnsolvedMemberType(symbolToRemove, 0, List.of(), false),
-          new SolvedMemberType("java.lang.Object"));
+      discardPlaceholder(symbolToRemove, SolvedMemberType.JAVA_LANG_OBJECT);
     }
 
     return new ArrayList<>(symbolsToRemove);
+  }
+
+  /**
+   * Returns the placeholder types among a generated method's return types that carry no members.
+   *
+   * <p>A placeholder exists to be the thing use sites hang requirements on. One that has collected
+   * none says nothing that its bound does not already say, so it is safe to discard; one that has
+   * collected a member is the only type in the slice that declares that member, and discarding it
+   * would drop the requirement that produced it. This is the question that separates a placeholder
+   * worth keeping from an inert one, and both {@link #useUnconstrainedReturnType} and {@link
+   * #collapseMemberlessPlaceholderReturnTypes} turn on it.
+   *
+   * @param method a generated method
+   * @return the placeholder return types of that method that declare no members
+   */
+  private Set<UnsolvedClassOrInterfaceAlternates> memberlessPlaceholderReturnTypes(
+      UnsolvedMethodAlternates method) {
+    Set<UnsolvedClassOrInterfaceAlternates> memberless = new LinkedHashSet<>();
+    for (MemberType returnType : method.getReturnTypes()) {
+      if (returnType instanceof UnsolvedMemberType unsolvedReturnType
+          && unsolvedReturnType.usesGeneratedName()
+          && findAllMembers(unsolvedReturnType.getUnsolvedType()).isEmpty()) {
+        memberless.add(unsolvedReturnType.getUnsolvedType());
+      }
+    }
+    return memberless;
+  }
+
+  /**
+   * Drops a placeholder type from the slice, rewriting everything that named it to name {@code
+   * replaceWith} instead.
+   *
+   * @param placeholder the placeholder type to discard
+   * @param replaceWith the type that takes its place at every site that named it
+   */
+  private void discardPlaceholder(
+      UnsolvedClassOrInterfaceAlternates placeholder, MemberType replaceWith) {
+    removeTypeAndReplaceUses(new UnsolvedMemberType(placeholder, 0, List.of(), false), replaceWith);
+  }
+
+  /**
+   * Replaces every synthetic return type that exists only to carry requirements, and never
+   * collected any, with the bound it was interposed on.
+   *
+   * <p>{@link #returnTypesForNewMethod} declines to adopt a use site's context type as a synthetic
+   * method's return type, because doing so would discard whatever a use site elsewhere needs of the
+   * result. That is only worth paying for when some use site actually needed something: when none
+   * did, the placeholder is an extra file in the output that says exactly what its bound says.
+   * Running after every use site has been seen is what makes this decidable, and is why it cannot
+   * be decided at generation time.
+   *
+   * <p>What a memberless placeholder collapses to is the supertype the use sites settled on, which
+   * may be narrower than the bound it was created for; the recorded bound is the fallback for when
+   * no use site recorded anything, which is what happens when the bound is {@code
+   * java.lang.Object}. A placeholder required to be a subtype of several types at once collapses to
+   * none of them, and falls back to an unconstrained return type instead.
+   *
+   * @return the placeholder types that are no longer needed, for the caller to drop from the slice
+   */
+  public List<UnsolvedSymbolAlternates<?>> collapseMemberlessPlaceholderReturnTypes() {
+    List<UnsolvedSymbolAlternates<?>> removed = new ArrayList<>();
+
+    for (UnsolvedSymbolAlternates<?> symbol : Set.copyOf(generatedSymbols.values())) {
+      if (!(symbol instanceof UnsolvedMethodAlternates method)) {
+        continue;
+      }
+
+      Set<UnsolvedClassOrInterfaceAlternates> memberless = memberlessPlaceholderReturnTypes(method);
+
+      for (MemberType returnType : Set.copyOf(method.getReturnTypes())) {
+        if (!(returnType instanceof UnsolvedMemberType unsolved)) {
+          continue;
+        }
+
+        UnsolvedClassOrInterfaceAlternates placeholder = unsolved.getUnsolvedType();
+        MemberType bound = placeholderReturnTypeBounds.get(placeholder);
+
+        // Only placeholders interposed by returnTypesForNewMethod are this pass's business.
+        if (bound == null) {
+          continue;
+        }
+
+        if (!memberless.contains(placeholder)) {
+          if (placeholder.getSuperTypeCount() == 0) {
+            // The placeholder carries a member, but no use site ended up recording what it must be
+            // assignable to. Putting the bound back is what keeps this from dropping the
+            // requirement that created the placeholder in the first place.
+            placeholder.addSuperType(Set.of(bound));
+          }
+          continue;
+        }
+
+        if (placeholder.getSuperTypeCount() > 1) {
+          // Use sites required this result to be a subtype of several types at once, and an empty
+          // placeholder cannot be all of them. A type variable can, since it is instantiated
+          // separately at each site.
+          removed.addAll(useUnconstrainedReturnType(method));
+          continue;
+        }
+
+        // Prefer what the use sites settled on over the bound this placeholder was created for: a
+        // later site may have narrowed it, and the narrower type satisfies the earlier site too.
+        MemberType soleSuperType = placeholder.getSoleSuperType();
+        MemberType replacement = soleSuperType != null ? soleSuperType : bound;
+
+        method.replaceReturnType(returnType, replacement);
+        discardPlaceholder(placeholder, replacement);
+        removed.add(placeholder);
+      }
+    }
+
+    return removed;
   }
 
   /**

--- a/src/test/java/org/checkerframework/specimin/ContextTypeThenMemberAccessTest.java
+++ b/src/test/java/org/checkerframework/specimin/ContextTypeThenMemberAccessTest.java
@@ -1,0 +1,19 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link MemberAccessThenContextTypeTest} with the two statements swapped. See that test for what
+ * the two use sites require; the expected outputs of the two tests differ only in the order of the
+ * statements in {@code Simple.java}, which is the property being checked.
+ */
+public class ContextTypeThenMemberAccessTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "contexttypethenmemberaccess",
+        new String[] {"com/example/Simple.java", "com/example/Payload.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/MemberAccessThenContextTypeTest.java
+++ b/src/test/java/org/checkerframework/specimin/MemberAccessThenContextTypeTest.java
@@ -1,0 +1,26 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Two use sites constrain the result of the same unsolved method: one reads a member off it, and
+ * one assigns it to a variable of a known type. JLS 15.12.1 requires the return type to have a
+ * member named {@code foo}, and JLS 5.2 makes the initializer of {@code Payload p} an assignment
+ * context, so the return type must also be assignable to {@code Payload}. A synthetic subtype of
+ * {@code Payload} that declares {@code foo} satisfies both; reporting {@code Payload} flatly
+ * satisfies only the second, and does not compile.
+ *
+ * <p>The point of the test is that this does not depend on which use site Specimin reaches first.
+ * {@link ContextTypeThenMemberAccessTest} is this same program with the two statements swapped, and
+ * its expected output is identical apart from that swap.
+ */
+public class MemberAccessThenContextTypeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "memberaccessthencontexttype",
+        new String[] {"com/example/Simple.java", "com/example/Payload.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetTypeVariableTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetTypeVariableTest.java
@@ -10,8 +10,10 @@ import org.junit.jupiter.api.Test;
  * so an unconstrained type variable is again the only return type that satisfies both assignments.
  *
  * <p>The target method's {@code U} is not in scope in the generated {@code Item}, so the generated
- * method binds a type variable of its own; the name it gets is whichever one is free, which is why
- * the expected output says {@code T1} rather than {@code T}.
+ * method binds a type variable of its own. The name it gets is incidental: it is whichever one is
+ * free when the unconstrained return type is installed, and here that is the caller's own {@code
+ * U}, reused as the name of the generated method's variable. {@code <U> U get()} and {@code <T1> T1
+ * get()} declare the same signature.
  */
 public class NonExtendableTargetTypeVariableTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/NonExtendableTargetTypeVariableTest.java
+++ b/src/test/java/org/checkerframework/specimin/NonExtendableTargetTypeVariableTest.java
@@ -8,12 +8,6 @@ import org.junit.jupiter.api.Test;
  * may not name a type variable as a superclass or superinterface (JLS 8.1.4, 8.1.5), and the only
  * values assignable to an unbounded type variable are {@code null} and values already of that type,
  * so an unconstrained type variable is again the only return type that satisfies both assignments.
- *
- * <p>The target method's {@code U} is not in scope in the generated {@code Item}, so the generated
- * method binds a type variable of its own. The name it gets is incidental: it is whichever one is
- * free when the unconstrained return type is installed, and here that is the caller's own {@code
- * U}, reused as the name of the generated method's variable. {@code <U> U get()} and {@code <T1> T1
- * get()} declare the same signature.
  */
 public class NonExtendableTargetTypeVariableTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/ObjectContextThenMemberAccessTest.java
+++ b/src/test/java/org/checkerframework/specimin/ObjectContextThenMemberAccessTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link MemberAccessThenContextTypeTest} with {@code java.lang.Object} as the assignment target.
+ *
+ * <p>{@code Object} is a bound like any other for the purpose of not letting it outrank the member
+ * access -- it is a type from the JDK, so {@code foo} cannot be declared on it -- but it is the one
+ * bound that is never written down: every class extends it already, so it is not recorded as a
+ * supertype of the synthetic type. The expected output therefore names no supertype at all, and the
+ * synthetic type has to be kept on the strength of the member it carries rather than the supertype
+ * it does not.
+ */
+public class ObjectContextThenMemberAccessTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "objectcontextthenmemberaccess",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Item)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/PlaceholderAndCallerTypeVariableTest.java
+++ b/src/test/java/org/checkerframework/specimin/PlaceholderAndCallerTypeVariableTest.java
@@ -1,0 +1,30 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A synthetic method whose result is bounded by one use site is also called with an argument whose
+ * type is a type variable of the caller.
+ *
+ * <p>The generated method must bind that type variable itself, since the caller's is not in scope
+ * in the generated class, and its return type must stay independent of it: {@code U u =
+ * item.get(arg);} and {@code Payload p = item.get(arg);} pass the same argument but want different
+ * results, so a signature that returned the parameter's type could satisfy only one of them. Hence
+ * {@code <U, T1> T1 get(U parameter0)}, with a second type variable for the result.
+ *
+ * <p>The hazard this guards against is a placeholder return type being mistaken for an unknown one.
+ * Both carry a generated name, but a placeholder interposed on a bound stands for something
+ * Specimin does know, and code that reads a generated name as "nothing is known here" will happily
+ * swap it for a type variable already in the signature -- here, the caller's {@code U}, which ties
+ * the result to the argument and does not compile.
+ */
+public class PlaceholderAndCallerTypeVariableTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "placeholderandcallertypevariable",
+        new String[] {"com/example/Simple.java", "com/example/Payload.java"},
+        new String[] {"com.example.Simple#bar(Item, U)"});
+  }
+}

--- a/src/test/resources/contexttypethenmemberaccess/expected/com/example/Payload.java
+++ b/src/test/resources/contexttypethenmemberaccess/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/contexttypethenmemberaccess/expected/com/example/Simple.java
+++ b/src/test/resources/contexttypethenmemberaccess/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  void bar(Item item) {
+    Payload p = item.getPayload();
+    item.getPayload().foo();
+  }
+}

--- a/src/test/resources/contexttypethenmemberaccess/expected/org/example/FooReturnType.java
+++ b/src/test/resources/contexttypethenmemberaccess/expected/org/example/FooReturnType.java
@@ -1,0 +1,3 @@
+package org.example;
+public class FooReturnType {
+}

--- a/src/test/resources/contexttypethenmemberaccess/expected/org/example/GetPayloadReturnType.java
+++ b/src/test/resources/contexttypethenmemberaccess/expected/org/example/GetPayloadReturnType.java
@@ -1,0 +1,7 @@
+package org.example;
+public class GetPayloadReturnType extends com.example.Payload  {
+
+    public org.example.FooReturnType foo() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/contexttypethenmemberaccess/expected/org/example/Item.java
+++ b/src/test/resources/contexttypethenmemberaccess/expected/org/example/Item.java
@@ -1,7 +1,7 @@
 package org.example;
 public class Item {
 
-    public <U> U get() {
+    public org.example.GetPayloadReturnType getPayload() {
         throw new java.lang.Error();
     }
 }

--- a/src/test/resources/contexttypethenmemberaccess/input/com/example/Payload.java
+++ b/src/test/resources/contexttypethenmemberaccess/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/contexttypethenmemberaccess/input/com/example/Simple.java
+++ b/src/test/resources/contexttypethenmemberaccess/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        Payload p = item.getPayload();
+        item.getPayload().foo();
+    }
+}

--- a/src/test/resources/memberaccessthencontexttype/expected/com/example/Payload.java
+++ b/src/test/resources/memberaccessthencontexttype/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/memberaccessthencontexttype/expected/com/example/Simple.java
+++ b/src/test/resources/memberaccessthencontexttype/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  void bar(Item item) {
+    item.getPayload().foo();
+    Payload p = item.getPayload();
+  }
+}

--- a/src/test/resources/memberaccessthencontexttype/expected/org/example/FooReturnType.java
+++ b/src/test/resources/memberaccessthencontexttype/expected/org/example/FooReturnType.java
@@ -1,0 +1,3 @@
+package org.example;
+public class FooReturnType {
+}

--- a/src/test/resources/memberaccessthencontexttype/expected/org/example/GetPayloadReturnType.java
+++ b/src/test/resources/memberaccessthencontexttype/expected/org/example/GetPayloadReturnType.java
@@ -1,0 +1,7 @@
+package org.example;
+public class GetPayloadReturnType extends com.example.Payload  {
+
+    public org.example.FooReturnType foo() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/memberaccessthencontexttype/expected/org/example/Item.java
+++ b/src/test/resources/memberaccessthencontexttype/expected/org/example/Item.java
@@ -1,7 +1,7 @@
 package org.example;
 public class Item {
 
-    public <U> U get() {
+    public org.example.GetPayloadReturnType getPayload() {
         throw new java.lang.Error();
     }
 }

--- a/src/test/resources/memberaccessthencontexttype/input/com/example/Payload.java
+++ b/src/test/resources/memberaccessthencontexttype/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/memberaccessthencontexttype/input/com/example/Simple.java
+++ b/src/test/resources/memberaccessthencontexttype/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        item.getPayload().foo();
+        Payload p = item.getPayload();
+    }
+}

--- a/src/test/resources/objectcontextthenmemberaccess/expected/com/example/Simple.java
+++ b/src/test/resources/objectcontextthenmemberaccess/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  void bar(Item item) {
+    item.getPayload().foo();
+    Object o = item.getPayload();
+  }
+}

--- a/src/test/resources/objectcontextthenmemberaccess/expected/org/example/FooReturnType.java
+++ b/src/test/resources/objectcontextthenmemberaccess/expected/org/example/FooReturnType.java
@@ -1,0 +1,3 @@
+package org.example;
+public class FooReturnType {
+}

--- a/src/test/resources/objectcontextthenmemberaccess/expected/org/example/GetPayloadReturnType.java
+++ b/src/test/resources/objectcontextthenmemberaccess/expected/org/example/GetPayloadReturnType.java
@@ -1,0 +1,7 @@
+package org.example;
+public class GetPayloadReturnType {
+
+    public org.example.FooReturnType foo() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/objectcontextthenmemberaccess/expected/org/example/Item.java
+++ b/src/test/resources/objectcontextthenmemberaccess/expected/org/example/Item.java
@@ -1,7 +1,7 @@
 package org.example;
 public class Item {
 
-    public <U> U get() {
+    public org.example.GetPayloadReturnType getPayload() {
         throw new java.lang.Error();
     }
 }

--- a/src/test/resources/objectcontextthenmemberaccess/input/com/example/Simple.java
+++ b/src/test/resources/objectcontextthenmemberaccess/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    void bar(Item item) {
+        item.getPayload().foo();
+        Object o = item.getPayload();
+    }
+}

--- a/src/test/resources/placeholderandcallertypevariable/expected/com/example/Payload.java
+++ b/src/test/resources/placeholderandcallertypevariable/expected/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/placeholderandcallertypevariable/expected/com/example/Simple.java
+++ b/src/test/resources/placeholderandcallertypevariable/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+
+  <U> void bar(Item item, U arg) {
+    U u = item.get(arg);
+    Payload p = item.get(arg);
+  }
+}

--- a/src/test/resources/placeholderandcallertypevariable/expected/org/example/Item.java
+++ b/src/test/resources/placeholderandcallertypevariable/expected/org/example/Item.java
@@ -1,7 +1,7 @@
 package org.example;
 public class Item {
 
-    public <T1> T1 get() {
+    public <U, T1> T1 get(U parameter0) {
         throw new java.lang.Error();
     }
 }

--- a/src/test/resources/placeholderandcallertypevariable/input/com/example/Payload.java
+++ b/src/test/resources/placeholderandcallertypevariable/input/com/example/Payload.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Payload {}

--- a/src/test/resources/placeholderandcallertypevariable/input/com/example/Simple.java
+++ b/src/test/resources/placeholderandcallertypevariable/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Item;
+
+class Simple {
+    // Target method.
+    <U> void bar(Item item, U arg) {
+        U u = item.get(arg);
+        Payload p = item.get(arg);
+    }
+}


### PR DESCRIPTION
This fixes an order-dependency bug (that I discovered while working on #509): before this change, the source order determined which type from context was actually installed as the return type, which meant that when there were multiple use sites some orders compiled and some did not. This change correctly treats context as a bound rather than a fact.