### PR TITLE
Resolve type names in anonymous classes and include implicitly-declared java.lang types in list of possible FQNs for a simple name

### DIFF
--- a/src/main/java/org/checkerframework/specimin/Resolver.java
+++ b/src/main/java/org/checkerframework/specimin/Resolver.java
@@ -11,6 +11,7 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
+import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.resolution.MethodAmbiguityException;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
@@ -201,19 +202,28 @@ public class Resolver {
       if (result != null) {
         return result;
       }
+    }
 
-      result = JavaParserUtil.tryResolveNodeIfInAnonymousClass(expr);
+    // Nothing resolves inside an anonymous class whose supertype is unsolvable, because
+    // JavaParser builds a JavaParserAnonymousClassDeclaration (which resolves that supertype)
+    // before it looks up the name. For example, even a java.lang type named in the body of such
+    // is considered "unsolvable" by JavaParser. We only retry expressions and types, because those
+    // denote the same thing wherever they are written; the alternative resolution strategy here
+    // tries to hoist them out of the anonymous class and checks if they resolve there.
+    if (unsolvable instanceof Expression || unsolvable instanceof Type) {
+      Object resolvedOutsideAnonymousClass =
+          JavaParserUtil.tryResolveNodeIfInAnonymousClass(unsolvable);
+
+      if (resolvedOutsideAnonymousClass != null) {
+        return resolvedOutsideAnonymousClass;
+      }
+    }
+
+    if (unsolvable instanceof MethodCallExpr methodCallExpr) {
+      Object result = handleUnresolvableRecordMember(methodCallExpr);
 
       if (result != null) {
         return result;
-      }
-
-      if (expr.isMethodCallExpr()) {
-        result = handleUnresolvableRecordMember(expr.asMethodCallExpr());
-
-        if (result != null) {
-          return result;
-        }
       }
     }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -2442,6 +2442,10 @@ public class FullyQualifiedNameGenerator {
       }
     }
 
+    // The implicit "import java.lang.*" (JLS 7.5.5) is not written in the file, so it has to be
+    // modelled here, or else a java.lang type gets guessed into the enclosing package instead.
+    String javaLangFQN = getJavaLangFQNIfInScope(firstIdentifier, fullName, compilationUnit);
+
     // Not imported
     boolean shouldAddAfter = false;
     if (fullName.contains(".") && !fullName.contains(" ")) {
@@ -2491,7 +2495,45 @@ public class FullyQualifiedNameGenerator {
         }
       }
     }
+
+    if (javaLangFQN != null) {
+      // A real java.lang type beats every guess here, all of which name a class that Specimin
+      // would have to invent.
+      Set<String> withJavaLang = new LinkedHashSet<>();
+      withJavaLang.add(javaLangFQN);
+      withJavaLang.addAll(fqns);
+      return withJavaLang;
+    }
+
     return fqns;
+  }
+
+  /**
+   * Returns the fully-qualified java.lang name that an unresolvable simple name could refer to via
+   * the implicit {@code import java.lang.*}, or null if it could not refer to one.
+   *
+   * @param firstIdentifier The leftmost identifier of the class name/class path
+   * @param fullName The full, known name of the class
+   * @param compilationUnit The compilation unit in which the name appears
+   * @return The java.lang FQN this name could denote, or null if there is none
+   */
+  private @Nullable String getJavaLangFQNIfInScope(
+      String firstIdentifier, String fullName, CompilationUnit compilationUnit) {
+    if (JavaLangUtils.isPrimitive(firstIdentifier)
+        || !JavaLangUtils.isJavaLangOrPrimitiveName(firstIdentifier)) {
+      return null;
+    }
+
+    // A type declared in the compilation unit's own package shadows the implicit import
+    // (JLS 6.5.5.1), so java.lang only applies if the input declares no such type.
+    Optional<PackageDeclaration> packageDecl = compilationUnit.getPackageDeclaration();
+    String packagePrefix = packageDecl.isPresent() ? packageDecl.get().getNameAsString() + "." : "";
+
+    if (fqnToCompilationUnits.containsKey(packagePrefix + firstIdentifier)) {
+      return null;
+    }
+
+    return "java.lang." + fullName;
   }
 
   /**

--- a/src/test/java/org/checkerframework/specimin/JavaLangExceptionTest.java
+++ b/src/test/java/org/checkerframework/specimin/JavaLangExceptionTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that the {@code Exception} in the throws clause of an anonymous class' override
+ * is recognized as {@code java.lang.Exception}, rather than being guessed into the enclosing
+ * package. Nothing resolves inside an anonymous class whose supertype is unsolvable, so before
+ * issue 525 was fixed, this fell back to the guessing logic, which did not model the implicit
+ * {@code import java.lang.*} (JLS 7.5.5) and so named a nonexistent {@code example.Exception}.
+ *
+ * <p>An override may only throw checked exceptions that the overridden method throws (JLS 8.4.8.3),
+ * so {@code java.lang.Exception} is also the right thing for the synthetic supertype to declare.
+ */
+public class JavaLangExceptionTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "javalangexception",
+        new String[] {"example/Target.java"},
+        new String[] {"example.Target#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/JavaLangParamTypeTest.java
+++ b/src/test/java/org/checkerframework/specimin/JavaLangParamTypeTest.java
@@ -1,0 +1,21 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that a java.lang type named in the body of an anonymous class whose supertype is
+ * unsolvable is recognized as such, rather than being guessed into the enclosing package. The
+ * override's parameter type must be identical to the overridden method's (JLS 8.4.2), so the
+ * synthetic supertype has to declare {@code started(java.lang.String)}. This is the same bug as
+ * {@link JavaLangExceptionTest} (issue 525), on a parameter type rather than a throws clause.
+ */
+public class JavaLangParamTypeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "javalangparamtype",
+        new String[] {"example/Target.java"},
+        new String[] {"example.Target#target()"});
+  }
+}

