### PR TITLE
Synthetic annotation arguments need to be special-cased when they appear by name, not just when they appear as field accesses

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -360,6 +360,20 @@ public final class JavaLangUtils {
   }
 
   /**
+   * Returns true if a variable of the named type can be a <em>constant variable</em> (JLS 4.12.4),
+   * which requires the type to be a primitive type or {@code String}. No other type can be a
+   * constant variable, so a variable of any other type is never usable in a constant context, such
+   * as an annotation argument or a {@code case} label.
+   *
+   * @param type a primitive type name, or a fully-qualified class name. A simple class name is not
+   *     accepted, for the reason given in {@link #isJavaLangString(String)}.
+   * @return true if a constant variable can have this type
+   */
+  public static boolean isConstantVariableType(String type) {
+    return isPrimitive(type) || isJavaLangString(type);
+  }
+
+  /**
    * Converts a primitive to its boxed type (i.e. int --> Integer)
    *
    * @param primitive the primitive type (int, boolean, char, etc.)

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -22,14 +22,17 @@ import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.ArrayInitializerExpr;
 import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.LambdaExpr;
+import com.github.javaparser.ast.expr.MemberValuePair;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.SwitchExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
@@ -56,6 +59,8 @@ import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.AssociableToAST;
+import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedAnnotationMemberDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedEnumConstantDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
@@ -2241,6 +2246,98 @@ public class JavaParserUtil {
   }
 
   /**
+   * Like {@link #getInitializerRHS(String)}, but the returned value is guaranteed to be a constant
+   * expression (JLS 15.29) whenever one exists for the given type. A {@code static final} field
+   * initialized with it is therefore a constant variable (JLS 4.12.4), and so may be read from a
+   * constant context such as an annotation argument or a {@code case} label.
+   *
+   * <p>The two methods differ only for {@code String}: the null literal is not a constant
+   * expression, so a String constant needs a string literal instead. Primitives already get
+   * literals, and no other type can be a constant variable at all, so nothing else can be improved.
+   *
+   * @param variableType the type of the variable, as a fully-qualified name
+   * @return a default value for that type, which is a constant expression if the type permits one
+   */
+  public static String getConstantInitializerRHS(String variableType) {
+    if (JavaLangUtils.isJavaLangString(variableType)) {
+      return "\"\"";
+    }
+    return getInitializerRHS(variableType);
+  }
+
+  /**
+   * If the given expression supplies the value of an annotation element whose annotation type is
+   * resolvable, returns that element's declared type. An expression inside an array initializer
+   * supplies one element of an array-typed element, so the component type is returned for it.
+   *
+   * <p>JLS 9.7.1 requires an element value to be assignment-compatible with the element's declared
+   * type, so the answer is a fact about the expression's type rather than a guess. Returns null
+   * when the expression is not in an element value position, when the annotation type is one
+   * Specimin has to synthesize (and which therefore constrains nothing, since Specimin chooses the
+   * element's type itself), or when the annotation type declares no matching element.
+   *
+   * @param expr the expression to test
+   * @return the declared type of the annotation element this expression supplies, or null
+   */
+  public static @Nullable ResolvedType getAnnotationElementType(Expression expr) {
+    Node parent = expr.getParentNode().orElse(null);
+
+    // An array-valued element is written as an ArrayInitializerExpr whose values each have the
+    // element type's component type. Nested array initializers are impossible, because no legal
+    // element type is an array of arrays, so at most one level is unwrapped here.
+    boolean isArrayElement = false;
+    if (parent instanceof ArrayInitializerExpr arrayInitializer) {
+      isArrayElement = true;
+      parent = arrayInitializer.getParentNode().orElse(null);
+    }
+
+    // No identity check against the annotation's value is needed in either case below: the value
+    // is the only Expression child of both node kinds, since a MemberValuePair holds its name as a
+    // SimpleName.
+    String elementName;
+    AnnotationExpr annotation;
+    if (parent instanceof SingleMemberAnnotationExpr singleMember) {
+      elementName = "value";
+      annotation = singleMember;
+    } else if (parent instanceof MemberValuePair pair
+        && pair.getParentNode().orElse(null) instanceof AnnotationExpr enclosing) {
+      elementName = pair.getNameAsString();
+      annotation = enclosing;
+    } else {
+      return null;
+    }
+
+    ResolvedAnnotationDeclaration resolved = Resolver.resolve(annotation);
+
+    if (resolved == null) {
+      return null;
+    }
+
+    for (ResolvedAnnotationMemberDeclaration member : resolved.getAnnotationMembers()) {
+      if (!member.getName().equals(elementName)) {
+        continue;
+      }
+
+      ResolvedType elementType;
+      try {
+        elementType = member.getType();
+      } catch (UnsolvedSymbolException ex) {
+        // The annotation type resolves but the element's type does not, so there is nothing to
+        // report.
+        return null;
+      }
+
+      if (!isArrayElement) {
+        return elementType;
+      }
+
+      return elementType.isArray() ? elementType.asArrayType().getComponentType() : null;
+    }
+
+    return null;
+  }
+
+  /**
    * Given a list of parameter types, return a super/this(...) call with the default values of those
    * types.
    *
@@ -2903,14 +3000,14 @@ public class JavaParserUtil {
    * @return true if node is in a position requiring a compile-time constant
    */
   public static boolean isInConstantContext(Node node) {
+    if (isInsideAnnotation(node)) {
+      return true;
+    }
+
     Node child = node;
     Node parent = child.getParentNode().orElse(null);
 
     while (parent != null) {
-      if (parent instanceof AnnotationExpr) {
-        return true;
-      }
-
       if (parent instanceof SwitchEntry entry && isCaseLabel(entry, child)) {
         return true;
       }
@@ -2928,6 +3025,18 @@ public class JavaParserUtil {
     }
 
     return false;
+  }
+
+  /**
+   * Returns true if the given node is inside an annotation, and so supplies an annotation element
+   * value or part of one. JLS 9.7.1 restricts such a value to a constant expression, a class
+   * literal, an enum constant, an annotation, or an array initializer of those.
+   *
+   * @param node the node to test
+   * @return true if node is inside an annotation
+   */
+  public static boolean isInsideAnnotation(Node node) {
+    return node.findAncestor(AnnotationExpr.class).isPresent();
   }
 
   /**
@@ -2973,21 +3082,44 @@ public class JavaParserUtil {
   }
 
   /**
-   * Returns true if the given type is one that a constant variable may be declared with: a
-   * primitive type or {@code String} (JLS 4.12.4). No other type can be a constant variable, so a
-   * field of any other type is never usable in a constant context.
+   * Applies {@link JavaLangUtils#isConstantVariableType(String)} to a resolved type. Unlike {@link
+   * #isConstantVariableType(Type)}, this names the type exactly, so it does not approximate.
+   *
+   * @param type a resolved type
+   * @return true if a constant variable could have this type
+   */
+  public static boolean isConstantVariableType(ResolvedType type) {
+    if (type.isPrimitive()) {
+      return JavaLangUtils.isConstantVariableType(type.describe());
+    }
+    return type.isReferenceType()
+        && JavaLangUtils.isConstantVariableType(type.asReferenceType().getQualifiedName());
+  }
+
+  /**
+   * Applies {@link JavaLangUtils#isConstantVariableType(String)} to a declared type, without
+   * resolving it.
    *
    * @param type the declared type of a field
    * @return true if a field of this type could be a constant variable
    */
   private static boolean isConstantVariableType(Type type) {
+    String name;
     if (type.isPrimitiveType()) {
-      return true;
+      // Type#asString() pretty-prints any type annotation along with the type, so the name is
+      // taken from JavaParser's Primitive enum instead.
+      name = type.asPrimitiveType().getType().asString();
+    } else if (type instanceof ClassOrInterfaceType classType) {
+      // getNameAsString() returns the last identifier, with any package qualification held
+      // separately as the scope, so qualifying it with java.lang matches both "String" and
+      // "java.lang.String" -- and, imprecisely, a String declared in some other package. Callers of
+      // this overload deliberately work on unresolved syntax, where that is the best available
+      // answer.
+      name = "java.lang." + classType.getNameAsString();
+    } else {
+      return false;
     }
-    // Matches both "String" and "java.lang.String": getNameAsString() returns the last identifier,
-    // with any package qualification held separately as the scope.
-    return type instanceof ClassOrInterfaceType classType
-        && classType.getNameAsString().equals("String");
+    return JavaLangUtils.isConstantVariableType(name);
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -2267,8 +2267,10 @@ public class JavaParserUtil {
 
   /**
    * If the given expression supplies the value of an annotation element whose annotation type is
-   * resolvable, returns that element's declared type. An expression inside an array initializer
-   * supplies one element of an array-typed element, so the component type is returned for it.
+   * resolvable, returns the type that expression must have. That is the element's declared type,
+   * except that an expression supplying a single component of an array-typed element gets the
+   * component type: either from inside a braced initializer, or as the unbraced single value that
+   * JLS 9.7.1 accepts as shorthand for a one-element array.
    *
    * <p>Returns null when the expression is not in an element value position, when the annotation
    * type is one Specimin has to synthesize (and which therefore constrains nothing, since Specimin
@@ -2280,12 +2282,12 @@ public class JavaParserUtil {
   public static @Nullable ResolvedType getAnnotationElementType(Expression expr) {
     Node parent = expr.getParentNode().orElse(null);
 
-    // An array-valued element is written as an ArrayInitializerExpr whose values each have the
-    // element type's component type. Nested array initializers are impossible, because no legal
-    // element type is an array of arrays, so at most one level is unwrapped here.
-    boolean isArrayElement = false;
+    // A braced array value is an ArrayInitializerExpr whose values each supply one component of the
+    // array. Nested array initializers are impossible, because no legal element type is an array of
+    // arrays, so at most one level is stepped over here.
+    boolean insideBraces = false;
     if (parent instanceof ArrayInitializerExpr arrayInitializer) {
-      isArrayElement = true;
+      insideBraces = true;
       parent = arrayInitializer.getParentNode().orElse(null);
     }
 
@@ -2325,11 +2327,20 @@ public class JavaParserUtil {
         return null;
       }
 
-      if (!isArrayElement) {
-        return elementType;
+      if (insideBraces) {
+        // The expression supplies one component of the array. A non-array element type here means
+        // the input does not compile, so report nothing rather than a type that cannot be right.
+        return elementType.isArray() ? elementType.asArrayType().getComponentType() : null;
       }
 
-      return elementType.isArray() ? elementType.asArrayType().getComponentType() : null;
+      // The expression is the whole element value. JLS 9.7.1 also lets an array-typed element take
+      // a single value without braces, as shorthand for a one-element array, so a value that is not
+      // itself an initializer supplies one component rather than the whole array.
+      if (elementType.isArray() && !expr.isArrayInitializerExpr()) {
+        return elementType.asArrayType().getComponentType();
+      }
+
+      return elementType;
     }
 
     return null;

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -2252,8 +2252,8 @@ public class JavaParserUtil {
    * constant context such as an annotation argument or a {@code case} label.
    *
    * <p>The two methods differ only for {@code String}: the null literal is not a constant
-   * expression, so a String constant needs a string literal instead. Primitives already get
-   * literals, and no other type can be a constant variable at all, so nothing else can be improved.
+   * expression, so a String constant needs a string literal instead. (Primitives are the only other
+   * constant variable types, and already get literal initializers.)
    *
    * @param variableType the type of the variable, as a fully-qualified name
    * @return a default value for that type, which is a constant expression if the type permits one
@@ -2270,11 +2270,9 @@ public class JavaParserUtil {
    * resolvable, returns that element's declared type. An expression inside an array initializer
    * supplies one element of an array-typed element, so the component type is returned for it.
    *
-   * <p>JLS 9.7.1 requires an element value to be assignment-compatible with the element's declared
-   * type, so the answer is a fact about the expression's type rather than a guess. Returns null
-   * when the expression is not in an element value position, when the annotation type is one
-   * Specimin has to synthesize (and which therefore constrains nothing, since Specimin chooses the
-   * element's type itself), or when the annotation type declares no matching element.
+   * <p>Returns null when the expression is not in an element value position, when the annotation
+   * type is one Specimin has to synthesize (and which therefore constrains nothing, since Specimin
+   * chooses the element's type itself), or when the annotation type declares no matching element.
    *
    * @param expr the expression to test
    * @return the declared type of the annotation element this expression supplies, or null

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -1872,6 +1872,16 @@ public class FullyQualifiedNameGenerator {
    * @return A set of FQNs, or null if unfound
    */
   private @Nullable Set<FullyQualifiedNameSet> getFQNsFromSurroundingContextType(Expression expr) {
+    // An annotation element value must be assignment-compatible with the element's declared type
+    // (JLS 9.7.1). This is checked before the parent-kind dispatch below because the relevant
+    // parent is one of three shapes -- a SingleMemberAnnotationExpr, a MemberValuePair, or an
+    // ArrayInitializerExpr under either of those.
+    ResolvedType annotationElementType = JavaParserUtil.getAnnotationElementType(expr);
+
+    if (annotationElementType != null) {
+      return Set.of(getFQNsForResolvedType(annotationElementType));
+    }
+
     Node parentNode = expr.getParentNode().get();
 
     // Method call, constructor call, super() call

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedField.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedField.java
@@ -90,7 +90,13 @@ public class UnsolvedField extends UnsolvedSymbolAlternate implements UnsolvedFi
         + type
         + " "
         + name
-        + (isStatic && isFinal ? " = " + JavaParserUtil.getInitializerRHS(type.toString()) : "")
+        // A constant expression is used rather than the ordinary default so that this field is a
+        // constant variable (JLS 4.12.4) whenever its type permits one. That is required when the
+        // field is read from a constant context, such as an annotation argument, and costs nothing
+        // anywhere else: a constant expression is a legal initializer wherever the default was.
+        + (isStatic && isFinal
+            ? " = " + JavaParserUtil.getConstantInitializerRHS(type.toString())
+            : "")
         + ";";
   }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -528,15 +528,12 @@ public class UnsolvedSymbolGenerator {
                   .iterator()
                   .next();
         }
-      } else if (toLookUpTypeFor instanceof FieldAccessExpr fieldAccess
-          && JavaParserUtil.isProbablyAConstant(fieldAccess.getNameAsString())
-          && !declaringTypeIsSyntheticNonEnum(fieldAccess)) {
-        // An enum constant's type is the enum itself, so the member's type is the field's scope.
+      } else if (isEnumConstantAnnotationArgument(toLookUpTypeFor)) {
+        // An enum constant's type is the enum itself, so the member's type is the constant's
+        // declaring type rather than the constant's own (empty) declared type.
         rawFqns =
-            fullyQualifiedNameGenerator
-                .getFQNsForExpressionType(fieldAccess.getScope())
-                .iterator()
-                .next();
+            new FullyQualifiedNameSet(
+                getConstantDeclaringTypeFQNs(toLookUpTypeFor).iterator().next());
       } else {
         rawFqns =
             fullyQualifiedNameGenerator.getFQNsForExpressionType(toLookUpTypeFor).iterator().next();
@@ -688,61 +685,23 @@ public class UnsolvedSymbolGenerator {
         potentialParents.add((UnsolvedClassOrInterfaceAlternates) generated);
       }
 
-      @SuppressWarnings("unchecked")
-      boolean isInAnnotation = field.findAncestor(AnnotationExpr.class).isPresent();
-
-      // Whether this field access is being generated as an enum constant, as opposed to a static
-      // final constant of an ordinary class. Only meaningful when isInAnnotation is true.
-      boolean isEnumConstant = false;
-
-      if (isInAnnotation) {
-        // A field access in an annotation argument is usually an enum constant, but it can also be
-        // a static final constant of an ordinary class. This is only a guess, so it must not
-        // override anything we actually know: a constructor call on the same type, for example,
-        // establishes that it is a class (see the ObjectCreationExpr case of inferContextImpl).
-        isEnumConstant = true;
-        for (UnsolvedClassOrInterfaceAlternates parent : potentialParents) {
-          if (parent.getType() == UnsolvedClassOrInterfaceType.UNKNOWN) {
-            parent.setType(UnsolvedClassOrInterfaceType.ENUM);
-          } else if (parent.getType() != UnsolvedClassOrInterfaceType.ENUM) {
-            isEnumConstant = false;
-          }
-        }
-      }
+      AnnotationArgumentKind annotationArgumentKind =
+          classifyAnnotationArgument(field, potentialParents);
+      boolean isConstantVariable = mustBeConstantVariable(annotationArgumentKind);
 
       boolean isStatic = JavaParserUtil.getFQNIfStaticMember(field) != null;
 
       UnsolvedFieldAlternates createdField;
       if (typeToMustPreserveNode.isEmpty()) {
-        Set<MemberType> types;
-        if (isEnumConstant) {
-          // An enum constant declaration names no type, so the empty type is what should be
-          // printed; see UnsolvedField#toString.
-          types = Set.of(new SolvedMemberType(""));
-        } else if (isInAnnotation) {
-          // The declaring type is not an enum, so this is an ordinary field being used as an
-          // annotation argument. JLS 9.7.1 requires such an argument to be a constant expression,
-          // so the field must be given a primitive (or String) type and a constant initializer.
-          types = Set.of(ANNOTATION_CONSTANT_TYPE);
-        } else {
-          types = new LinkedHashSet<>();
-          for (FullyQualifiedNameSet potentialTypeFQNs :
-              fullyQualifiedNameGenerator.getFQNsForExpressionType(field)) {
-            types.add(getOrCreateMemberTypeFromFQNs(potentialTypeFQNs));
-          }
-        }
-
         createdField =
             UnsolvedFieldAlternates.create(
                 field.getNameAsString(),
-                types,
+                getTypesForGeneratedField(field, annotationArgumentKind),
                 potentialParents,
                 // A constant expression must be reached through a static field, and a final field
                 // that is not static would be emitted without an initializer.
-                isStatic || (isInAnnotation && !isEnumConstant),
-                // A non-enum constant used as an annotation argument must be final for it to be a
-                // constant expression.
-                isInAnnotation && !isEnumConstant);
+                isStatic || isConstantVariable,
+                isConstantVariable);
       } else {
         createdField =
             UnsolvedFieldAlternates.create(
@@ -755,6 +714,111 @@ public class UnsolvedSymbolGenerator {
       ((UnsolvedFieldAlternates) alreadyGenerated)
           .updateFieldTypesAndMustPreserveNodes(typeToMustPreserveNode);
     }
+  }
+
+  /**
+   * How a name that appears as an annotation argument must be declared. JLS 9.7.1 permits only two
+   * kinds of name in that position: an enum constant, or a constant variable, whose type is
+   * necessarily a primitive or {@code String} (JLS 4.12.4).
+   */
+  private enum AnnotationArgumentKind {
+    /** An enum constant, whose declaring type is therefore an enum. */
+    ENUM_CONSTANT,
+    /**
+     * A constant variable whose type the annotation type dictates, because that annotation type is
+     * known.
+     */
+    DECLARED_CONSTANT,
+    /**
+     * A constant variable whose type Specimin must invent, because the annotation type is itself
+     * synthetic and so constrains the argument's type in no way.
+     */
+    INVENTED_CONSTANT
+  }
+
+  /**
+   * Classifies a name or field access that appears as an annotation argument, deciding how the
+   * synthetic field generated for it must be declared. Shared by {@link #handleNameExpr} and {@link
+   * #handleFieldAccessExpr}, which differ only in how they find the declaring types.
+   *
+   * <p>As a side effect, a declaring type that Specimin has not already classified as something
+   * else is promoted to an enum whenever the argument is treated as an enum constant.
+   *
+   * @param constant the NameExpr or FieldAccessExpr a field is being generated for
+   * @param potentialParents the synthetic types that may declare that field
+   * @return the classification, or null if the expression is not an annotation argument
+   */
+  private @Nullable AnnotationArgumentKind classifyAnnotationArgument(
+      Expression constant, List<UnsolvedClassOrInterfaceAlternates> potentialParents) {
+    if (!JavaParserUtil.isInsideAnnotation(constant)) {
+      return null;
+    }
+
+    // A name whose required type is a primitive or String can only be a constant variable, and the
+    // element's declaration says which one it is. Every other element type either requires an enum
+    // constant or admits no name at all, so it is left to the guess below.
+    ResolvedType elementType = JavaParserUtil.getAnnotationElementType(constant);
+
+    if (elementType != null && JavaParserUtil.isConstantVariableType(elementType)) {
+      return AnnotationArgumentKind.DECLARED_CONSTANT;
+    }
+
+    // A name in an annotation argument is usually an enum constant, but it can also be a static
+    // final constant of an ordinary class. This is only a guess, so it must not override anything
+    // we actually know: a constructor call on the same type, for example, establishes that it is a
+    // class (see the ObjectCreationExpr case of inferContextImpl).
+    boolean isEnumConstant = true;
+    for (UnsolvedClassOrInterfaceAlternates parent : potentialParents) {
+      if (parent.getType() == UnsolvedClassOrInterfaceType.UNKNOWN) {
+        parent.setType(UnsolvedClassOrInterfaceType.ENUM);
+      } else if (parent.getType() != UnsolvedClassOrInterfaceType.ENUM) {
+        isEnumConstant = false;
+      }
+    }
+
+    return isEnumConstant
+        ? AnnotationArgumentKind.ENUM_CONSTANT
+        : AnnotationArgumentKind.INVENTED_CONSTANT;
+  }
+
+  /**
+   * Returns true if a field classified this way is a constant variable, and so must be declared
+   * {@code static final} with a constant initializer. An enum constant needs neither, and a field
+   * that is not an annotation argument at all is under no such obligation.
+   *
+   * @param kind the classification, or null if the field is not an annotation argument
+   * @return true if the field must be declared as a constant variable
+   */
+  private static boolean mustBeConstantVariable(@Nullable AnnotationArgumentKind kind) {
+    return kind != null && kind != AnnotationArgumentKind.ENUM_CONSTANT;
+  }
+
+  /**
+   * Returns the possible types of a synthetic field, honoring any constraint that the field's use
+   * as an annotation argument imposes.
+   *
+   * @param constant the NameExpr or FieldAccessExpr the field is generated for
+   * @param kind how the field is used as an annotation argument, or null if it is not one
+   * @return the possible types of the field
+   */
+  private Set<MemberType> getTypesForGeneratedField(
+      Expression constant, @Nullable AnnotationArgumentKind kind) {
+    if (kind == AnnotationArgumentKind.ENUM_CONSTANT) {
+      // An enum constant declaration names no type, so the empty type is what should be printed;
+      // see UnsolvedField#toString.
+      return Set.of(new SolvedMemberType(""));
+    }
+
+    if (kind == AnnotationArgumentKind.INVENTED_CONSTANT) {
+      return Set.of(ANNOTATION_CONSTANT_TYPE);
+    }
+
+    Set<MemberType> types = new LinkedHashSet<>();
+    for (FullyQualifiedNameSet potentialTypeFQNs :
+        fullyQualifiedNameGenerator.getFQNsForExpressionType(constant)) {
+      types.add(getOrCreateMemberTypeFromFQNs(potentialTypeFQNs));
+    }
+    return types;
   }
 
   /**
@@ -934,23 +998,18 @@ public class UnsolvedSymbolGenerator {
       // NameExpr and static import must be static and final
       boolean isStaticImport = JavaParserUtil.getFQNIfStaticMember(nameExpr) != null;
 
+      AnnotationArgumentKind annotationArgumentKind =
+          classifyAnnotationArgument(nameExpr, generatedClasses);
+      boolean isConstantVariable = mustBeConstantVariable(annotationArgumentKind);
+
       if (typeToMustPreserveNode.isEmpty()) {
-        Set<MemberType> memberTypes = new LinkedHashSet<>();
-
-        for (FullyQualifiedNameSet typeFQNs :
-            fullyQualifiedNameGenerator.getFQNsForExpressionType(nameExpr)) {
-          MemberType type = getOrCreateMemberTypeFromFQNs(typeFQNs);
-
-          memberTypes.add(type);
-        }
-
         generatedField =
             UnsolvedFieldAlternates.create(
                 nameExpr.getNameAsString(),
-                memberTypes,
+                getTypesForGeneratedField(nameExpr, annotationArgumentKind),
                 generatedClasses,
-                isStaticImport,
-                isStaticImport);
+                isStaticImport || isConstantVariable,
+                isStaticImport || isConstantVariable);
       } else {
         generatedField =
             UnsolvedFieldAlternates.create(
@@ -5044,36 +5103,84 @@ public class UnsolvedSymbolGenerator {
   }
 
   /**
-   * Determines whether Specimin has already classified the declaring type of a field access as a
-   * synthetic type that is not an enum.
+   * Returns the candidate types that could declare the constant a name or field access refers to.
+   * Each element is one candidate type, given as the set of fully-qualified names it could have.
    *
-   * <p>This exists because a field access in an annotation argument is ambiguous: it may be an enum
-   * constant, or a static final constant of an ordinary class. Specimin resolves that ambiguity in
-   * {@link #handleFieldAccessExpr} by classifying the declaring type, and this method reports that
-   * decision so that the annotation member's type can be made consistent with it. It is therefore
-   * not a general test for enum-ness: it says only whether we have already decided against it. A
-   * declaring type that Specimin did not synthesize is not a decision of ours, so it is not
-   * reported here even if it is in fact not an enum.
+   * @param constant a NameExpr or FieldAccessExpr
+   * @return the candidate declaring types; empty if none could be determined
+   */
+  private Collection<Set<String>> getConstantDeclaringTypeFQNs(Expression constant) {
+    if (constant instanceof FieldAccessExpr fieldAccess) {
+      // A qualified constant's scope is its declaring type, which is more direct than the location
+      // analysis that a bare name requires.
+      Collection<Set<String>> result = new LinkedHashSet<>();
+      for (FullyQualifiedNameSet scopeFQNs :
+          fullyQualifiedNameGenerator.getFQNsForExpressionType(fieldAccess.getScope())) {
+        result.add(scopeFQNs.erasedFqns());
+      }
+      return result;
+    }
+
+    // A bare name has no scope, so its declaring type is wherever the name could have been
+    // declared: the type named by a static import, or an unsolvable supertype of the enclosing
+    // class.
+    return fullyQualifiedNameGenerator.getFQNsForExpressionLocation(constant);
+  }
+
+  /**
+   * Returns true if an annotation argument is being generated as an enum constant. The annotation
+   * element's type is then the declaring enum, since an enum constant declaration has no type of
+   * its own.
    *
-   * <p>The scope may have more than one candidate type. This method mirrors the rule used when the
-   * field itself is generated: a single candidate that is definitively not an enum is enough to
-   * decide against enum-ness, since the field's type must then be one that works for that
+   * <p>This must be called after the argument has been passed to {@link #inferContextImpl}, so that
+   * any synthetic declaring type has already been created and classified.
+   *
+   * @param constant the annotation argument
+   * @return true if the argument is an enum constant whose declaring enum Specimin can name
+   */
+  private boolean isEnumConstantAnnotationArgument(Expression constant) {
+    String name;
+    if (constant instanceof NameExpr nameExpr) {
+      name = nameExpr.getNameAsString();
+    } else if (constant instanceof FieldAccessExpr fieldAccess) {
+      name = fieldAccess.getNameAsString();
+    } else {
+      return false;
+    }
+
+    return JavaParserUtil.isProbablyAConstant(name)
+        && !getConstantDeclaringTypeFQNs(constant).isEmpty()
+        && !declaringTypeIsSyntheticNonEnum(constant);
+  }
+
+  /**
+   * Determines whether Specimin has already classified the declaring type of a constant used as an
+   * annotation argument as a synthetic type that is not an enum.
+   *
+   * <p>This exists because such a name is ambiguous: it may be an enum constant, or a static final
+   * constant of an ordinary class. Specimin resolves that ambiguity in {@link
+   * #classifyAnnotationArgument}, and this method reports that decision so that the annotation
+   * member's type can be made consistent with it. It is therefore not a general test for enum-ness:
+   * it says only whether we have already decided against it. A declaring type that Specimin did not
+   * synthesize is not a decision of ours, so it is not reported here even if it is in fact not an
+   * enum.
+   *
+   * <p>The constant may have more than one candidate declaring type. This method mirrors the rule
+   * used when the field itself is generated: a single candidate that is definitively not an enum is
+   * enough to decide against enum-ness, since the field's type must then be one that works for that
    * candidate. Checking only one candidate would let the two decisions disagree, which would emit a
    * constant of one type and an annotation member of another.
    *
-   * <p>This must be called after the field access has been passed to {@link #inferContextImpl}, so
-   * that any synthetic declaring type has already been created and classified.
+   * <p>This must be called after the constant has been passed to {@link #inferContextImpl}, so that
+   * any synthetic declaring type has already been created and classified.
    *
-   * @param fieldAccess the field access to check the declaring type of
+   * @param constant the NameExpr or FieldAccessExpr to check the declaring type of
    * @return true if any candidate declaring type is a synthetic type classified as something other
    *     than an enum; false otherwise, including when every candidate was classified as an enum and
    *     when no candidate is a synthetic type at all
    */
-  private boolean declaringTypeIsSyntheticNonEnum(FieldAccessExpr fieldAccess) {
-    Set<FullyQualifiedNameSet> scopeFQNs =
-        fullyQualifiedNameGenerator.getFQNsForExpressionType(fieldAccess.getScope());
-
-    for (FullyQualifiedNameSet candidateFQNs : scopeFQNs) {
+  private boolean declaringTypeIsSyntheticNonEnum(Expression constant) {
+    for (Set<String> candidateFQNs : getConstantDeclaringTypeFQNs(constant)) {
       UnsolvedSymbolAlternates<?> scope = findExistingAndUpdateFQNs(candidateFQNs);
 
       if (!(scope instanceof UnsolvedClassOrInterfaceAlternates scopeType)) {

--- a/src/test/java/org/checkerframework/specimin/AnnotationArgKnownArrayTypeTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationArgKnownArrayTypeTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * An array-valued annotation element constrains each value in its array initializer to the array's
+ * component type (JLS 9.7.1), not to the array type itself. {@code Header} declares {@code String[]
+ * value()}, so the unsolved {@code HEADER_NAME} inside {@code @Header({HEADER_NAME})} is a {@code
+ * String} constant.
+ */
+public class AnnotationArgKnownArrayTypeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "annotationargknownarraytype",
+        new String[] {"org/example/Target.java"},
+        new String[] {"org.example.Target#target(String)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AnnotationArgKnownTypeQualifiedTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationArgKnownTypeQualifiedTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The qualified-name counterpart of {@link AnnotationArgKnownTypeTest}: {@code Constants} must stay
+ * an ordinary class holding a {@code String} constant, because {@code Header} declares {@code
+ * String value()}.
+ *
+ * <p>Specimin guesses that the declaring type of a constant used as an annotation argument is an
+ * enum, since an enum constant is the other thing JLS 9.7.1 allows there. That guess used to be
+ * applied even when the annotation type was in the input and ruled it out, producing an {@code enum
+ * Constants} that could not be converted to the declared {@code String}.
+ */
+public class AnnotationArgKnownTypeQualifiedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "annotationargknowntypequalified",
+        new String[] {"org/example/Target.java"},
+        new String[] {"org.example.Target#target(String)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AnnotationArgKnownTypeTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationArgKnownTypeTest.java
@@ -1,0 +1,25 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * When the annotation type is in the input, its element's declared type says exactly what an
+ * unsolved constant used as that element's value must be (JLS 9.7.1), so Specimin need not guess.
+ * Here {@code Header} declares {@code String value()}, so {@code HEADER_NAME} is a {@code String}
+ * constant variable rather than a type Specimin invents.
+ *
+ * <p>Being a constant variable also dictates the declaration: JLS 4.12.4 requires it to be final,
+ * with a constant initializer, and reaching it through a static import requires it to be static.
+ * The usual {@code null} default Specimin gives a reference-typed field is not a constant
+ * expression, so a string literal is used instead.
+ */
+public class AnnotationArgKnownTypeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "annotationargknowntype",
+        new String[] {"org/example/Target.java"},
+        new String[] {"org.example.Target#target(String)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AnnotationArgStaticImportTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationArgStaticImportTest.java
@@ -1,0 +1,25 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A statically-imported constant used as an annotation argument. JLS 9.7.1 permits only two kinds
+ * of name in that position: an enum constant, or a constant variable (whose type is a primitive or
+ * {@code String}, JLS 4.12.4). Neither the annotation type nor the constant's declaring type is in
+ * the input, so Specimin must invent both, and it guesses that the constant is an enum constant.
+ *
+ * <p>Specimin used to apply this rule only to a qualified name such as {@code Constants.X}, so a
+ * bare name reaching its declaration through a static import got an invented type of its own, which
+ * is neither an allowable annotation argument nor an allowable annotation element type. See <a
+ * href="https://github.com/njit-jerse/specimin/issues/524">issue 524</a>.
+ */
+public class AnnotationArgStaticImportTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "annotationargstaticimport",
+        new String[] {"org/example/Target.java"},
+        new String[] {"org.example.Target#target(String)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AnnotationArgUnbracedArrayTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationArgUnbracedArrayTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The unbraced counterpart of {@link AnnotationArgKnownArrayTypeTest}. JLS 9.7.1 lets an
+ * array-typed element take a single value without braces, as shorthand for a one-element array, so
+ * {@code HEADER_NAME} in {@code @Header(HEADER_NAME)} is constrained to {@code String} by a {@code
+ * String[] value()} element just as it would be inside braces.
+ *
+ * <p>Reading the declared {@code String[]} as this value's own type instead leaves the name looking
+ * unconstrained, which sends it to the guess that a name in an annotation argument is an enum
+ * constant -- and an enum constant cannot be converted to the declared {@code String}.
+ */
+public class AnnotationArgUnbracedArrayTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "annotationargunbracedarray",
+        new String[] {"org/example/Target.java"},
+        new String[] {"org.example.Target#target(String)"});
+  }
+}

--- a/src/test/resources/annotationargknownarraytype/expected/external/Constants.java
+++ b/src/test/resources/annotationargknownarraytype/expected/external/Constants.java
@@ -1,0 +1,4 @@
+package external;
+public class Constants {
+    public static final java.lang.String HEADER_NAME = "";
+}

--- a/src/test/resources/annotationargknownarraytype/expected/org/example/Header.java
+++ b/src/test/resources/annotationargknownarraytype/expected/org/example/Header.java
@@ -1,0 +1,6 @@
+package org.example;
+
+public @interface Header {
+
+  String[] value();
+}

--- a/src/test/resources/annotationargknownarraytype/expected/org/example/Target.java
+++ b/src/test/resources/annotationargknownarraytype/expected/org/example/Target.java
@@ -1,0 +1,13 @@
+package org.example;
+
+import static external.Constants.HEADER_NAME;
+
+@Header({HEADER_NAME})
+public class Target {
+
+  public void target(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/src/test/resources/annotationargknownarraytype/input/org/example/Header.java
+++ b/src/test/resources/annotationargknownarraytype/input/org/example/Header.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public @interface Header {
+  String[] value();
+}

--- a/src/test/resources/annotationargknownarraytype/input/org/example/Target.java
+++ b/src/test/resources/annotationargknownarraytype/input/org/example/Target.java
@@ -1,0 +1,12 @@
+package org.example;
+
+import static external.Constants.HEADER_NAME;
+
+@Header({HEADER_NAME})
+public class Target {
+  public void target(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/src/test/resources/annotationargknowntype/expected/external/Constants.java
+++ b/src/test/resources/annotationargknowntype/expected/external/Constants.java
@@ -1,0 +1,4 @@
+package external;
+public class Constants {
+    public static final java.lang.String HEADER_NAME = "";
+}

--- a/src/test/resources/annotationargknowntype/expected/org/example/Header.java
+++ b/src/test/resources/annotationargknowntype/expected/org/example/Header.java
@@ -1,0 +1,6 @@
+package org.example;
+
+public @interface Header {
+
+  String value();
+}

--- a/src/test/resources/annotationargknowntype/expected/org/example/Target.java
+++ b/src/test/resources/annotationargknowntype/expected/org/example/Target.java
@@ -1,0 +1,13 @@
+package org.example;
+
+import static external.Constants.HEADER_NAME;
+
+@Header(HEADER_NAME)
+public class Target {
+
+  public void target(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/src/test/resources/annotationargknowntype/input/org/example/Header.java
+++ b/src/test/resources/annotationargknowntype/input/org/example/Header.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public @interface Header {
+  String value();
+}

--- a/src/test/resources/annotationargknowntype/input/org/example/Target.java
+++ b/src/test/resources/annotationargknowntype/input/org/example/Target.java
@@ -1,0 +1,12 @@
+package org.example;
+
+import static external.Constants.HEADER_NAME;
+
+@Header(HEADER_NAME)
+public class Target {
+  public void target(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/src/test/resources/annotationargknowntypequalified/expected/external/Constants.java
+++ b/src/test/resources/annotationargknowntypequalified/expected/external/Constants.java
@@ -1,0 +1,4 @@
+package external;
+public class Constants {
+    public static final java.lang.String HEADER_NAME = "";
+}

--- a/src/test/resources/annotationargknowntypequalified/expected/org/example/Header.java
+++ b/src/test/resources/annotationargknowntypequalified/expected/org/example/Header.java
@@ -1,0 +1,6 @@
+package org.example;
+
+public @interface Header {
+
+  String value();
+}

--- a/src/test/resources/annotationargknowntypequalified/expected/org/example/Target.java
+++ b/src/test/resources/annotationargknowntypequalified/expected/org/example/Target.java
@@ -1,0 +1,13 @@
+package org.example;
+
+import external.Constants;
+
+@Header(Constants.HEADER_NAME)
+public class Target {
+
+  public void target(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/src/test/resources/annotationargknowntypequalified/input/org/example/Header.java
+++ b/src/test/resources/annotationargknowntypequalified/input/org/example/Header.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public @interface Header {
+  String value();
+}

--- a/src/test/resources/annotationargknowntypequalified/input/org/example/Target.java
+++ b/src/test/resources/annotationargknowntypequalified/input/org/example/Target.java
@@ -1,0 +1,12 @@
+package org.example;
+
+import external.Constants;
+
+@Header(Constants.HEADER_NAME)
+public class Target {
+  public void target(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/src/test/resources/annotationargstaticimport/expected/external/Constants.java
+++ b/src/test/resources/annotationargstaticimport/expected/external/Constants.java
@@ -1,0 +1,5 @@
+package external;
+public enum Constants {
+    HEADER_NAME,
+    ;
+}

--- a/src/test/resources/annotationargstaticimport/expected/external/Header.java
+++ b/src/test/resources/annotationargstaticimport/expected/external/Header.java
@@ -1,0 +1,6 @@
+package external;
+@java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
+public @interface Header {
+
+    public external.Constants value();
+}

--- a/src/test/resources/annotationargstaticimport/expected/org/example/Target.java
+++ b/src/test/resources/annotationargstaticimport/expected/org/example/Target.java
@@ -1,0 +1,15 @@
+package org.example;
+
+import static external.Constants.HEADER_NAME;
+
+import external.Header;
+
+@Header(HEADER_NAME)
+public class Target {
+
+  public void target(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/src/test/resources/annotationargstaticimport/input/org/example/Target.java
+++ b/src/test/resources/annotationargstaticimport/input/org/example/Target.java
@@ -1,0 +1,14 @@
+package org.example;
+
+import static external.Constants.HEADER_NAME;
+
+import external.Header;
+
+@Header(HEADER_NAME)
+public class Target {
+  public void target(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/src/test/resources/annotationargunbracedarray/expected/external/Constants.java
+++ b/src/test/resources/annotationargunbracedarray/expected/external/Constants.java
@@ -1,0 +1,4 @@
+package external;
+public class Constants {
+    public static final java.lang.String HEADER_NAME = "";
+}

--- a/src/test/resources/annotationargunbracedarray/expected/org/example/Header.java
+++ b/src/test/resources/annotationargunbracedarray/expected/org/example/Header.java
@@ -1,0 +1,6 @@
+package org.example;
+
+public @interface Header {
+
+  String[] value();
+}

--- a/src/test/resources/annotationargunbracedarray/expected/org/example/Target.java
+++ b/src/test/resources/annotationargunbracedarray/expected/org/example/Target.java
@@ -1,0 +1,13 @@
+package org.example;
+
+import static external.Constants.HEADER_NAME;
+
+@Header(HEADER_NAME)
+public class Target {
+
+  public void target(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/src/test/resources/annotationargunbracedarray/input/org/example/Header.java
+++ b/src/test/resources/annotationargunbracedarray/input/org/example/Header.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public @interface Header {
+  String[] value();
+}

--- a/src/test/resources/annotationargunbracedarray/input/org/example/Target.java
+++ b/src/test/resources/annotationargunbracedarray/input/org/example/Target.java
@@ -1,0 +1,12 @@
+package org.example;
+
+import static external.Constants.HEADER_NAME;
+
+@Header(HEADER_NAME)
+public class Target {
+  public void target(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException();
+    }
+  }
+}


### PR DESCRIPTION
Fixes #524. Also fixes an adjacent, closely-related problem: synthetic annotation arguments of type String need to be initialized to a constant value (since annotation argument are a constant context; see #490 and #492), which `null` is not. So, add a case for choosing the initializer value that returns `""`.

This PR also includes some refactoring to the code added by #492 to reduce duplication.