### PR TITLE
Work around JavaParser #1838

### DIFF
--- a/src/main/java/org/checkerframework/specimin/SpeciminAnnotationDeclaration.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminAnnotationDeclaration.java
@@ -1,0 +1,245 @@
+package org.checkerframework.specimin;
+
+import com.github.javaparser.ast.AccessSpecifier;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.resolution.Context;
+import com.github.javaparser.resolution.MethodUsage;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
+import com.github.javaparser.resolution.logic.MethodResolutionCapability;
+import com.github.javaparser.resolution.model.SymbolReference;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
+import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.symbolsolver.core.resolution.MethodUsageResolutionCapability;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserAnnotationDeclaration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * A {@link JavaParserAnnotationDeclaration} that can resolve a call to one of its members, or to
+ * one of the methods it inherits from {@code java.lang.annotation.Annotation}.
+ *
+ * <p>JavaParser models the members of an annotation type as {@link
+ * ResolvedAnnotationMemberDeclaration}s, which are values rather than methods, so {@code
+ * JavaParserAnnotationDeclaration} implements neither {@link MethodUsageResolutionCapability} nor
+ * {@code getDeclaredMethods()} (<a
+ * href="https://github.com/javaparser/javaparser/issues/1838">javaparser#1838</a>). Whenever
+ * JavaParser needs the type of a call to an annotation member -- which it does for every argument
+ * of a call, before it can pick an overload -- {@code ContextHelper#solveMethodAsUsage} therefore
+ * throws a bare {@code UnsupportedOperationException}. Annotations read by reflection do not have
+ * this problem, since {@code ReflectionAnnotationDeclaration} has the capability.
+ *
+ * <p>The same gap exists in the parallel {@link MethodResolutionCapability}, which {@code
+ * MethodResolutionLogic#solveMethodInType} needs to resolve the call's declaration rather than its
+ * type, so this class supplies both.
+ *
+ * <p>Instances of this class are substituted for {@code JavaParserAnnotationDeclaration}s by {@link
+ * SpeciminCombinedTypeSolver}.
+ */
+public class SpeciminAnnotationDeclaration extends JavaParserAnnotationDeclaration
+    implements MethodUsageResolutionCapability, MethodResolutionCapability {
+
+  /**
+   * Creates a declaration for the given annotation type.
+   *
+   * @param wrappedNode the annotation type's declaration in the AST
+   * @param typeSolver the type solver to use
+   */
+  public SpeciminAnnotationDeclaration(AnnotationDeclaration wrappedNode, TypeSolver typeSolver) {
+    super(wrappedNode, typeSolver);
+  }
+
+  @Override
+  public Optional<MethodUsage> solveMethodAsUsage(
+      String name,
+      List<ResolvedType> argumentTypes,
+      Context invokationContext,
+      List<ResolvedType> typeParameters) {
+    ResolvedMethodDeclaration member = findMember(name, argumentTypes, false);
+    if (member != null) {
+      return Optional.of(new MethodUsage(member));
+    }
+    for (ResolvedReferenceTypeDeclaration ancestor : ancestorDeclarations()) {
+      // An ancestor without the capability is skipped rather than passed to ContextHelper, which
+      // would throw the very exception this class exists to avoid.
+      if (ancestor instanceof MethodUsageResolutionCapability capableAncestor) {
+        Optional<MethodUsage> inherited =
+            capableAncestor.solveMethodAsUsage(
+                name, argumentTypes, invokationContext, typeParameters);
+        if (inherited.isPresent()) {
+          return inherited;
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public SymbolReference<ResolvedMethodDeclaration> solveMethod(
+      String name, List<ResolvedType> argumentsTypes, boolean staticOnly) {
+    ResolvedMethodDeclaration member = findMember(name, argumentsTypes, staticOnly);
+    if (member != null) {
+      return SymbolReference.solved(member);
+    }
+    for (ResolvedReferenceTypeDeclaration ancestor : ancestorDeclarations()) {
+      // As in solveMethodAsUsage: skip an ancestor that MethodResolutionLogic would throw on.
+      if (ancestor instanceof MethodResolutionCapability capableAncestor) {
+        SymbolReference<ResolvedMethodDeclaration> inherited =
+            capableAncestor.solveMethod(name, argumentsTypes, staticOnly);
+        if (inherited.isSolved()) {
+          return inherited;
+        }
+      }
+    }
+    return SymbolReference.unsolved();
+  }
+
+  /**
+   * Finds the member of this annotation type that a call would refer to.
+   *
+   * @param name the name of the called method
+   * @param argumentTypes the types of the call's arguments
+   * @param staticOnly whether the call can only refer to a static method
+   * @return the matching member, presented as a method, or null if there is none
+   */
+  private @Nullable ResolvedMethodDeclaration findMember(
+      String name, List<ResolvedType> argumentTypes, boolean staticOnly) {
+    // A member of an annotation type takes no arguments and is never static (JLS 9.6.1), so a call
+    // that does not fit that shape must be to something inherited instead.
+    if (!argumentTypes.isEmpty() || staticOnly) {
+      return null;
+    }
+    for (ResolvedAnnotationMemberDeclaration member : getAnnotationMembers()) {
+      if (member.getName().equals(name)) {
+        return new AnnotationMemberAsMethod(member, this);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns the declarations of this annotation type's ancestors. In practice the only one is
+   * {@code java.lang.annotation.Annotation}, which is what a call to {@code annotationType()},
+   * {@code toString()}, {@code hashCode()} or {@code equals()} on an annotation-typed expression
+   * resolves to.
+   *
+   * @return the ancestors' declarations, omitting any ancestor that cannot be solved
+   */
+  private List<ResolvedReferenceTypeDeclaration> ancestorDeclarations() {
+    List<ResolvedReferenceTypeDeclaration> ancestors = new ArrayList<>();
+    for (ResolvedReferenceType ancestor : getAncestors(true)) {
+      Optional<ResolvedReferenceTypeDeclaration> declaration = ancestor.getTypeDeclaration();
+      if (declaration.isPresent()) {
+        ancestors.add(declaration.get());
+      }
+    }
+    return ancestors;
+  }
+
+  /**
+   * Presents a member of an annotation type as the no-argument method that it is, so that it can be
+   * put into a {@link MethodUsage}.
+   */
+  private static class AnnotationMemberAsMethod implements ResolvedMethodDeclaration {
+
+    /** The member being presented as a method. */
+    private final ResolvedAnnotationMemberDeclaration member;
+
+    /** The annotation type that declares {@link #member}. */
+    private final ResolvedReferenceTypeDeclaration declaringType;
+
+    /**
+     * Creates a method view of an annotation member.
+     *
+     * @param member the member
+     * @param declaringType the annotation type that declares the member
+     */
+    AnnotationMemberAsMethod(
+        ResolvedAnnotationMemberDeclaration member,
+        ResolvedReferenceTypeDeclaration declaringType) {
+      this.member = member;
+      this.declaringType = declaringType;
+    }
+
+    @Override
+    public String getName() {
+      return member.getName();
+    }
+
+    @Override
+    public ResolvedReferenceTypeDeclaration declaringType() {
+      return declaringType;
+    }
+
+    @Override
+    public ResolvedType getReturnType() {
+      return member.getType();
+    }
+
+    @Override
+    public int getNumberOfParams() {
+      return 0;
+    }
+
+    @Override
+    public ResolvedParameterDeclaration getParam(int i) {
+      throw new IllegalArgumentException("An annotation member has no parameters: " + getName());
+    }
+
+    @Override
+    public int getNumberOfSpecifiedExceptions() {
+      return 0;
+    }
+
+    @Override
+    public ResolvedType getSpecifiedException(int index) {
+      throw new IllegalArgumentException("An annotation member throws nothing: " + getName());
+    }
+
+    @Override
+    public List<ResolvedTypeParameterDeclaration> getTypeParameters() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public AccessSpecifier accessSpecifier() {
+      // Implicitly public, per JLS 9.6.1.
+      return AccessSpecifier.PUBLIC;
+    }
+
+    @Override
+    public boolean isAbstract() {
+      // Implicitly abstract, per JLS 9.6.1. Note that "default" in the sense of isDefaultMethod is
+      // about interface default methods, not about an annotation member's default value.
+      return true;
+    }
+
+    @Override
+    public boolean isDefaultMethod() {
+      return false;
+    }
+
+    @Override
+    public boolean isStatic() {
+      return false;
+    }
+
+    @Override
+    public String toDescriptor() {
+      return "()" + getReturnType().toDescriptor();
+    }
+
+    @Override
+    public Optional<Node> toAst() {
+      return member.toAst();
+    }
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/SpeciminAnnotationDeclaration.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminAnnotationDeclaration.java
@@ -217,13 +217,14 @@ public class SpeciminAnnotationDeclaration extends JavaParserAnnotationDeclarati
 
     @Override
     public boolean isAbstract() {
-      // Implicitly abstract, per JLS 9.6.1. Note that "default" in the sense of isDefaultMethod is
-      // about interface default methods, not about an annotation member's default value.
+      // Implicitly abstract, per JLS 9.6.1.
       return true;
     }
 
     @Override
     public boolean isDefaultMethod() {
+      // "default" here refers to interface default methods, not an annotation member's
+      // default value.
       return false;
     }
 

--- a/src/main/java/org/checkerframework/specimin/SpeciminCombinedTypeSolver.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminCombinedTypeSolver.java
@@ -1,0 +1,78 @@
+package org.checkerframework.specimin;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.model.SymbolReference;
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserAnnotationDeclaration;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import java.util.IdentityHashMap;
+import java.util.Optional;
+
+/**
+ * A {@link CombinedTypeSolver} that hands back {@link SpeciminAnnotationDeclaration}s in place of
+ * the {@link JavaParserAnnotationDeclaration}s that JavaParser would otherwise produce for
+ * annotation types declared in the input.
+ *
+ * <p>The substitution happens here, rather than at the solvers that create the declarations,
+ * because a declaration also reaches callers straight out of this class' cache -- see {@link
+ * SpeciminTypeSolvers#overrideCache}.
+ */
+public class SpeciminCombinedTypeSolver extends CombinedTypeSolver {
+
+  /**
+   * The substitute for each annotation type seen so far, keyed by AST node. Reusing a substitute
+   * keeps {@code ResolvedReferenceType#equals}, which compares type declarations by identity,
+   * behaving as it does for the cached declarations this class replaces.
+   */
+  private final IdentityHashMap<AnnotationDeclaration, SpeciminAnnotationDeclaration> substitutes =
+      new IdentityHashMap<>();
+
+  /**
+   * Creates a combined type solver from the given solvers.
+   *
+   * @param elements the solvers to combine, in the order in which they should be consulted
+   */
+  public SpeciminCombinedTypeSolver(TypeSolver... elements) {
+    super(elements);
+  }
+
+  @Override
+  public SymbolReference<ResolvedReferenceTypeDeclaration> tryToSolveType(String name) {
+    return substituteAnnotationDeclaration(super.tryToSolveType(name));
+  }
+
+  @Override
+  public SymbolReference<ResolvedReferenceTypeDeclaration> tryToSolveTypeInModule(
+      String packageQualifiedName, String simpleName) {
+    return substituteAnnotationDeclaration(
+        super.tryToSolveTypeInModule(packageQualifiedName, simpleName));
+  }
+
+  /**
+   * Replaces a solved {@link JavaParserAnnotationDeclaration} with its {@link
+   * SpeciminAnnotationDeclaration} substitute. Anything else is returned unchanged.
+   *
+   * @param reference the reference to a solved (or unsolved) type declaration
+   * @return an equivalent reference whose declaration can solve calls to annotation members
+   */
+  private SymbolReference<ResolvedReferenceTypeDeclaration> substituteAnnotationDeclaration(
+      SymbolReference<ResolvedReferenceTypeDeclaration> reference) {
+    if (!reference.isSolved()) {
+      return reference;
+    }
+    ResolvedReferenceTypeDeclaration declaration = reference.getCorrespondingDeclaration();
+    if (!(declaration instanceof JavaParserAnnotationDeclaration)
+        || declaration instanceof SpeciminAnnotationDeclaration) {
+      return reference;
+    }
+    Optional<Node> ast = declaration.toAst();
+    if (ast.isEmpty() || !(ast.get() instanceof AnnotationDeclaration annotationDeclaration)) {
+      return reference;
+    }
+    return SymbolReference.solved(
+        substitutes.computeIfAbsent(
+            annotationDeclaration, node -> new SpeciminAnnotationDeclaration(node, this)));
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/SpeciminTypeSolvers.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminTypeSolvers.java
@@ -19,7 +19,7 @@ import java.util.List;
  */
 public class SpeciminTypeSolvers {
   /** The combined type solver. */
-  private final CombinedTypeSolver typeSolver;
+  private final SpeciminCombinedTypeSolver typeSolver;
 
   /** The solver that reads in files from the root. */
   private final JavaParserTypeSolver javaParserTypeSolver;
@@ -38,7 +38,7 @@ public class SpeciminTypeSolvers {
     this.memoryTypeSolver = new MemoryTypeSolver();
     this.javaParserTypeSolver = new JavaParserTypeSolver(new File(root));
     this.typeSolver =
-        new CombinedTypeSolver(new JdkTypeSolver(), javaParserTypeSolver, memoryTypeSolver);
+        new SpeciminCombinedTypeSolver(new JdkTypeSolver(), javaParserTypeSolver, memoryTypeSolver);
 
     for (String path : jarPaths) {
       this.typeSolver.add(new JarTypeSolver(path));
@@ -46,12 +46,12 @@ public class SpeciminTypeSolvers {
   }
 
   /**
-   * Gets the {@link CombinedTypeSolver} associated with this instance. Use this as the type solver
-   * for resolution.
+   * Gets the {@link SpeciminCombinedTypeSolver} associated with this instance. Use this as the type
+   * solver for resolution.
    *
-   * @return The {@link CombinedTypeSolver}
+   * @return The {@link SpeciminCombinedTypeSolver}
    */
-  public CombinedTypeSolver getTypeSolver() {
+  public SpeciminCombinedTypeSolver getTypeSolver() {
     return typeSolver;
   }
 

--- a/src/test/java/org/checkerframework/specimin/AnnotationInheritedMethodUsageTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationInheritedMethodUsageTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Like {@link AnnotationMethodUsageInArgumentTest}, but the calls are to methods that an annotation
+ * type inherits from {@code java.lang.annotation.Annotation} rather than to one of its own members.
+ */
+public class AnnotationInheritedMethodUsageTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "annotationinheritedmethodusage",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#foo(Anno)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AnnotationMethodUsageInArgumentTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationMethodUsageInArgumentTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Like {@link AnnotationMethodUsageTest}, but the call to the annotation member is an argument to
+ * another call, so JavaParser must compute the member call's type rather than just resolve it. This
+ * is the minimized trigger for <a href="https://github.com/njit-jerse/specimin/issues/521">issue
+ * 521</a>.
+ */
+public class AnnotationMethodUsageInArgumentTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "annotationmethodusageinargument",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#foo(Anno)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/Issue521Test.java
+++ b/src/test/java/org/checkerframework/specimin/Issue521Test.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test case for <a href="https://github.com/njit-jerse/specimin/issues/521">issue
+ * 521</a>.
+ */
+public class Issue521Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "issue521",
+        new String[] {"de/gurkenlabs/litiengine/entities/Creature.java"},
+        new String[] {"de.gurkenlabs.litiengine.entities.Creature#Creature(String)"});
+  }
+}

--- a/src/test/resources/annotationinheritedmethodusage/expected/com/example/Anno.java
+++ b/src/test/resources/annotationinheritedmethodusage/expected/com/example/Anno.java
@@ -1,0 +1,6 @@
+package com.example;
+
+public @interface Anno {
+
+  float velocity() default 100;
+}

--- a/src/test/resources/annotationinheritedmethodusage/expected/com/example/Simple.java
+++ b/src/test/resources/annotationinheritedmethodusage/expected/com/example/Simple.java
@@ -1,0 +1,17 @@
+package com.example;
+
+public class Simple {
+
+  void foo(Anno anno) {
+    sinkClass(anno.annotationType());
+    sinkString(anno.toString());
+  }
+
+  void sinkClass(Class<?> clazz) {
+    throw new java.lang.Error();
+  }
+
+  void sinkString(String value) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/annotationinheritedmethodusage/input/com/example/Anno.java
+++ b/src/test/resources/annotationinheritedmethodusage/input/com/example/Anno.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public @interface Anno {
+    float velocity() default 100;
+}

--- a/src/test/resources/annotationinheritedmethodusage/input/com/example/Simple.java
+++ b/src/test/resources/annotationinheritedmethodusage/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public class Simple {
+    void foo(Anno anno) {
+        sinkClass(anno.annotationType());
+        sinkString(anno.toString());
+    }
+
+    void sinkClass(Class<?> clazz) {}
+
+    void sinkString(String value) {}
+}

--- a/src/test/resources/annotationmethodusageinargument/expected/com/example/Anno.java
+++ b/src/test/resources/annotationmethodusageinargument/expected/com/example/Anno.java
@@ -1,0 +1,6 @@
+package com.example;
+
+public @interface Anno {
+
+  float velocity() default 100;
+}

--- a/src/test/resources/annotationmethodusageinargument/expected/com/example/Simple.java
+++ b/src/test/resources/annotationmethodusageinargument/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public class Simple {
+
+  void foo(Anno anno) {
+    sink(anno.velocity());
+  }
+
+  void sink(float value) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/annotationmethodusageinargument/input/com/example/Anno.java
+++ b/src/test/resources/annotationmethodusageinargument/input/com/example/Anno.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public @interface Anno {
+    float velocity() default 100;
+}

--- a/src/test/resources/annotationmethodusageinargument/input/com/example/Simple.java
+++ b/src/test/resources/annotationmethodusageinargument/input/com/example/Simple.java
@@ -1,0 +1,9 @@
+package com.example;
+
+public class Simple {
+    void foo(Anno anno) {
+        sink(anno.velocity());
+    }
+
+    void sink(float value) {}
+}

--- a/src/test/resources/issue521/expected/de/gurkenlabs/litiengine/entities/Attribute.java
+++ b/src/test/resources/issue521/expected/de/gurkenlabs/litiengine/entities/Attribute.java
@@ -1,0 +1,8 @@
+package de.gurkenlabs.litiengine.entities;
+
+final class Attribute<T extends Number> {
+
+  Attribute(T value) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/issue521/expected/de/gurkenlabs/litiengine/entities/Creature.java
+++ b/src/test/resources/issue521/expected/de/gurkenlabs/litiengine/entities/Creature.java
@@ -1,0 +1,16 @@
+package de.gurkenlabs.litiengine.entities;
+
+import javax.annotation.Nullable;
+
+@MovementInfo
+public class Creature {
+
+  @Nullable private Attribute<Float> velocity;
+
+  public Creature(@Nullable String spritesheetName) {
+    MovementInfo movementInfo = this.getClass().getAnnotation(MovementInfo.class);
+    if (movementInfo != null) {
+      this.velocity = new Attribute<>(movementInfo.velocity());
+    }
+  }
+}

--- a/src/test/resources/issue521/expected/de/gurkenlabs/litiengine/entities/MovementInfo.java
+++ b/src/test/resources/issue521/expected/de/gurkenlabs/litiengine/entities/MovementInfo.java
@@ -1,0 +1,15 @@
+package de.gurkenlabs.litiengine.entities;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MovementInfo {
+
+  float velocity() default 100;
+}

--- a/src/test/resources/issue521/expected/javax/annotation/Nullable.java
+++ b/src/test/resources/issue521/expected/javax/annotation/Nullable.java
@@ -1,0 +1,3 @@
+package javax.annotation;
+
+public @interface Nullable {}

--- a/src/test/resources/issue521/input/de/gurkenlabs/litiengine/entities/Attribute.java
+++ b/src/test/resources/issue521/input/de/gurkenlabs/litiengine/entities/Attribute.java
@@ -1,0 +1,5 @@
+package de.gurkenlabs.litiengine.entities;
+
+final class Attribute<T extends Number> {
+  Attribute(T value) {}
+}

--- a/src/test/resources/issue521/input/de/gurkenlabs/litiengine/entities/Creature.java
+++ b/src/test/resources/issue521/input/de/gurkenlabs/litiengine/entities/Creature.java
@@ -1,0 +1,15 @@
+package de.gurkenlabs.litiengine.entities;
+
+import javax.annotation.Nullable;
+
+@MovementInfo
+public class Creature {
+  @Nullable private Attribute<Float> velocity;
+
+  public Creature(@Nullable String spritesheetName) {
+    MovementInfo movementInfo = this.getClass().getAnnotation(MovementInfo.class);
+    if (movementInfo != null) {
+      this.velocity = new Attribute<>(movementInfo.velocity());
+    }
+  }
+}

--- a/src/test/resources/issue521/input/de/gurkenlabs/litiengine/entities/MovementInfo.java
+++ b/src/test/resources/issue521/input/de/gurkenlabs/litiengine/entities/MovementInfo.java
@@ -1,0 +1,14 @@
+package de.gurkenlabs.litiengine.entities;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MovementInfo {
+  float velocity() default 100;
+}

--- a/src/test/resources/issue521/input/javax/annotation/Nullable.java
+++ b/src/test/resources/issue521/input/javax/annotation/Nullable.java
@@ -1,0 +1,3 @@
+package javax.annotation;
+
+public @interface Nullable {}


### PR DESCRIPTION
There is a mismatch between how JavaParser's AST represents annotation member accesses and how its symbol solver represents them: the AST treats them as method calls, but the symbol solver does not. This is a known JavaParser bug, and seems to cause people using JavaParser no end of grief: [#1838](https://github.com/javaparser/javaparser/issues/1838), [#3539](https://github.com/javaparser/javaparser/issues/3539). This PR works around the problem for Specimin; this fix is like 90% of the way to an actual fix in JavaParser, and we should probably consider upstreaming it (assuming it works in practice).

Fixes #521.