--- a/src/test/resources/javalangexception/expected/example/Target.java
+++ b/src/test/resources/javalangexception/expected/example/Target.java
@@ -1,0 +1,15 @@
+package example;
+
+import library.Listener;
+
+public final class Target {
+
+  public void target() {
+    Listener listener =
+        new Listener() {
+
+          public void started() throws Exception {}
+        };
+    listener.toString();
+  }
+}

--- a/src/test/resources/javalangexception/expected/library/Listener.java
+++ b/src/test/resources/javalangexception/expected/library/Listener.java
@@ -1,0 +1,15 @@
+package library;
+public class Listener {
+
+    public java.lang.String toString() {
+        throw new java.lang.Error();
+    }
+
+    public Listener() {
+        throw new java.lang.Error();
+    }
+
+    public void started() throws java.lang.Exception {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/javalangexception/input/example/Target.java
+++ b/src/test/resources/javalangexception/input/example/Target.java
@@ -1,0 +1,14 @@
+package example;
+
+import library.Listener;
+
+public final class Target {
+  public void target() {
+    Listener listener =
+        new Listener() {
+          @Override
+          public void started() throws Exception {}
+        };
+    listener.toString();
+  }
+}

--- a/src/test/resources/javalangparamtype/expected/example/Target.java
+++ b/src/test/resources/javalangparamtype/expected/example/Target.java
@@ -1,0 +1,15 @@
+package example;
+
+import library.Listener;
+
+public final class Target {
+
+  public void target() {
+    Listener listener =
+        new Listener() {
+
+          public void started(String name) {}
+        };
+    listener.toString();
+  }
+}

--- a/src/test/resources/javalangparamtype/expected/library/Listener.java
+++ b/src/test/resources/javalangparamtype/expected/library/Listener.java
@@ -1,0 +1,15 @@
+package library;
+public class Listener {
+
+    public java.lang.String toString() {
+        throw new java.lang.Error();
+    }
+
+    public Listener() {
+        throw new java.lang.Error();
+    }
+
+    public void started(java.lang.String parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/javalangparamtype/input/example/Target.java
+++ b/src/test/resources/javalangparamtype/input/example/Target.java
@@ -1,0 +1,14 @@
+package example;
+
+import library.Listener;
+
+public final class Target {
+  public void target() {
+    Listener listener =
+        new Listener() {
+          @Override
+          public void started(String name) {}
+        };
+    listener.toString();
+  }
+}


### PR DESCRIPTION
Either of these fixes should, on its own, prevent #525. I implemented both defensively, since I view both as bugs:
* the first fix (in `Resolver.java`) extends a workaround for a JavaParser limitation to types, in addition to expressions. In an anonymous class with an unsolved superclass, JavaParser can't resolve anything. We hoisted expressions out of the anonymous class to check if they're resolvable there; this fix does the same for types. We can't do this for all nodes because not all nodes have the same meaning regardless of source position.
* the second fix (in `FullyQualifiedNameGenerator.java`) explicitly models the possibility that a simple name may refer to a java.lang class. This was just an oversight on our part when writing that logic - there's no reason we shouldn't have already considered the possibility.

I tested both fixes independently and either one would have prevented the miscompilation in #525. Since they're both safe, I see no reason not to merge both.