### PR TITLE
Don't try to generate array types

### DIFF
--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -165,6 +165,29 @@ public class FullyQualifiedNameGenerator {
    *     expression's declaration could be located in.
    */
   public Collection<Set<String>> getFQNsForExpressionLocation(Expression expr) {
+    Collection<Set<String>> result = new LinkedHashSet<>();
+
+    for (Set<String> alternative : getFQNsForExpressionLocationImpl(expr)) {
+      // Arrays never have unsolved members (JLS 10.7). So, arrays are treated as solvable
+      // types here.
+      if (!alternative.isEmpty() && alternative.stream().allMatch(fqn -> fqn.endsWith("[]"))) {
+        continue;
+      }
+      result.add(alternative);
+    }
+
+    return result;
+  }
+
+  /**
+   * Computes the declaring types for an expression, without the filtering that {@link
+   * #getFQNsForExpressionLocation(Expression)} applies to the result. Call that method instead.
+   *
+   * @param expr The expression to do the analysis upon
+   * @return A collection of sets of FQNs. Each set represents a different type that the
+   *     expression's declaration could be located in.
+   */
+  private Collection<Set<String>> getFQNsForExpressionLocationImpl(Expression expr) {
     Collection<Set<String>> alreadyGenerated =
         getFQNsForExpressionLocationIfRepresentsGenerated(expr);
 
@@ -571,8 +594,13 @@ public class FullyQualifiedNameGenerator {
     }
     // cast expression
     else if (expr.isCastExpr()) {
+      Type castType = expr.asCastExpr().getType();
+      // This branch runs only for an unsolvable cast target, which is usually a class or interface
+      // type but can also be an array of one, which getFQNsFromClassOrInterfaceType cannot take.
       return Set.of(
-          getFQNsFromClassOrInterfaceType(expr.asCastExpr().getType().asClassOrInterfaceType()));
+          castType.isClassOrInterfaceType()
+              ? getFQNsFromClassOrInterfaceType(castType.asClassOrInterfaceType())
+              : getFQNsFromType(castType));
     } else if (expr.isClassExpr()) {
       return Set.of(
           new FullyQualifiedNameSet(

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameSet.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameSet.java
@@ -1,6 +1,7 @@
 package org.checkerframework.specimin.unsolved;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -115,6 +116,41 @@ public record FullyQualifiedNameSet(
     }
     Set<String> erasedFqns = inferredType.iterator().next().erasedFqns();
     return erasedFqns.size() == 1 ? erasedFqns.iterator().next() : null;
+  }
+
+  /**
+   * Removes the given number of array levels from every name in the given inferred type, or returns
+   * null if some name is not an array that deep.
+   *
+   * <p>JLS 4.10.3 derives array subtyping from the element types: {@code S[]} is a subtype of
+   * {@code T[]} exactly when {@code S} is a subtype of {@code T}. A caller that has to relate two
+   * array types can use this method to strip the brackets off both before it relates what is left.
+   *
+   * @param inferredType an inferred type, as produced by FullyQualifiedNameGenerator
+   * @param levels how many array levels to remove; must not be negative
+   * @return the element type at the given depth, or null if some name is not an array that deep
+   */
+  public static @Nullable Set<FullyQualifiedNameSet> stripArrayLevels(
+      Set<FullyQualifiedNameSet> inferredType, int levels) {
+    String brackets = "[]".repeat(levels);
+    Set<FullyQualifiedNameSet> result = new LinkedHashSet<>();
+
+    for (FullyQualifiedNameSet fqnSet : inferredType) {
+      Set<String> stripped = new LinkedHashSet<>();
+
+      for (String fqn : fqnSet.erasedFqns()) {
+        if (!fqn.endsWith(brackets)) {
+          return null;
+        }
+        stripped.add(fqn.substring(0, fqn.length() - brackets.length()));
+      }
+
+      result.add(
+          new FullyQualifiedNameSet(
+              stripped, fqnSet.typeArguments(), fqnSet.wildcard(), fqnSet.usesGeneratedName()));
+    }
+
+    return result;
   }
 
   @Override

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2229,6 +2229,23 @@ public class UnsolvedSymbolGenerator {
   }
 
   /**
+   * Does the given method reference name a member of an array type?
+   *
+   * <p>Such a reference never has anything for Specimin to synthesize, and no declaring type to put
+   * it in: JLS 10.7 gives an array type only {@code length}, {@code clone()}, and the members
+   * inherited from {@code Object}, and JLS 15.13 makes {@code T[]::new} an array creation reference
+   * rather than a reference to a declared constructor.
+   *
+   * @param methodRef The method reference expression
+   * @return true if the method reference's scope is an array type
+   */
+  private boolean hasArrayScope(MethodReferenceExpr methodRef) {
+    return fullyQualifiedNameGenerator.getFQNsForExpressionType(methodRef.getScope()).stream()
+        .flatMap(fqns -> fqns.erasedFqns().stream())
+        .anyMatch(fqn -> fqn.endsWith("[]"));
+  }
+
+  /**
    * Helper method for {@link #inferContextImpl(Node, List)}. Generates the method corresponding
    * with the given method reference expression (parameterless void). If the method reference
    * matches a method in java.lang.Object, no new method is generated. Likewise, if a method with
@@ -2249,7 +2266,8 @@ public class UnsolvedSymbolGenerator {
 
     boolean needToGenerateMethod =
         fullyQualifiedNameGenerator.getExpressionTypesIfRepresentsGenerated(methodRef) == null
-            && JavaParserUtil.getMethodDeclarationsFromMethodRef(methodRef).isEmpty();
+            && JavaParserUtil.getMethodDeclarationsFromMethodRef(methodRef).isEmpty()
+            && !hasArrayScope(methodRef);
 
     String methodName = JavaParserUtil.erase(methodRef.getIdentifier());
     boolean isConstructor = false;
@@ -3508,9 +3526,29 @@ public class UnsolvedSymbolGenerator {
    */
   private List<UnsolvedSymbolAlternates<?>> makeSyntheticTypeASubtypeOfExpressionType(
       Type syntheticType, Expression operand, String kind) {
-    Set<MemberType> operandTypes =
-        getMemberTypesAndExpectNonNullFromFQNSets(
-            fullyQualifiedNameGenerator.getFQNsForExpressionType(operand));
+    Set<FullyQualifiedNameSet> operandFQNs =
+        fullyQualifiedNameGenerator.getFQNsForExpressionType(operand);
+
+    // An array type has no declaration to attach a supertype to, so a synthetic array imposes its
+    // requirement on its element type instead: JLS 4.10.3 makes S[] a subtype of T[] exactly when
+    // S is a subtype of T, so peeling the same number of brackets off both sides states the same
+    // requirement about types that do have declarations. When the operand is not an array that
+    // deep there is no such reduction, and the requirement is one no choice of element supertype
+    // can meet.
+    int arrayLevel = syntheticType.getArrayLevel();
+    if (arrayLevel > 0) {
+      Set<FullyQualifiedNameSet> elementFQNs =
+          FullyQualifiedNameSet.stripArrayLevels(operandFQNs, arrayLevel);
+
+      if (elementFQNs == null) {
+        return meetRequirementOnOperandInstead(operand);
+      }
+
+      operandFQNs = elementFQNs;
+      syntheticType = syntheticType.getElementType();
+    }
+
+    Set<MemberType> operandTypes = getMemberTypesAndExpectNonNullFromFQNSets(operandFQNs);
 
     if (operandTypes.isEmpty()) {
       // No information about the operand's type. This happens when the operand's type is
@@ -3541,23 +3579,7 @@ public class UnsolvedSymbolGenerator {
             .collect(Collectors.toCollection(LinkedHashSet::new));
 
     if (extendableOperandTypes.isEmpty()) {
-      // The requirement cannot be met by making the synthetic type a subtype, so it has to be met
-      // on the other side: if the operand is a call to a generated method, that method's return
-      // type is the thing standing in the way, and an unconstrained one accommodates this site
-      // along with every other. Repairing it here rather than leaving the requirement dropped is
-      // what makes the outcome independent of the order these sites are visited in -- the site
-      // that assigns the result elsewhere may already have been visited, and would then see a
-      // return type that satisfies it and no reason to act.
-      if (operand.isMethodCallExpr()) {
-        UnsolvedMethodAlternates generatedMethod =
-            findGeneratedMethodFromMethodCall(operand.asMethodCallExpr());
-
-        if (generatedMethod != null) {
-          return useUnconstrainedReturnType(generatedMethod);
-        }
-      }
-
-      return List.of();
+      return meetRequirementOnOperandInstead(operand);
     }
 
     UnsolvedClassOrInterfaceAlternates unsolvedSyntheticType =
@@ -3572,6 +3594,34 @@ public class UnsolvedSymbolGenerator {
               + syntheticType);
     }
     unsolvedSyntheticType.addSuperType(extendableOperandTypes);
+
+    return List.of();
+  }
+
+  /**
+   * Handles a requirement from a cast or instanceof that no choice of supertype for the synthetic
+   * type can meet, by meeting it on the other side instead.
+   *
+   * <p>If the operand is a call to a generated method, that method's return type is the thing
+   * standing in the way, and an unconstrained one accommodates this site along with every other.
+   * Repairing it here rather than leaving the requirement dropped is what makes the outcome
+   * independent of the order these sites are visited in -- the site that assigns the result
+   * elsewhere may already have been visited, and would then see a return type that satisfies it and
+   * no reason to act. Any other operand has a type Specimin does not get to choose, so the
+   * requirement is dropped.
+   *
+   * @param operand the operand of the instanceof or the cast
+   * @return the placeholder types that are no longer needed, for the caller to drop from the slice
+   */
+  private List<UnsolvedSymbolAlternates<?>> meetRequirementOnOperandInstead(Expression operand) {
+    if (operand.isMethodCallExpr()) {
+      UnsolvedMethodAlternates generatedMethod =
+          findGeneratedMethodFromMethodCall(operand.asMethodCallExpr());
+
+      if (generatedMethod != null) {
+        return useUnconstrainedReturnType(generatedMethod);
+      }
+    }
 
     return List.of();
   }

--- a/src/test/java/org/checkerframework/specimin/CastToSyntheticArray2dTest.java
+++ b/src/test/java/org/checkerframework/specimin/CastToSyntheticArray2dTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Like {@link CastToSyntheticArrayTest}, but two-dimensional: both bracket levels have to come off
+ * before the supertype is recorded, since JLS 4.10.3 applies once per level.
+ */
+public class CastToSyntheticArray2dTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "casttosyntheticarray2d",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Bar[][])"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/CastToSyntheticArrayFromObjectTest.java
+++ b/src/test/java/org/checkerframework/specimin/CastToSyntheticArrayFromObjectTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A cast to an array of a synthetic type, applied to an {@code Object}. Again there is no pair of
+ * element types to relate, but here nothing needs to be done: JLS 4.10.3 makes {@code Object} a
+ * supertype of every array type, so the cast is already a legal downcast and {@code Baz} is
+ * correctly left with no supertype.
+ */
+public class CastToSyntheticArrayFromObjectTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "casttosyntheticarrayfromobject",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Object)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/CastToSyntheticArrayFromReturnTest.java
+++ b/src/test/java/org/checkerframework/specimin/CastToSyntheticArrayFromReturnTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A cast to an array of a synthetic type, applied to something whose inferred type is not an array.
+ * There is no pair of element types to relate here, so no supertype of {@code Baz} can make the
+ * cast legal, and the requirement has to be met on the operand instead: {@code Foo#get}'s return
+ * type becomes an unconstrained type variable, which every use site can instantiate as it needs.
+ *
+ * <p>Contrast {@code casttosynthetic}, where the same operand yields {@code Baz extends
+ * GetReturnType}. Dropping the requirement here rather than relaxing the return type would leave
+ * {@code Foo#get} returning a type unrelated to {@code Baz[]}, and the output would not compile.
+ */
+public class CastToSyntheticArrayFromReturnTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "casttosyntheticarrayfromreturn",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Foo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/CastToSyntheticArrayTest.java
+++ b/src/test/java/org/checkerframework/specimin/CastToSyntheticArrayTest.java
@@ -1,0 +1,22 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A cast to an array of a synthetic type. JLS 4.10.3 derives array subtyping from the element
+ * types, and no class declaration can name an array type as a supertype, so the requirement that
+ * makes the cast legal has to be recorded on {@code Baz} rather than on {@code Baz[]}: the expected
+ * output has {@code Baz extends Bar}, which gives {@code Baz[] <: Bar[]}.
+ *
+ * <p>This is the array analogue of the {@code casttosynthetic} test.
+ */
+public class CastToSyntheticArrayTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "casttosyntheticarray",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#target(Bar[])"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/Issue520Test.java
+++ b/src/test/java/org/checkerframework/specimin/Issue520Test.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test case for <a href="https://github.com/njit-jerse/specimin/issues/520">issue
+ * 520</a>.
+ */
+public class Issue520Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "issue520",
+        new String[] {"retrofit2/RequestFactory.java"},
+        new String[] {"retrofit2.RequestFactory#create(Object[])"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/Issue520bTest.java
+++ b/src/test/java/org/checkerframework/specimin/Issue520bTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A method-call variant of <a href="https://github.com/njit-jerse/specimin/issues/520">issue
+ * 520</a>: a member accessed on an array whose element type is unsolved. Per JLS 10.7, the members
+ * of an array type are {@code length}, {@code clone()}, and the members inherited from {@code
+ * Object}, so nothing here needs to be synthesized.
+ */
+public class Issue520bTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "issue520b",
+        new String[] {"retrofit2/RequestFactory.java"},
+        new String[] {"retrofit2.RequestFactory#create(ParameterHandler[])"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/Issue520cTest.java
+++ b/src/test/java/org/checkerframework/specimin/Issue520cTest.java
@@ -1,0 +1,21 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A method-reference variant of <a href="https://github.com/njit-jerse/specimin/issues/520">issue
+ * 520</a>: a method reference whose scope is an array whose element type is unsolved. JLS 10.7
+ * gives an array type only {@code length}, {@code clone()}, and the members inherited from {@code
+ * Object}, and JLS 15.13 makes {@code T[]::new} an array creation reference rather than a reference
+ * to a declared constructor, so neither form has anything for Specimin to synthesize.
+ */
+public class Issue520cTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "issue520c",
+        new String[] {"retrofit2/RequestFactory.java"},
+        new String[] {"retrofit2.RequestFactory#create(ParameterHandler[])"});
+  }
+}

--- a/src/test/resources/casttosyntheticarray/expected/com/example/Simple.java
+++ b/src/test/resources/casttosyntheticarray/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Bar;
+import org.example.Baz;
+
+public class Simple {
+
+  public void target(Bar[] bars) {
+    Baz[] b = (Baz[]) bars;
+    System.out.println(b);
+  }
+}

--- a/src/test/resources/casttosyntheticarray/expected/org/example/Bar.java
+++ b/src/test/resources/casttosyntheticarray/expected/org/example/Bar.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Bar {
+}

--- a/src/test/resources/casttosyntheticarray/expected/org/example/Baz.java
+++ b/src/test/resources/casttosyntheticarray/expected/org/example/Baz.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Baz extends org.example.Bar  {
+}

--- a/src/test/resources/casttosyntheticarray/input/com/example/Simple.java
+++ b/src/test/resources/casttosyntheticarray/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Bar;
+import org.example.Baz;
+
+public class Simple {
+  public void target(Bar[] bars) {
+    Baz[] b = (Baz[]) bars;
+    System.out.println(b);
+  }
+}

--- a/src/test/resources/casttosyntheticarray2d/expected/com/example/Simple.java
+++ b/src/test/resources/casttosyntheticarray2d/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Bar;
+import org.example.Baz;
+
+public class Simple {
+
+  public void target(Bar[][] bars) {
+    Baz[][] b = (Baz[][]) bars;
+    System.out.println(b);
+  }
+}

--- a/src/test/resources/casttosyntheticarray2d/expected/org/example/Bar.java
+++ b/src/test/resources/casttosyntheticarray2d/expected/org/example/Bar.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Bar {
+}

--- a/src/test/resources/casttosyntheticarray2d/expected/org/example/Baz.java
+++ b/src/test/resources/casttosyntheticarray2d/expected/org/example/Baz.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Baz extends org.example.Bar  {
+}

--- a/src/test/resources/casttosyntheticarray2d/input/com/example/Simple.java
+++ b/src/test/resources/casttosyntheticarray2d/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Bar;
+import org.example.Baz;
+
+public class Simple {
+  public void target(Bar[][] bars) {
+    Baz[][] b = (Baz[][]) bars;
+    System.out.println(b);
+  }
+}

--- a/src/test/resources/casttosyntheticarrayfromobject/expected/com/example/Simple.java
+++ b/src/test/resources/casttosyntheticarrayfromobject/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Baz;
+
+public class Simple {
+
+  public void target(Object o) {
+    Baz[] b = (Baz[]) o;
+    System.out.println(b);
+  }
+}

--- a/src/test/resources/casttosyntheticarrayfromobject/expected/org/example/Baz.java
+++ b/src/test/resources/casttosyntheticarrayfromobject/expected/org/example/Baz.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Baz {
+}

--- a/src/test/resources/casttosyntheticarrayfromobject/input/com/example/Simple.java
+++ b/src/test/resources/casttosyntheticarrayfromobject/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Baz;
+
+public class Simple {
+  public void target(Object o) {
+    Baz[] b = (Baz[]) o;
+    System.out.println(b);
+  }
+}

--- a/src/test/resources/casttosyntheticarrayfromreturn/expected/com/example/Simple.java
+++ b/src/test/resources/casttosyntheticarrayfromreturn/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+
+  public void target(Foo f) {
+    Baz[] b = (Baz[]) f.get();
+    System.out.println(b);
+  }
+}

--- a/src/test/resources/casttosyntheticarrayfromreturn/expected/org/example/Baz.java
+++ b/src/test/resources/casttosyntheticarrayfromreturn/expected/org/example/Baz.java
@@ -1,0 +1,3 @@
+package org.example;
+public class Baz {
+}

--- a/src/test/resources/casttosyntheticarrayfromreturn/expected/org/example/Foo.java
+++ b/src/test/resources/casttosyntheticarrayfromreturn/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+public class Foo {
+
+    public <T> T get() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/casttosyntheticarrayfromreturn/input/com/example/Simple.java
+++ b/src/test/resources/casttosyntheticarrayfromreturn/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.Baz;
+import org.example.Foo;
+
+public class Simple {
+  public void target(Foo f) {
+    Baz[] b = (Baz[]) f.get();
+    System.out.println(b);
+  }
+}

--- a/src/test/resources/issue520/expected/javax/annotation/Nullable.java
+++ b/src/test/resources/issue520/expected/javax/annotation/Nullable.java
@@ -1,0 +1,3 @@
+package javax.annotation;
+
+public @interface Nullable {}

--- a/src/test/resources/issue520/expected/retrofit2/ParameterHandler.java
+++ b/src/test/resources/issue520/expected/retrofit2/ParameterHandler.java
@@ -1,0 +1,3 @@
+package retrofit2;
+public class ParameterHandler<T> {
+}

--- a/src/test/resources/issue520/expected/retrofit2/RequestFactory.java
+++ b/src/test/resources/issue520/expected/retrofit2/RequestFactory.java
@@ -1,0 +1,15 @@
+package retrofit2;
+
+import javax.annotation.Nullable;
+
+final class RequestFactory {
+  @Nullable private final ParameterHandler<?>[] parameterHandlers = null;
+
+  void create(Object[] args) {
+    @SuppressWarnings("unchecked")
+    ParameterHandler<Object>[] handlers = (ParameterHandler<Object>[]) parameterHandlers;
+    if (args.length != handlers.length) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/src/test/resources/issue520/input/javax/annotation/Nullable.java
+++ b/src/test/resources/issue520/input/javax/annotation/Nullable.java
@@ -1,0 +1,3 @@
+package javax.annotation;
+
+public @interface Nullable {}

--- a/src/test/resources/issue520/input/retrofit2/RequestFactory.java
+++ b/src/test/resources/issue520/input/retrofit2/RequestFactory.java
@@ -1,0 +1,28 @@
+package retrofit2;
+
+import javax.annotation.Nullable;
+
+final class RequestFactory {
+  @Nullable private final ParameterHandler<?>[] parameterHandlers;
+
+  RequestFactory(Builder builder) {
+    parameterHandlers = builder.parameterHandlers;
+  }
+
+  void create(Object[] args) {
+    @SuppressWarnings("unchecked")
+    ParameterHandler<Object>[] handlers = (ParameterHandler<Object>[]) parameterHandlers;
+    if (args.length != handlers.length) {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  static final class Builder {
+    @Nullable ParameterHandler<?>[] parameterHandlers;
+
+    RequestFactory build() {
+      parameterHandlers = new ParameterHandler<?>[1];
+      return new RequestFactory(this);
+    }
+  }
+}

--- a/src/test/resources/issue520b/expected/retrofit2/ParameterHandler.java
+++ b/src/test/resources/issue520b/expected/retrofit2/ParameterHandler.java
@@ -1,0 +1,3 @@
+package retrofit2;
+public class ParameterHandler {
+}

--- a/src/test/resources/issue520b/expected/retrofit2/RequestFactory.java
+++ b/src/test/resources/issue520b/expected/retrofit2/RequestFactory.java
@@ -1,0 +1,7 @@
+package retrofit2;
+
+final class RequestFactory {
+  Object create(ParameterHandler[] handlers) {
+    return handlers.clone();
+  }
+}

--- a/src/test/resources/issue520b/input/retrofit2/RequestFactory.java
+++ b/src/test/resources/issue520b/input/retrofit2/RequestFactory.java
@@ -1,0 +1,7 @@
+package retrofit2;
+
+final class RequestFactory {
+  Object create(ParameterHandler[] handlers) {
+    return handlers.clone();
+  }
+}

--- a/src/test/resources/issue520c/expected/retrofit2/ParameterHandler.java
+++ b/src/test/resources/issue520c/expected/retrofit2/ParameterHandler.java
@@ -1,0 +1,3 @@
+package retrofit2;
+public class ParameterHandler {
+}

--- a/src/test/resources/issue520c/expected/retrofit2/RequestFactory.java
+++ b/src/test/resources/issue520c/expected/retrofit2/RequestFactory.java
@@ -1,0 +1,14 @@
+package retrofit2;
+
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+
+final class RequestFactory {
+
+  void create(ParameterHandler[] handlers) {
+    Supplier<Object> s = handlers::clone;
+    IntFunction<ParameterHandler[]> f = ParameterHandler[]::new;
+    s.get();
+    f.apply(1);
+  }
+}

--- a/src/test/resources/issue520c/input/retrofit2/RequestFactory.java
+++ b/src/test/resources/issue520c/input/retrofit2/RequestFactory.java
@@ -1,0 +1,13 @@
+package retrofit2;
+
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+
+final class RequestFactory {
+  void create(ParameterHandler[] handlers) {
+    Supplier<Object> s = handlers::clone;
+    IntFunction<ParameterHandler[]> f = ParameterHandler[]::new;
+    s.get();
+    f.apply(1);
+  }
+}


### PR DESCRIPTION
Should fix the crash in #520, and also several similar crashes related to how array names are handled (see the test cases).