### PR TITLE
Fix proximate cause of #523 by applying JLS 6.5.2 ambiguous-name-resolution rule

### DIFF
--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -639,6 +639,13 @@ public class UnsolvedSymbolGenerator {
 
     Expression scope = field.getScope();
 
+    if (isPackageName(scope)) {
+      // JLS 6.5.2: the leftmost identifier of this qualified name is not a variable in scope, so
+      // no prefix of the name is an expression. So, this node _must_ be a package name (e.g.,
+      // "java.util" in "java.util.UUID.fromString(s)"), not an actual field access.
+      return;
+    }
+
     // Special case: handle this/super separately since potentialScopeFQNs
     // provides more information than a this/super expression alone in
     // inferContextImpl
@@ -750,6 +757,37 @@ public class UnsolvedSymbolGenerator {
   }
 
   /**
+   * Returns true if the given expression is a package name rather than an expression. By JLS 6.5.2,
+   * an ambiguous name whose leftmost identifier is not a variable in scope must be a package or
+   * type name. This method returns true when that structural condition means the input must be a
+   * package or type name, and the usual package vs type heuristic suggests that the input is
+   * probably a package rather than a class.
+   *
+   * @param expr The expression to check
+   * @return True if the expression is a package name
+   */
+  private boolean isPackageName(Expression expr) {
+    if (Resolver.calculateResolvedType(expr) != null) {
+      return false;
+    }
+
+    if (expr.isFieldAccessExpr()) {
+      // A qualified name that names a type -- org.sampling.Baz in org.sampling.Baz.myField -- ends
+      // the package part of the name, even though its own leftmost identifier is a package.
+      return !JavaParserUtil.isAClassPath(expr.toString())
+          && isPackageName(expr.asFieldAccessExpr().getScope());
+    }
+
+    if (!expr.isNameExpr()) {
+      return false;
+    }
+
+    return !JavaParserUtil.isAClassName(expr.asNameExpr().getNameAsString())
+        && Resolver.resolve(expr.asNameExpr()) == null
+        && fullyQualifiedNameGenerator.getFQNsForExpressionLocation(expr).isEmpty();
+  }
+
+  /**
    * Helper method for {@link #inferContextImpl(Node, List)}. Adds the existing definition to the
    * result if found, or a new definition if one does not already exist. This method handles cases
    * where NameExpr could be either a type or a field (when getting the scope of a FieldAccessExpr,
@@ -824,6 +862,15 @@ public class UnsolvedSymbolGenerator {
 
     Collection<Set<String>> parentClassFQNs =
         fullyQualifiedNameGenerator.getFQNsForExpressionLocation(nameExpr);
+
+    if (parentClassFQNs.isEmpty()) {
+      // No type could declare a member with this name. By JLS 6.5.2, an
+      // ambiguous name that is neither a variable in scope nor a type is reclassified as a package
+      // name, which is the usual reason to get here: the leftmost identifier of a fully-qualified
+      // name used as an expression, such as "java" in "java.util.UUID.fromString(s)".
+      return;
+    }
+
     Set<String> fieldFQNs = new LinkedHashSet<>();
 
     for (Set<String> set : parentClassFQNs) {

--- a/src/test/java/org/checkerframework/specimin/AcronymClassInFqnTest.java
+++ b/src/test/java/org/checkerframework/specimin/AcronymClassInFqnTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that Specimin can handle a fully-qualified reference whose simple class name
+ * does not have a lowercase second character (e.g. an acronym like {@code UUID}), which the usual
+ * class-name-vs-constant-name heuristic rejects. Reduced from
+ * https://github.com/njit-jerse/specimin/issues/523.
+ */
+public class AcronymClassInFqnTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "acronymclassinfqn",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#bar()"});
+  }
+}

--- a/src/test/resources/acronymclassinfqn/expected/com/example/Foo.java
+++ b/src/test/resources/acronymclassinfqn/expected/com/example/Foo.java
@@ -1,0 +1,8 @@
+package com.example;
+
+public class Foo {
+
+  public Object bar() {
+    return java.util.UUID.fromString("00000000-0000-0000-0000-000000000000");
+  }
+}

--- a/src/test/resources/acronymclassinfqn/input/com/example/Foo.java
+++ b/src/test/resources/acronymclassinfqn/input/com/example/Foo.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Foo {
+  public Object bar() {
+    return java.util.UUID.fromString("00000000-0000-0000-0000-000000000000");
+  }
+}


### PR DESCRIPTION
Fixes #523. The underlying problem is that Specimin is using a heuristic to decide between package and class names when they are ambiguous. This fix handles the specific case in #523 (which is not really ambiguous, because there is only one sensible interpretation: if "java" is a field, what class should it go in?). This fix leaves a number of similar shapes that still crash or fail to compile, which I plan to address in a follow-up PR that improves the heuristic.