### PR TITLE
Better model inner class constructors

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -3178,7 +3178,7 @@ public class JavaParserUtil {
 
     ClassOrInterfaceType asClassOrInterface = scope.asTypeExpr().getType().asClassOrInterfaceType();
 
-    if (asClassOrInterface.getScope().isPresent()
+    if (QualifiedTypeName.of(asClassOrInterface).isQualified()
         || asClassOrInterface.getTypeArguments().isPresent()) {
       // A qualified name or an explicitly parameterized name is unambiguously a type.
       return null;

--- a/src/main/java/org/checkerframework/specimin/QualifiedTypeName.java
+++ b/src/main/java/org/checkerframework/specimin/QualifiedTypeName.java
@@ -12,22 +12,23 @@ import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
 /**
  * A type name decomposed into its identifiers: {@code library.Outer.Nested} becomes {@code
  * [library, Outer, Nested]}. Specifically, this class can answer questions about:
- *  <ul>
- *    <li>the <b>first identifier</b> is the one a single-type-import must be matched against (JLS
- *        6.5.5.2 resolves {@code Outer.Nested} by first resolving {@code Outer}, so it is {@code
- *        Outer} that {@code import library.Outer;} binds), and
- *    <li>the <b>simple name</b> is the last identifier (JLS 6.2), which is the name a constructor
- *        declaration must use (JLS 8.8.1) and the name the type is declared under.
- *  </ul>
  *
- * <p>Deciding where a name's package part ends and its type part begins does <em>not</em> have
- * an exact answer in the general case, and is not handled by this class: JLS 6.5.2 asks whether package
- * {@code Q} contains a type {@code Id}, which needs a classpath that Specimin may not have.
+ * <ul>
+ *   <li>the <b>first identifier</b> is the one a single-type-import must be matched against (JLS
+ *       6.5.5.2 resolves {@code Outer.Nested} by first resolving {@code Outer}, so it is {@code
+ *       Outer} that {@code import library.Outer;} binds), and
+ *   <li>the <b>simple name</b> is the last identifier (JLS 6.2), which is the name a constructor
+ *       declaration must use (JLS 8.8.1) and the name the type is declared under.
+ * </ul>
+ *
+ * <p>Deciding where a name's package part ends and its type part begins does <em>not</em> have an
+ * exact answer in the general case, and is not handled by this class: JLS 6.5.2 asks whether
+ * package {@code Q} contains a type {@code Id}, which needs a classpath that Specimin may not have.
  * Naming convention logic is used to guess the answer to that question via {@link
  * JavaParserUtil#isProbablyAPackage(String)} and {@link JavaParserUtil#isAClassPath(String)}.
  *
- * <p>Prefer this class' AST factories over {@link #parse(String)}: a name that is still attached to source
- * carries its own structure, so reading it needs no string surgery. Type arguments and array
+ * <p>Prefer this class' AST factories over {@link #parse(String)}: a name that is still attached to
+ * source carries its own structure, so reading it needs no string surgery. Type arguments and array
  * brackets are not part of a type's name and are dropped by every factory.
  */
 public final class QualifiedTypeName {
@@ -88,8 +89,8 @@ public final class QualifiedTypeName {
    * out in a {@code NameExpr} that a qualified name takes anywhere else.
    *
    * <p>Callers that reach this method by way of a naming-convention guess, such as {@link
-   * JavaParserUtil#isAClassPath(String)}, are still asking an exact question of it: given
-   * that this name denotes a type, what are its identifiers?
+   * JavaParserUtil#isAClassPath(String)}, are still asking an exact question of it: given that this
+   * name denotes a type, what are its identifiers?
    *
    * @param expr the expression
    * @return the decomposition of the name {@code expr} writes, or null if {@code expr} is not a

--- a/src/main/java/org/checkerframework/specimin/QualifiedTypeName.java
+++ b/src/main/java/org/checkerframework/specimin/QualifiedTypeName.java
@@ -1,0 +1,209 @@
+package org.checkerframework.specimin;
+
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
+
+/**
+ * A type name decomposed into its identifiers: {@code library.Outer.Nested} becomes {@code
+ * [library, Outer, Nested]}.
+ *
+ * <p>This class answers only the questions that have exact answers. Deciding where a name's package
+ * part ends and its type part begins does <em>not</em> have one: JLS 6.5.2 asks whether package
+ * {@code Q} contains a type {@code Id}, which needs a classpath that Specimin does not have for an
+ * unsolvable name. That question is a naming-convention guess, and it lives in {@link
+ * JavaParserUtil#isProbablyAPackage(String)} and {@link JavaParserUtil#isAClassPath(String)}.
+ *
+ * <p>What is exact is the decomposition itself, and the two ends of it:
+ *
+ * <ul>
+ *   <li>the <b>first identifier</b> is the one a single-type-import must be matched against (JLS
+ *       6.5.5.2 resolves {@code Outer.Nested} by first resolving {@code Outer}, so it is {@code
+ *       Outer} that {@code import library.Outer;} binds), and
+ *   <li>the <b>simple name</b> is the last identifier (JLS 6.2), which is the name a constructor
+ *       declaration must use (JLS 8.8.1) and the name the type is declared under.
+ * </ul>
+ *
+ * <p>Prefer the AST factories over {@link #parse(String)}: a name that is still attached to source
+ * carries its own structure, so reading it needs no string surgery. Type arguments and array
+ * brackets are not part of a type's name and are dropped by every factory.
+ */
+public final class QualifiedTypeName {
+  /** The identifiers of this name, leftmost first. Never empty. */
+  private final List<String> identifiers;
+
+  /**
+   * Creates a new QualifiedTypeName. Private; use the factory methods.
+   *
+   * @param identifiers the identifiers of the name, leftmost first; must not be empty
+   */
+  private QualifiedTypeName(List<String> identifiers) {
+    if (identifiers.isEmpty()) {
+      throw new IllegalArgumentException("A type name must have at least one identifier.");
+    }
+    this.identifiers = Collections.unmodifiableList(new ArrayList<>(identifiers));
+  }
+
+  /**
+   * Returns the decomposition of a type name as it is written in source.
+   *
+   * @param type the type
+   * @return the decomposition of {@code type}'s name
+   */
+  public static QualifiedTypeName of(ClassOrInterfaceType type) {
+    List<String> identifiers = new ArrayList<>();
+
+    for (ClassOrInterfaceType part = type; part != null; part = part.getScope().orElse(null)) {
+      identifiers.add(part.getNameAsString());
+    }
+
+    Collections.reverse(identifiers);
+    return new QualifiedTypeName(identifiers);
+  }
+
+  /**
+   * Returns the decomposition of a name node, such as the name of an annotation.
+   *
+   * @param name the name
+   * @return the decomposition of {@code name}
+   */
+  public static QualifiedTypeName of(Name name) {
+    List<String> identifiers = new ArrayList<>();
+
+    for (Name part = name; part != null; part = part.getQualifier().orElse(null)) {
+      identifiers.add(part.getIdentifier());
+    }
+
+    Collections.reverse(identifiers);
+    return new QualifiedTypeName(identifiers);
+  }
+
+  /**
+   * Returns the decomposition of an expression that names a type. Every shape a type name can take
+   * in an expression position is accepted: a {@code TypeExpr} (which is how JavaParser wraps the
+   * scope of a method reference, whether or not that scope really is a type -- see {@link
+   * JavaParserUtil#getMethodRefScopeAsVariable}), and the {@code FieldAccessExpr} chain bottoming
+   * out in a {@code NameExpr} that a qualified name takes anywhere else.
+   *
+   * <p>Callers that reach this method by way of a naming-convention guess -- {@link
+   * JavaParserUtil#isAClassPath(String)}, say -- are still asking an exact question of it: given
+   * that this name denotes a type, what are its identifiers?
+   *
+   * @param expr the expression
+   * @return the decomposition of the name {@code expr} writes, or null if {@code expr} is not a
+   *     name
+   */
+  public static @Nullable QualifiedTypeName ofTypeName(Expression expr) {
+    if (expr.isTypeExpr()) {
+      return expr.asTypeExpr().getType().isClassOrInterfaceType()
+          ? of(expr.asTypeExpr().getType().asClassOrInterfaceType())
+          : null;
+    }
+
+    List<String> identifiers = new ArrayList<>();
+
+    for (Expression part = expr; ; ) {
+      if (part.isFieldAccessExpr()) {
+        identifiers.add(part.asFieldAccessExpr().getNameAsString());
+        part = part.asFieldAccessExpr().getScope();
+      } else if (part.isNameExpr()) {
+        identifiers.add(part.asNameExpr().getNameAsString());
+        break;
+      } else {
+        return null;
+      }
+    }
+
+    Collections.reverse(identifiers);
+    return new QualifiedTypeName(identifiers);
+  }
+
+  /**
+   * Returns the decomposition of a dotted name. Use an AST factory instead wherever the name is
+   * still attached to source.
+   *
+   * @param dotted a type name, such as a fully-qualified name; may carry type arguments or array
+   *     brackets, which are dropped
+   * @return the decomposition of {@code dotted}
+   */
+  public static QualifiedTypeName parse(String dotted) {
+    String name = JavaParserUtil.removeArrayBrackets(JavaParserUtil.erase(dotted));
+
+    return new QualifiedTypeName(List.of(name.split("\\.", -1)));
+  }
+
+  /**
+   * Returns the leftmost identifier of this name. This is the identifier that names either the
+   * outermost enclosing type or the first segment of the package, and so is the one that an import
+   * declaration can bind (JLS 6.5.5.2).
+   *
+   * @return the leftmost identifier
+   */
+  public String firstIdentifier() {
+    return identifiers.get(0);
+  }
+
+  /**
+   * Returns the simple name of the type this name denotes: its rightmost identifier (JLS 6.2).
+   *
+   * @return the simple name
+   */
+  @SuppressWarnings("signature") // an identifier of a type name is that type's simple name
+  public @ClassGetSimpleName String simpleName() {
+    return identifiers.get(identifiers.size() - 1);
+  }
+
+  /**
+   * Returns this name without its last identifier: the name of the package or of the enclosing type
+   * that qualifies it. Which of those two it is cannot be decided here; see the class
+   * documentation.
+   *
+   * @return the qualifier, or null if this name is unqualified
+   */
+  public @Nullable QualifiedTypeName enclosingName() {
+    return isQualified()
+        ? new QualifiedTypeName(identifiers.subList(0, identifiers.size() - 1))
+        : null;
+  }
+
+  /**
+   * Returns whether this name is qualified, i.e. whether it has more than one identifier. A
+   * qualified name is unambiguously a type name in a method reference scope, where a simple name is
+   * not (JLS 15.13).
+   *
+   * @return true if this name has a qualifier
+   */
+  public boolean isQualified() {
+    return identifiers.size() > 1;
+  }
+
+  /**
+   * Returns the identifiers of this name, leftmost first. The list is read-only and never empty.
+   *
+   * @return the identifiers
+   */
+  public List<String> identifiers() {
+    return identifiers;
+  }
+
+  @Override
+  public String toString() {
+    return String.join(".", identifiers);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object other) {
+    return other instanceof QualifiedTypeName otherName
+        && identifiers.equals(otherName.identifiers);
+  }
+
+  @Override
+  public int hashCode() {
+    return identifiers.hashCode();
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/QualifiedTypeName.java
+++ b/src/main/java/org/checkerframework/specimin/QualifiedTypeName.java
@@ -11,25 +11,22 @@ import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
 
 /**
  * A type name decomposed into its identifiers: {@code library.Outer.Nested} becomes {@code
- * [library, Outer, Nested]}.
+ * [library, Outer, Nested]}. Specifically, this class can answer questions about:
+ *  <ul>
+ *    <li>the <b>first identifier</b> is the one a single-type-import must be matched against (JLS
+ *        6.5.5.2 resolves {@code Outer.Nested} by first resolving {@code Outer}, so it is {@code
+ *        Outer} that {@code import library.Outer;} binds), and
+ *    <li>the <b>simple name</b> is the last identifier (JLS 6.2), which is the name a constructor
+ *        declaration must use (JLS 8.8.1) and the name the type is declared under.
+ *  </ul>
  *
- * <p>This class answers only the questions that have exact answers. Deciding where a name's package
- * part ends and its type part begins does <em>not</em> have one: JLS 6.5.2 asks whether package
- * {@code Q} contains a type {@code Id}, which needs a classpath that Specimin does not have for an
- * unsolvable name. That question is a naming-convention guess, and it lives in {@link
+ * <p>Deciding where a name's package part ends and its type part begins does <em>not</em> have
+ * an exact answer in the general case, and is not handled by this class: JLS 6.5.2 asks whether package
+ * {@code Q} contains a type {@code Id}, which needs a classpath that Specimin may not have.
+ * Naming convention logic is used to guess the answer to that question via {@link
  * JavaParserUtil#isProbablyAPackage(String)} and {@link JavaParserUtil#isAClassPath(String)}.
  *
- * <p>What is exact is the decomposition itself, and the two ends of it:
- *
- * <ul>
- *   <li>the <b>first identifier</b> is the one a single-type-import must be matched against (JLS
- *       6.5.5.2 resolves {@code Outer.Nested} by first resolving {@code Outer}, so it is {@code
- *       Outer} that {@code import library.Outer;} binds), and
- *   <li>the <b>simple name</b> is the last identifier (JLS 6.2), which is the name a constructor
- *       declaration must use (JLS 8.8.1) and the name the type is declared under.
- * </ul>
- *
- * <p>Prefer the AST factories over {@link #parse(String)}: a name that is still attached to source
+ * <p>Prefer this class' AST factories over {@link #parse(String)}: a name that is still attached to source
  * carries its own structure, so reading it needs no string surgery. Type arguments and array
  * brackets are not part of a type's name and are dropped by every factory.
  */
@@ -90,8 +87,8 @@ public final class QualifiedTypeName {
    * JavaParserUtil#getMethodRefScopeAsVariable}), and the {@code FieldAccessExpr} chain bottoming
    * out in a {@code NameExpr} that a qualified name takes anywhere else.
    *
-   * <p>Callers that reach this method by way of a naming-convention guess -- {@link
-   * JavaParserUtil#isAClassPath(String)}, say -- are still asking an exact question of it: given
+   * <p>Callers that reach this method by way of a naming-convention guess, such as {@link
+   * JavaParserUtil#isAClassPath(String)}, are still asking an exact question of it: given
    * that this name denotes a type, what are its identifiers?
    *
    * @param expr the expression
@@ -160,8 +157,7 @@ public final class QualifiedTypeName {
 
   /**
    * Returns this name without its last identifier: the name of the package or of the enclosing type
-   * that qualifies it. Which of those two it is cannot be decided here; see the class
-   * documentation.
+   * that qualifies it. Which of those two it is cannot be decided here.
    *
    * @return the qualifier, or null if this name is unqualified
    */
@@ -172,9 +168,7 @@ public final class QualifiedTypeName {
   }
 
   /**
-   * Returns whether this name is qualified, i.e. whether it has more than one identifier. A
-   * qualified name is unambiguously a type name in a method reference scope, where a simple name is
-   * not (JLS 15.13).
+   * Returns whether this name is qualified, i.e. whether it has more than one identifier.
    *
    * @return true if this name has a qualifier
    */

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -1033,11 +1033,12 @@ public class FullyQualifiedNameGenerator {
         }
       }
 
-      Set<UnsolvedMethodAlternates> generatedMethods = new LinkedHashSet<>();
+      // A ::new reference resolves to a constructor, so this cannot be narrowed to methods.
+      Set<UnsolvedCallableAlternates<?>> generatedMethods = new LinkedHashSet<>();
 
       for (Entry<String, UnsolvedSymbolAlternates<?>> genSymbolEntry :
           generatedSymbols.entrySet()) {
-        if (!(genSymbolEntry.getValue() instanceof UnsolvedMethodAlternates method)) {
+        if (!(genSymbolEntry.getValue() instanceof UnsolvedCallableAlternates<?> method)) {
           continue;
         }
 
@@ -1052,11 +1053,16 @@ public class FullyQualifiedNameGenerator {
       if (!generatedMethods.isEmpty()) {
         Set<FullyQualifiedNameSet> functionalInterfaces = new LinkedHashSet<>();
 
-        for (UnsolvedMethodAlternates method : generatedMethods) {
-          for (UnsolvedMethod alternate : method.getAlternates()) {
+        for (UnsolvedCallableAlternates<?> method : generatedMethods) {
+          for (UnsolvedCallable alternate : method.getAlternates()) {
             List<FullyQualifiedNameSet> parameterTypes = new ArrayList<>();
 
-            if (!method.isStatic() && JavaParserUtil.methodRefHasTypeScope(methodRef)) {
+            // An unbound reference to an instance method takes the receiver as an extra leading
+            // parameter. A constructor reference does not: its scope names the type being
+            // instantiated, not a receiver, so its parameters are the constructor's one for one.
+            if (!(alternate instanceof UnsolvedConstructor)
+                && !method.isStatic()
+                && JavaParserUtil.methodRefHasTypeScope(methodRef)) {
               parameterTypes.add(getFQNsFromType(methodRef.getScope().asTypeExpr().getType()));
             }
 
@@ -1070,7 +1076,8 @@ public class FullyQualifiedNameGenerator {
             functionalInterfaces.add(
                 getQualifiedNameOfFunctionalInterface(
                     parameterTypes,
-                    !isConstructor && alternate.getReturnType().toString().equals("void")));
+                    !(alternate instanceof UnsolvedConstructor)
+                        && alternate.getReturnType().toString().equals("void")));
           }
         }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -22,7 +22,6 @@ import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
-import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.SwitchExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
@@ -80,6 +79,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
 import org.checkerframework.specimin.JavaLangUtils;
 import org.checkerframework.specimin.JavaParserUtil;
+import org.checkerframework.specimin.QualifiedTypeName;
 import org.checkerframework.specimin.Resolver;
 
 /**
@@ -588,17 +588,17 @@ public class FullyQualifiedNameGenerator {
     else if (JavaParserUtil.isAClassPath(expr.toString())
         || (expr.isFieldAccessExpr()
             && JavaParserUtil.isAQualifiedTypeName(expr.asFieldAccessExpr()))) {
-      Expression scoped = expr;
+      QualifiedTypeName name = QualifiedTypeName.ofTypeName(expr);
 
-      while (scoped instanceof NodeWithTraversableScope
-          && ((NodeWithTraversableScope) scoped).traverseScope().isPresent()) {
-        scoped = ((NodeWithTraversableScope) scoped).traverseScope().get();
-      }
+      // An expression that writes no name has no identifiers to read, so its text is all there is
+      // to go on.
+      String firstIdentifier = name == null ? expr.toString() : name.firstIdentifier();
+      String fullName = name == null ? expr.toString() : name.toString();
 
       return Set.of(
           new FullyQualifiedNameSet(
               getFQNsFromErasedClassName(
-                  scoped.toString(), expr.toString(), expr.findCompilationUnit().get(), expr)));
+                  firstIdentifier, fullName, expr.findCompilationUnit().get(), expr)));
     } else if (expr.isNameExpr() && JavaParserUtil.isAClassName(expr.toString())) {
       return Set.of(
           new FullyQualifiedNameSet(
@@ -2318,21 +2318,13 @@ public class FullyQualifiedNameGenerator {
       return new FullyQualifiedNameSet(type.getNameAsString());
     }
     // If a ClassOrInterfaceType is Map.Entry, we need to find the import with java.util.Map, not
-    // java.util.Map.Entry.
-    // Hence, look for the import with the "earliest" scope (with Map.Entry, this would be Map).
-    String getImportedName = type.getNameAsString();
-
-    Optional<ClassOrInterfaceType> scope = type.getScope();
-
-    while (scope.isPresent()) {
-      getImportedName = scope.get().getNameAsString();
-      scope = scope.get().getScope();
-    }
+    // java.util.Map.Entry: it is the first identifier that an import binds (JLS 6.5.5.2).
+    QualifiedTypeName name = QualifiedTypeName.of(type);
 
     Set<String> erasedFQNs =
         getFQNsFromErasedClassNameImpl(
-            JavaParserUtil.erase(getImportedName),
-            JavaParserUtil.erase(type.getNameWithScope()),
+            name.firstIdentifier(),
+            name.toString(),
             type.findCompilationUnit().get(),
             type,
             alreadyTraversed);
@@ -2357,16 +2349,8 @@ public class FullyQualifiedNameGenerator {
    */
   public FullyQualifiedNameSet getFQNsFromAnnotation(AnnotationExpr anno) {
     // If an annotation is @Foo.Bar, we need to find the import with org.example.Foo, not
-    // org.example.Foo.Bar.
-    // Hence, look for the import with the "earliest" scope (with @Foo.Bar, this would be Foo).
-    String getImportedName = anno.getNameAsString();
-
-    Optional<Name> scope = anno.getName().getQualifier();
-
-    while (scope.isPresent()) {
-      getImportedName = scope.get().asString();
-      scope = scope.get().getQualifier();
-    }
+    // org.example.Foo.Bar: it is the first identifier that an import binds (JLS 6.5.5.2).
+    QualifiedTypeName name = QualifiedTypeName.of(anno.getName());
 
     TypeDeclaration<?> parent = null;
 
@@ -2379,7 +2363,7 @@ public class FullyQualifiedNameGenerator {
 
     return new FullyQualifiedNameSet(
         getFQNsFromErasedClassName(
-            getImportedName, anno.getNameAsString(), anno.findCompilationUnit().get(), parent));
+            name.firstIdentifier(), name.toString(), anno.findCompilationUnit().get(), parent));
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -1033,7 +1033,6 @@ public class FullyQualifiedNameGenerator {
         }
       }
 
-      // A ::new reference resolves to a constructor, so this cannot be narrowed to methods.
       Set<UnsolvedCallableAlternates<?>> generatedMethods = new LinkedHashSet<>();
 
       for (Entry<String, UnsolvedSymbolAlternates<?>> genSymbolEntry :
@@ -1060,8 +1059,8 @@ public class FullyQualifiedNameGenerator {
             // An unbound reference to an instance method takes the receiver as an extra leading
             // parameter. A constructor reference does not: its scope names the type being
             // instantiated, not a receiver, so its parameters are the constructor's one for one.
-            if (!(alternate instanceof UnsolvedConstructor)
-                && !method.isStatic()
+            if (alternate instanceof UnsolvedMethod asMethod
+                && !asMethod.isStatic()
                 && JavaParserUtil.methodRefHasTypeScope(methodRef)) {
               parameterTypes.add(getFQNsFromType(methodRef.getScope().asTypeExpr().getType()));
             }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallable.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallable.java
@@ -1,0 +1,374 @@
+package org.checkerframework.specimin.unsolved;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
+import org.checkerframework.specimin.JavaParserUtil;
+
+/**
+ * A synthetic method or constructor declaration: everything a declaration has whether or not it is
+ * a constructor. {@link UnsolvedMethod} adds a name and a return type; {@link UnsolvedConstructor}
+ * adds neither, because JLS 8.8.1 gives a constructor no return type and fixes its name to the
+ * simple name of the type that declares it.
+ *
+ * <p>The pair matches JavaParser's own split, where {@code MethodDeclaration} and {@code
+ * ConstructorDeclaration} are both {@code CallableDeclaration}s.
+ */
+public abstract class UnsolvedCallable extends UnsolvedSymbolAlternate
+    implements UnsolvedCallableCommon {
+  /** The list of the types of the parameters of this callable. */
+  private final List<MemberType> parameterList;
+
+  /** This field is set to true if this is a static method. */
+  private boolean isStatic;
+
+  /** The list of the types of the exceptions thrown by this callable. */
+  private final List<MemberType> throwsList;
+
+  /**
+   * The names of this callable's type variables, in declaration order.
+   *
+   * <p>These names are the state. Most of a callable's type variables are invented by Specimin and
+   * named by {@link JavaParserUtil#getGeneratedTypeParameterName}, but one that {@link
+   * #declareTypeVariables} binds carries a name that is already written into the signature and
+   * cannot be renamed.
+   */
+  private final List<String> typeVariableNames;
+
+  /** The access modifier of this callable. */
+  private String accessModifier;
+
+  /** The body of this callable. */
+  private String content = "throw new java.lang.Error();";
+
+  /**
+   * Base constructor for a synthetic callable.
+   *
+   * @param parameterList the list of parameters
+   * @param throwsList the list of exceptions thrown
+   * @param mustPreserve the set of nodes that must be preserved with this alternate
+   * @param accessModifier the access modifier
+   * @param isStatic whether this is static
+   * @param typeVariableNames the names of the type variables, in declaration order
+   */
+  protected UnsolvedCallable(
+      List<MemberType> parameterList,
+      List<MemberType> throwsList,
+      Set<Node> mustPreserve,
+      String accessModifier,
+      boolean isStatic,
+      List<String> typeVariableNames) {
+    super(mustPreserve);
+
+    // Parameter and throws lists should be mutable, so copy them to be safe
+    this.parameterList = new ArrayList<>(parameterList);
+    this.throwsList = new ArrayList<>(throwsList);
+
+    this.accessModifier = accessModifier;
+    this.isStatic = isStatic;
+    this.typeVariableNames = new ArrayList<>(typeVariableNames);
+  }
+
+  /**
+   * Returns the first {@code count} generated type variable names.
+   *
+   * @param count how many names to generate
+   * @return the generated names, in order
+   */
+  protected static List<String> generatedTypeVariableNames(int count) {
+    List<String> names = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      names.add(JavaParserUtil.getGeneratedTypeParameterName(i));
+    }
+    return names;
+  }
+
+  /**
+   * Returns the name under which this callable is declared. A method is declared under its own
+   * name; a constructor is declared under the simple name of the type that declares it (JLS 8.8.1),
+   * which is why the declaring type's name has to be supplied here rather than stored.
+   *
+   * @param declaringTypeName the simple name of the type that declares this callable
+   * @return the name to declare this callable under
+   */
+  protected abstract String declaredName(@ClassGetSimpleName String declaringTypeName);
+
+  /**
+   * Returns the text that precedes the declared name in this callable's signature: the return type
+   * followed by a space for a method, and nothing at all for a constructor, which declares no
+   * return type (JLS 8.8.1).
+   *
+   * @return the return type to print, followed by a space, or the empty string
+   */
+  protected abstract String returnTypePrefix();
+
+  /**
+   * Returns the types written into this callable's signature, which are the types that can mention
+   * its type variables: the parameter types, plus a method's return type.
+   *
+   * @return the types in this callable's signature
+   */
+  protected List<MemberType> typesInSignature() {
+    return getParameterList();
+  }
+
+  /**
+   * Get the return type of this callable.
+   *
+   * @return the return type
+   * @throws UnsupportedOperationException if this is a constructor, which declares no return type
+   */
+  public abstract MemberType getReturnType();
+
+  /**
+   * Getter for the parameter list. Note that the list is read-only.
+   *
+   * @return the parameter list
+   */
+  public List<MemberType> getParameterList() {
+    return Collections.unmodifiableList(parameterList);
+  }
+
+  /**
+   * Replaces the type of a parameter in the parameter list with a new type.
+   *
+   * @param oldType The old type
+   * @param newType The new type
+   */
+  public void replaceParameterType(MemberType oldType, MemberType newType) {
+    for (int i = 0; i < parameterList.size(); i++) {
+      if (parameterList.get(i).equals(oldType)) {
+        parameterList.set(i, newType);
+      }
+    }
+  }
+
+  /**
+   * Getter for the throws list. Note that the list is read-only.
+   *
+   * @return the throws list
+   */
+  @Override
+  public List<MemberType> getThrownExceptions() {
+    return Collections.unmodifiableList(throwsList);
+  }
+
+  @Override
+  public void addThrownException(MemberType exception) {
+    if (!throwsList.contains(exception)) {
+      throwsList.add(exception);
+    }
+  }
+
+  /** Set isStatic to true */
+  @Override
+  public void setStatic() {
+    isStatic = true;
+  }
+
+  /**
+   * This method sets the number of type variables for the current class
+   *
+   * @param numberOfTypeVariables number of type variable in this class.
+   */
+  @Override
+  public void setNumberOfTypeVariables(int numberOfTypeVariables) {
+    // Resize rather than replace, so that a name bound by declareTypeVariables at an index below
+    // the new size survives.
+    while (typeVariableNames.size() > numberOfTypeVariables) {
+      typeVariableNames.remove(typeVariableNames.size() - 1);
+    }
+    while (typeVariableNames.size() < numberOfTypeVariables) {
+      typeVariableNames.add(JavaParserUtil.getGeneratedTypeParameterName(typeVariableNames.size()));
+    }
+  }
+
+  /**
+   * Return the content of this callable. Note that the body is stubbed out.
+   *
+   * @param type The type of the declaring type
+   * @param declaringTypeName The simple name of the declaring type, which is the name a constructor
+   *     is declared under (JLS 8.8.1)
+   * @return the declaration with the body stubbed out
+   */
+  public String toString(
+      UnsolvedClassOrInterfaceType type, @ClassGetSimpleName String declaringTypeName) {
+    StringBuilder arguments = new StringBuilder();
+    for (int i = 0; i < parameterList.size(); i++) {
+      MemberType parameterType = parameterList.get(i);
+
+      arguments.append(parameterType).append(" ").append("parameter").append(i);
+      if (i < parameterList.size() - 1) {
+        arguments.append(", ");
+      }
+    }
+    StringBuilder signature = new StringBuilder();
+    if (accessModifier != null) {
+      signature.append(accessModifier);
+      signature.append(" ");
+    }
+
+    if (isStatic) {
+      signature.append("static ");
+    }
+
+    String typeVariables = getTypeVariablesAsString();
+
+    if (!typeVariables.isEmpty()) {
+      signature.append(getTypeVariablesAsString()).append(" ");
+    }
+
+    signature.append(returnTypePrefix());
+    signature.append(declaredName(declaringTypeName)).append("(");
+    signature.append(arguments);
+    signature.append(")");
+
+    if (!throwsList.isEmpty()) {
+      signature.append(" throws ");
+    }
+
+    StringBuilder exceptions = new StringBuilder();
+    for (int i = 0; i < throwsList.size(); i++) {
+      MemberType exception = throwsList.get(i);
+      exceptions.append(exception);
+      if (i < throwsList.size() - 1) {
+        exceptions.append(", ");
+      }
+    }
+    signature.append(exceptions);
+
+    if (type == UnsolvedClassOrInterfaceType.ANNOTATION
+        || type == UnsolvedClassOrInterfaceType.INTERFACE) {
+      return "\n    " + signature + ";\n";
+    } else {
+      return "\n    " + signature + " {\n        " + content + "\n    }\n";
+    }
+  }
+
+  /**
+   * Gets the number of type variables.
+   *
+   * @return The number of type variables
+   */
+  @Override
+  public int getNumberOfTypeVariables() {
+    return typeVariableNames.size();
+  }
+
+  /**
+   * Returns the names of this callable's type variables, in declaration order. Pass this to a
+   * subclass constructor when copying: a name that {@link #declareTypeVariables} bound cannot be
+   * reconstructed from a count.
+   *
+   * @return the type variable names; the list is read-only
+   */
+  public List<String> getTypeVariableNames() {
+    return Collections.unmodifiableList(typeVariableNames);
+  }
+
+  /**
+   * Return a synthetic representation for type variables of the current class.
+   *
+   * @return the synthetic representation for type variables
+   */
+  private String getTypeVariablesAsString() {
+    if (typeVariableNames.isEmpty()) {
+      return "";
+    }
+
+    List<String> used = getTypeVariablesImpl();
+
+    // A type variable may be allocated for this callable but end up used by no alternate's
+    // signature, in which case there is no type parameter section to print at all.
+    if (used.isEmpty()) {
+      return "";
+    }
+
+    return "<" + String.join(", ", used) + ">";
+  }
+
+  /** Gets a list of the type variable names that are used in this callable. */
+  private List<String> getTypeVariablesImpl() {
+    // While it is better to have the exact type number of type variables
+    // on a per-alternate basis, it's easier for other parts of this codebase
+    // to deal with the same number of type variables for all alternates of a given method.
+    // So, we'll deal with that limitation here and not include any type variables
+    // that are not used in this specific alternate.
+
+    // Parse to properly handle type arguments (i.e., a class named TheUnsolved should not be
+    // considered to use T)
+    List<ClassOrInterfaceType> usedTypes = new ArrayList<>();
+    for (MemberType signatureType : typesInSignature()) {
+      Type parsedType = StaticJavaParser.parseType(signatureType.toString());
+
+      if (!parsedType.isClassOrInterfaceType()) {
+        continue;
+      }
+
+      usedTypes.add(parsedType.asClassOrInterfaceType());
+    }
+
+    List<String> usedTypeVariableNames = new ArrayList<>();
+    for (String typeVariableName : typeVariableNames) {
+      for (ClassOrInterfaceType usedType : usedTypes) {
+        if (usedType.findAll(ClassOrInterfaceType.class).stream()
+            .anyMatch(t -> t.getNameAsString().equals(typeVariableName))) {
+          usedTypeVariableNames.add(typeVariableName);
+          break;
+        }
+      }
+    }
+    return usedTypeVariableNames;
+  }
+
+  /**
+   * Given the index of a type variable, return the name of that type variable.
+   *
+   * @param index The index
+   * @return the name of the type variable with the given index
+   * @throws IllegalArgumentException if the index is out of bounds
+   */
+  @Override
+  public String getTypeVariableName(int index) {
+    if (index < 0 || index >= typeVariableNames.size()) {
+      throw new IllegalArgumentException(
+          "Index out of bounds. There are only " + typeVariableNames.size() + " type variables.");
+    }
+    return typeVariableNames.get(index);
+  }
+
+  @Override
+  public void declareTypeVariables(List<String> names) {
+    for (String name : names) {
+      if (!typeVariableNames.contains(name)) {
+        typeVariableNames.add(name);
+      }
+    }
+  }
+
+  @Override
+  public String getAccessModifier() {
+    return accessModifier;
+  }
+
+  @Override
+  public void setAccessModifier(String accessModifier) {
+    this.accessModifier = accessModifier;
+  }
+
+  @Override
+  public void setContent(String content) {
+    this.content = content;
+  }
+
+  @Override
+  public boolean isStatic() {
+    return isStatic;
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallable.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallable.java
@@ -11,22 +11,12 @@ import java.util.Set;
 import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
 import org.checkerframework.specimin.JavaParserUtil;
 
-/**
- * A synthetic method or constructor declaration: everything a declaration has whether or not it is
- * a constructor. {@link UnsolvedMethod} adds a name and a return type; {@link UnsolvedConstructor}
- * adds neither, because JLS 8.8.1 gives a constructor no return type and fixes its name to the
- * simple name of the type that declares it.
- *
- * <p>The pair matches JavaParser's own split, where {@code MethodDeclaration} and {@code
- * ConstructorDeclaration} are both {@code CallableDeclaration}s.
- */
+/** A synthetic method or constructor. */
 public abstract class UnsolvedCallable extends UnsolvedSymbolAlternate
     implements UnsolvedCallableCommon {
+
   /** The list of the types of the parameters of this callable. */
   private final List<MemberType> parameterList;
-
-  /** This field is set to true if this is a static method. */
-  private boolean isStatic;
 
   /** The list of the types of the exceptions thrown by this callable. */
   private final List<MemberType> throwsList;
@@ -54,7 +44,6 @@ public abstract class UnsolvedCallable extends UnsolvedSymbolAlternate
    * @param throwsList the list of exceptions thrown
    * @param mustPreserve the set of nodes that must be preserved with this alternate
    * @param accessModifier the access modifier
-   * @param isStatic whether this is static
    * @param typeVariableNames the names of the type variables, in declaration order
    */
   protected UnsolvedCallable(
@@ -62,7 +51,6 @@ public abstract class UnsolvedCallable extends UnsolvedSymbolAlternate
       List<MemberType> throwsList,
       Set<Node> mustPreserve,
       String accessModifier,
-      boolean isStatic,
       List<String> typeVariableNames) {
     super(mustPreserve);
 
@@ -71,7 +59,6 @@ public abstract class UnsolvedCallable extends UnsolvedSymbolAlternate
     this.throwsList = new ArrayList<>(throwsList);
 
     this.accessModifier = accessModifier;
-    this.isStatic = isStatic;
     this.typeVariableNames = new ArrayList<>(typeVariableNames);
   }
 
@@ -98,6 +85,14 @@ public abstract class UnsolvedCallable extends UnsolvedSymbolAlternate
    * @return the name to declare this callable under
    */
   protected abstract String declaredName(@ClassGetSimpleName String declaringTypeName);
+
+  /**
+   * Returns {@code "static "} if this callable is declared static, and the empty string otherwise.
+   * A constructor is never static (JLS 8.8), so only a method can return anything here.
+   *
+   * @return the static modifier to print, followed by a space, or the empty string
+   */
+  protected abstract String staticModifier();
 
   /**
    * Returns the text that precedes the declared name in this callable's signature: the return type
@@ -166,12 +161,6 @@ public abstract class UnsolvedCallable extends UnsolvedSymbolAlternate
     }
   }
 
-  /** Set isStatic to true */
-  @Override
-  public void setStatic() {
-    isStatic = true;
-  }
-
   /**
    * This method sets the number of type variables for the current class
    *
@@ -214,9 +203,7 @@ public abstract class UnsolvedCallable extends UnsolvedSymbolAlternate
       signature.append(" ");
     }
 
-    if (isStatic) {
-      signature.append("static ");
-    }
+    signature.append(staticModifier());
 
     String typeVariables = getTypeVariablesAsString();
 
@@ -365,10 +352,5 @@ public abstract class UnsolvedCallable extends UnsolvedSymbolAlternate
   @Override
   public void setContent(String content) {
     this.content = content;
-  }
-
-  @Override
-  public boolean isStatic() {
-    return isStatic;
   }
 }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallableAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallableAlternates.java
@@ -91,12 +91,6 @@ public abstract class UnsolvedCallableAlternates<T extends UnsolvedCallable>
     return fqns;
   }
 
-  /** Makes this callable static. */
-  @Override
-  public void setStatic() {
-    applyToAllAlternates(UnsolvedCallable::setStatic);
-  }
-
   /**
    * Gets the number of type variables.
    *
@@ -283,10 +277,5 @@ public abstract class UnsolvedCallableAlternates<T extends UnsolvedCallable>
   @Override
   public void setContent(String content) {
     applyToAllAlternates(UnsolvedCallable::setContent, content);
-  }
-
-  @Override
-  public boolean isStatic() {
-    return getAlternates().get(0).isStatic();
   }
 }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallableAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallableAlternates.java
@@ -1,0 +1,292 @@
+package org.checkerframework.specimin.unsolved;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.checkerframework.specimin.JavaParserUtil;
+import org.checkerframework.specimin.QualifiedTypeName;
+
+/**
+ * Alternates of one synthetic method or constructor: everything that does not depend on which of
+ * the two it is. See {@link UnsolvedMethodAlternates} for the members that only a method has (a
+ * name and a return type) and {@link UnsolvedConstructorAlternates} for the constructor case.
+ *
+ * <p>Given a set of parameters and a set of potential encapsulating classes, this class allows for
+ * alternates of the same callable to be generated in different locations. If a class were:
+ *
+ * <pre><code>
+ * class A extends B implements C {
+ *    void x() {
+ *      int y = a();
+ *    }
+ * }
+ * </code></pre>
+ *
+ * where B and C are both unresolvable, method a() could be in either one.
+ *
+ * <p>For type parameters, you may always assume the following convention: T, T1, T2, ...
+ *
+ * @param <T> the kind of alternate this holds
+ */
+public abstract class UnsolvedCallableAlternates<T extends UnsolvedCallable>
+    extends UnsolvedSymbolAlternates<T> implements UnsolvedCallableCommon {
+  /**
+   * Base constructor for setting alternate declaring types.
+   *
+   * @param alternateDeclaringTypes A list of potential declaring types for this callable.
+   */
+  protected UnsolvedCallableAlternates(
+      List<UnsolvedClassOrInterfaceAlternates> alternateDeclaringTypes) {
+    super(alternateDeclaringTypes);
+  }
+
+  /**
+   * Returns a copy of the given alternate with a different parameter list and everything else the
+   * same. Alternates are copied rather than mutated wherever a signature might take more than one
+   * shape, and only a subclass knows how to build one of its own kind.
+   *
+   * @param alternate the alternate to copy
+   * @param parameterList the parameter list the copy should have
+   * @return the copy
+   */
+  protected abstract T copyWithParameters(T alternate, List<MemberType> parameterList);
+
+  @Override
+  public Set<String> getFullyQualifiedNames() {
+    Set<String> fqns = new LinkedHashSet<>();
+
+    for (T alternate : getAlternates()) {
+      // The declared name is prepended below, once per declaring type: a constructor takes its
+      // name from the type that declares it, so it is not the same for every key built here.
+      StringBuilder signature = new StringBuilder("(");
+
+      List<MemberType> parameterList = alternate.getParameterList();
+      for (int i = 0; i < parameterList.size(); i++) {
+        MemberType param = parameterList.get(i);
+
+        // This is safe because all simple names are the same for unsolved types
+        // and there is only one FQN for solved types
+        signature.append(
+            JavaParserUtil.getSimpleNameFromQualifiedName(JavaParserUtil.erase(param.toString())));
+
+        if (i + 1 < parameterList.size()) {
+          signature.append(", ");
+        }
+      }
+
+      signature.append(')');
+
+      for (UnsolvedClassOrInterfaceAlternates declaringType : getAlternateDeclaringTypes()) {
+        for (String fqn : declaringType.getFullyQualifiedNames()) {
+          fqns.add(
+              fqn
+                  + "#"
+                  + alternate.declaredName(QualifiedTypeName.parse(fqn).simpleName())
+                  + signature);
+        }
+      }
+    }
+
+    return fqns;
+  }
+
+  /** Makes this callable static. */
+  @Override
+  public void setStatic() {
+    applyToAllAlternates(UnsolvedCallable::setStatic);
+  }
+
+  /**
+   * Gets the number of type variables.
+   *
+   * @return The number of type variables
+   */
+  @Override
+  public int getNumberOfTypeVariables() {
+    return getAlternates().get(0).getNumberOfTypeVariables();
+  }
+
+  /**
+   * Sets the number of type variables.
+   *
+   * @param number The number of type variables
+   */
+  @Override
+  public void setNumberOfTypeVariables(int number) {
+    applyToAllAlternates(UnsolvedCallable::setNumberOfTypeVariables, number);
+  }
+
+  @Override
+  public String getTypeVariableName(int index) {
+    return getAlternates().get(0).getTypeVariableName(index);
+  }
+
+  @Override
+  public void declareTypeVariables(List<String> names) {
+    applyToAllAlternates(UnsolvedCallable::declareTypeVariables, names);
+  }
+
+  /**
+   * Returns whether the given type is one of the type variables bound by this callable's own
+   * declaration (i.e. a name introduced by this callable, such as the {@code T} in {@code <T> T
+   * get()}).
+   *
+   * <p>Such a name is only meaningful inside the declaration that binds it. Callers that are about
+   * to use a type outside of that declaration -- for example, to describe the type of an expression
+   * at a call site -- must not use the name, because it is not in scope there.
+   *
+   * @param type The type to check
+   * @return true if the type is a type variable bound by this callable
+   */
+  public boolean isOwnTypeVariable(MemberType type) {
+    Set<String> fqns = type.getFullyQualifiedNames();
+    if (fqns.size() != 1 || !type.getTypeArguments().isEmpty()) {
+      return false;
+    }
+
+    String name = fqns.iterator().next();
+    for (T alternate : getAlternates()) {
+      for (int i = 0; i < alternate.getNumberOfTypeVariables(); i++) {
+        if (alternate.getTypeVariableName(i).equals(name)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Gets the parameter list, where each index contains a set of all possible parameter types at
+   * that index.
+   *
+   * @return The parameter list
+   */
+  public List<Set<MemberType>> getParameterList() {
+    List<Set<MemberType>> parameterList = new ArrayList<>();
+
+    for (T alternate : getAlternates()) {
+      List<MemberType> parameters = alternate.getParameterList();
+
+      for (int i = 0; i < parameters.size(); i++) {
+        MemberType param = parameters.get(i);
+
+        if (parameterList.size() <= i) {
+          parameterList.add(new LinkedHashSet<>());
+        }
+
+        parameterList.get(i).add(param);
+      }
+    }
+
+    return parameterList;
+  }
+
+  @Override
+  public List<MemberType> getThrownExceptions() {
+    return getAlternates().get(0).getThrownExceptions();
+  }
+
+  @Override
+  public void addThrownException(MemberType exception) {
+    applyToAllAlternates(UnsolvedCallable::addThrownException, exception);
+  }
+
+  /**
+   * Records that this callable might declare the given exception in its throws clause, by adding a
+   * copy of each existing alternate with the exception added. Use this instead of {@link
+   * #addThrownException} when it is not certain that this callable is the one that throws the
+   * exception.
+   *
+   * <p>Note that {@link UnsolvedMethod#equals} ignores the throws clause, so a later call to {@link
+   * #removeDuplicateAlternates()} collapses the alternates added here back into whichever of the
+   * two possibilities comes first.
+   *
+   * @param exception the exception that this callable might throw
+   * @param preferred whether the alternates that declare the exception should be preferred; if
+   *     true, they are placed before the alternates that do not declare it
+   */
+  public void addAlternatesWithThrownException(MemberType exception, boolean preferred) {
+    List<T> throwing = new ArrayList<>();
+
+    for (T alternate : getAlternates()) {
+      if (alternate.getThrownExceptions().contains(exception)) {
+        // This callable is already known to throw the exception; there is no alternative to record.
+        return;
+      }
+
+      T copy = copyWithParameters(alternate, alternate.getParameterList());
+      copy.addThrownException(exception);
+      throwing.add(copy);
+    }
+
+    if (preferred) {
+      getAlternates().addAll(0, throwing);
+    } else {
+      getAlternates().addAll(throwing);
+    }
+  }
+
+  /**
+   * Replaces a parameter type with new parameter types in all alternates.
+   *
+   * @param oldType The parameter type to replace
+   * @param newTypes The parameter types to replace with
+   */
+  public void replaceParameterType(MemberType oldType, Set<MemberType> newTypes) {
+    int originalSize = getAlternates().size();
+    for (int i = 0; i < originalSize; i++) {
+      T alternate = getAlternates().get(i);
+
+      List<MemberType> parameterList = alternate.getParameterList();
+      boolean hasOldType = parameterList.contains(oldType);
+
+      if (hasOldType) {
+        boolean isFirst = true;
+        for (MemberType newType : newTypes) {
+          if (isFirst) {
+            alternate.replaceParameterType(oldType, newType);
+            isFirst = false;
+            continue;
+          }
+
+          List<MemberType> newParameterList =
+              parameterList.stream().map(param -> param.equals(oldType) ? newType : param).toList();
+
+          addAlternate(copyWithParameters(alternate, newParameterList));
+        }
+      }
+    }
+  }
+
+  /**
+   * Use with caution: this method sets all alternates' return types to the same type.
+   *
+   * <p>{@inheritDoc}
+   */
+  @Override
+  public void setReturnType(MemberType memberType) {
+    applyToAllAlternates(UnsolvedCallable::setReturnType, memberType);
+    removeDuplicateAlternates();
+  }
+
+  @Override
+  public String getAccessModifier() {
+    return getAlternates().get(0).getAccessModifier();
+  }
+
+  @Override
+  public void setAccessModifier(String accessModifier) {
+    applyToAllAlternates(UnsolvedCallable::setAccessModifier, accessModifier);
+  }
+
+  @Override
+  public void setContent(String content) {
+    applyToAllAlternates(UnsolvedCallable::setContent, content);
+  }
+
+  @Override
+  public boolean isStatic() {
+    return getAlternates().get(0).isStatic();
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallableCommon.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallableCommon.java
@@ -7,8 +7,9 @@ import java.util.List;
  * should return the same value for each alternate; each setter should do the same operation to each
  * alternate. If these requirements are not met, do not include the method in this interface.
  *
- * <p>A method's name and return type are not here: a constructor has neither (JLS 8.8.1), so they
- * belong to {@link UnsolvedMethod} and {@link UnsolvedMethodAlternates}.
+ * <p>A method's name, return type and staticness are not here: a constructor has no name or return
+ * type of its own (JLS 8.8.1) and can never be static (JLS 8.8), so all three belong to {@link
+ * UnsolvedMethod} and {@link UnsolvedMethodAlternates}.
  */
 public interface UnsolvedCallableCommon {
   /**
@@ -31,16 +32,6 @@ public interface UnsolvedCallableCommon {
    * @return the access modifier
    */
   String getAccessModifier();
-
-  /** Makes this method static. */
-  void setStatic();
-
-  /**
-   * Returns true if this method is static
-   *
-   * @return True if the method is static
-   */
-  boolean isStatic();
 
   /**
    * Gets the number of type variables.

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallableCommon.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallableCommon.java
@@ -3,27 +3,14 @@ package org.checkerframework.specimin.unsolved;
 import java.util.List;
 
 /**
- * Common interface for {@link UnsolvedMethod} and {@link UnsolvedMethodAlternates}. Each getter
+ * Common interface for {@link UnsolvedCallable} and {@link UnsolvedCallableAlternates}. Each getter
  * should return the same value for each alternate; each setter should do the same operation to each
  * alternate. If these requirements are not met, do not include the method in this interface.
+ *
+ * <p>A method's name and return type are not here: a constructor has neither (JLS 8.8.1), so they
+ * belong to {@link UnsolvedMethod} and {@link UnsolvedMethodAlternates}.
  */
-public interface UnsolvedMethodCommon {
-  /**
-   * Get the name of this method.
-   *
-   * @return the name of this method
-   */
-  String getName();
-
-  /**
-   * Returns whether this is a constructor rather than an ordinary method. A constructor's name is
-   * not its own: JLS 8.8.1 requires it to be the simple name of the declaring type, so it is read
-   * from that type wherever the name is needed rather than trusted from {@link #getName}.
-   *
-   * @return true if this is a constructor
-   */
-  boolean isConstructor();
-
+public interface UnsolvedCallableCommon {
   /**
    * Getter for the throws list.
    *
@@ -93,7 +80,8 @@ public interface UnsolvedMethodCommon {
   void declareTypeVariables(List<String> names);
 
   /**
-   * Sets the return type.
+   * Sets the return type. A constructor has no return type (JLS 8.8.1) and throws from this; see
+   * {@link UnsolvedConstructor#setReturnType}.
    *
    * @param memberType The return type
    */

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterface.java
@@ -223,7 +223,7 @@ public class UnsolvedClassOrInterface extends UnsolvedSymbolAlternate
    * @return the content of the class
    */
   public String toString(
-      Collection<UnsolvedMethod> methods,
+      Collection<UnsolvedCallable> methods,
       Collection<UnsolvedField> fields,
       Collection<String> innerClassDefinitions,
       boolean isInnerClass) {
@@ -326,7 +326,7 @@ public class UnsolvedClassOrInterface extends UnsolvedSymbolAlternate
         sb.append("    ").append(variableDeclarations.toString(typeOfType)).append("\n");
       }
     }
-    for (UnsolvedMethod method : methods) {
+    for (UnsolvedCallable method : methods) {
       sb.append(method.toString(typeOfType, className));
     }
     sb.append("}\n");

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedClassOrInterface.java
@@ -327,7 +327,7 @@ public class UnsolvedClassOrInterface extends UnsolvedSymbolAlternate
       }
     }
     for (UnsolvedMethod method : methods) {
-      sb.append(method.toString(typeOfType));
+      sb.append(method.toString(typeOfType, className));
     }
     sb.append("}\n");
     return sb.toString();

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedConstructor.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedConstructor.java
@@ -1,0 +1,98 @@
+package org.checkerframework.specimin.unsolved;
+
+import com.github.javaparser.ast.Node;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
+
+/**
+ * A synthetic constructor declaration. A constructor has no state of its own beyond what every
+ * {@link UnsolvedCallable} has: JLS 8.8.1 gives it no return type, and requires it to be declared
+ * under the simple name of the type that declares it, so neither is stored here.
+ *
+ * <p>Two constructors of the same type are the same constructor when their parameters agree, which
+ * is why {@link #equals} looks at nothing else.
+ */
+public class UnsolvedConstructor extends UnsolvedCallable {
+  /**
+   * Create an instance of UnsolvedConstructor.
+   *
+   * @param parameterList the list of parameters for this constructor
+   * @param throwsList the list of exceptions thrown by this constructor
+   * @param mustPreserve the set of nodes that must be preserved with this alternate
+   * @param accessModifier the access modifier of this constructor
+   * @param typeVariableNames the names of this constructor's type variables, in declaration order
+   */
+  public UnsolvedConstructor(
+      List<MemberType> parameterList,
+      List<MemberType> throwsList,
+      Set<Node> mustPreserve,
+      String accessModifier,
+      List<String> typeVariableNames) {
+    // A constructor is never static (JLS 8.8).
+    super(parameterList, throwsList, mustPreserve, accessModifier, false, typeVariableNames);
+  }
+
+  /**
+   * A constructor declares no return type (JLS 8.8.1), so there is none to return. Reaching this is
+   * a sign that a caller meant to handle methods only; test for {@link UnsolvedMethod} instead.
+   *
+   * @return never returns
+   * @throws UnsupportedOperationException always
+   */
+  @Override
+  public MemberType getReturnType() {
+    throw new UnsupportedOperationException("A constructor has no return type: " + this);
+  }
+
+  /**
+   * A constructor declares no return type (JLS 8.8.1), so there is none to set. Reaching this is a
+   * sign that a caller meant to handle methods only; test for {@link UnsolvedMethod} instead.
+   *
+   * @param returnType ignored
+   * @throws UnsupportedOperationException always
+   */
+  @Override
+  public void setReturnType(MemberType returnType) {
+    throw new UnsupportedOperationException("A constructor has no return type: " + this);
+  }
+
+  @Override
+  protected String declaredName(@ClassGetSimpleName String declaringTypeName) {
+    return declaringTypeName;
+  }
+
+  @Override
+  protected String returnTypePrefix() {
+    return "";
+  }
+
+  /**
+   * A constructor cannot be static (JLS 8.8). Reaching this is a sign that a caller meant to handle
+   * methods only; test for {@link UnsolvedMethod} instead.
+   *
+   * @throws UnsupportedOperationException always
+   */
+  @Override
+  public void setStatic() {
+    throw new UnsupportedOperationException("A constructor cannot be static: " + this);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    return o instanceof UnsolvedConstructor other
+        && other.getParameterList().equals(getParameterList());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getParameterList());
+  }
+
+  @Override
+  public String toString() {
+    return "constructor(" + getParameterList() + ")";
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedConstructor.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedConstructor.java
@@ -31,8 +31,7 @@ public class UnsolvedConstructor extends UnsolvedCallable {
       Set<Node> mustPreserve,
       String accessModifier,
       List<String> typeVariableNames) {
-    // A constructor is never static (JLS 8.8).
-    super(parameterList, throwsList, mustPreserve, accessModifier, false, typeVariableNames);
+    super(parameterList, throwsList, mustPreserve, accessModifier, typeVariableNames);
   }
 
   /**
@@ -69,15 +68,10 @@ public class UnsolvedConstructor extends UnsolvedCallable {
     return "";
   }
 
-  /**
-   * A constructor cannot be static (JLS 8.8). Reaching this is a sign that a caller meant to handle
-   * methods only; test for {@link UnsolvedMethod} instead.
-   *
-   * @throws UnsupportedOperationException always
-   */
   @Override
-  public void setStatic() {
-    throw new UnsupportedOperationException("A constructor cannot be static: " + this);
+  protected String staticModifier() {
+    // A constructor is never static (JLS 8.8).
+    return "";
   }
 
   @Override

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedConstructorAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedConstructorAlternates.java
@@ -1,0 +1,108 @@
+package org.checkerframework.specimin.unsolved;
+
+import com.github.javaparser.ast.Node;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.specimin.JavaParserUtil;
+
+/**
+ * Alternates of one synthetic constructor. There is no name or return type here, nor a parameter
+ * for either in the factories: JLS 8.8.1 gives a constructor no return type and requires it to be
+ * declared under the simple name of its declaring type, so both are read from that type rather than
+ * supplied by a caller.
+ */
+public class UnsolvedConstructorAlternates extends UnsolvedCallableAlternates<UnsolvedConstructor> {
+  /**
+   * Creates a new instance of UnsolvedConstructorAlternates. Private constructor; use the create
+   * methods.
+   *
+   * @param declaringTypes A list of potential declaring types for this constructor.
+   */
+  private UnsolvedConstructorAlternates(List<UnsolvedClassOrInterfaceAlternates> declaringTypes) {
+    super(declaringTypes);
+  }
+
+  /**
+   * Creates a new unsolved constructor declaration.
+   *
+   * @param declaringTypes The types whose constructor this could be
+   * @param parameters Potential parameters of the constructor. Each set represents a possibility of
+   *     parameter types at that position
+   * @return The constructor definition
+   */
+  public static UnsolvedConstructorAlternates create(
+      List<UnsolvedClassOrInterfaceAlternates> declaringTypes, List<Set<MemberType>> parameters) {
+    UnsolvedConstructorAlternates result = checkAndCreate(declaringTypes);
+
+    for (List<MemberType> parameterList : JavaParserUtil.generateAllCombinations(parameters)) {
+      result.addAlternate(
+          new UnsolvedConstructor(parameterList, List.of(), Set.of(), "public", List.of()));
+    }
+
+    return result;
+  }
+
+  /**
+   * Creates a new unsolved constructor declaration, recording nodes that must be preserved if a
+   * given parameter type is chosen.
+   *
+   * @param declaringTypes The types whose constructor this could be
+   * @param parameters Potential parameters of the constructor. Each map represents a possibility of
+   *     parameter types at that position, along with nodes that must be preserved if that type is
+   *     chosen
+   * @return The constructor definition
+   */
+  public static UnsolvedConstructorAlternates createWithPreservation(
+      List<UnsolvedClassOrInterfaceAlternates> declaringTypes,
+      List<Map<MemberType, @Nullable Node>> parameters) {
+    UnsolvedConstructorAlternates result = checkAndCreate(declaringTypes);
+
+    for (List<Map.Entry<MemberType, @Nullable Node>> parameterList :
+        JavaParserUtil.generateAllCombinationsForListOfMaps(parameters)) {
+      List<MemberType> params = parameterList.stream().map(Map.Entry::getKey).toList();
+      Set<Node> toPreserve = new HashSet<>();
+
+      for (Map.Entry<MemberType, @Nullable Node> entry : parameterList) {
+        Node node = entry.getValue();
+        if (node != null) {
+          toPreserve.add(node);
+        }
+      }
+
+      result.addAlternate(
+          new UnsolvedConstructor(params, List.of(), toPreserve, "public", List.of()));
+    }
+
+    return result;
+  }
+
+  /**
+   * Checks that there is at least one declaring type and creates an empty instance.
+   *
+   * @param declaringTypes The types whose constructor this could be
+   * @return an instance with no alternates yet
+   */
+  private static UnsolvedConstructorAlternates checkAndCreate(
+      List<UnsolvedClassOrInterfaceAlternates> declaringTypes) {
+    if (declaringTypes.isEmpty()) {
+      throw new RuntimeException(
+          "Unsolved constructor must have at least one potential declaring type.");
+    }
+
+    return new UnsolvedConstructorAlternates(declaringTypes);
+  }
+
+  @Override
+  protected UnsolvedConstructor copyWithParameters(
+      UnsolvedConstructor alternate, List<MemberType> parameterList) {
+    return new UnsolvedConstructor(
+        parameterList,
+        alternate.getThrownExceptions(),
+        alternate.getMustPreserveNodes(),
+        alternate.getAccessModifier(),
+        alternate.getTypeVariableNames());
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
 import org.checkerframework.specimin.JavaParserUtil;
 
 /**
@@ -22,8 +23,15 @@ import org.checkerframework.specimin.JavaParserUtil;
  * to, call .equals on UnsolvedMethodAlternates instead of here.</strong>
  */
 public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedMethodCommon {
-  /** The name of the method */
+  /**
+   * The name of the method. For a constructor this is the simple name of the declaring type, which
+   * is where {@link #toString} takes it from instead: JLS 8.8.1 fixes a constructor's name to be
+   * that simple name, so it is not independent state and no caller supplies it.
+   */
   private final String name;
+
+  /** Whether this is a constructor rather than an ordinary method. */
+  private final boolean isConstructor;
 
   /** The return type of the method. */
   private MemberType returnType;
@@ -146,8 +154,46 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
       String accessModifier,
       boolean isStatic,
       List<String> typeVariableNames) {
+    this(
+        name,
+        returnType,
+        parameterList,
+        throwsList,
+        mustPreserve,
+        accessModifier,
+        isStatic,
+        typeVariableNames,
+        false);
+  }
+
+  /**
+   * Create an instance of UnsolvedMethod, which may be a constructor. Prefer {@link
+   * UnsolvedMethodAlternates#createConstructor} to calling this directly with {@code isConstructor}
+   * set: it derives the name from the declaring type, which is the only name JLS 8.8.1 permits.
+   *
+   * @param name the name of the method; for a constructor, the declaring type's simple name
+   * @param returnType the return type of the method; the empty type for a constructor
+   * @param parameterList the list of parameters for this method
+   * @param throwsList the list of exceptions thrown by this method
+   * @param accessModifier the access modifier of this method
+   * @param mustPreserve the set of nodes that must be preserved with this alternate
+   * @param isStatic whether this method is static
+   * @param typeVariableNames the names of this method's type variables, in declaration order
+   * @param isConstructor whether this is a constructor rather than an ordinary method
+   */
+  public UnsolvedMethod(
+      String name,
+      MemberType returnType,
+      List<MemberType> parameterList,
+      List<MemberType> throwsList,
+      Set<Node> mustPreserve,
+      String accessModifier,
+      boolean isStatic,
+      List<String> typeVariableNames,
+      boolean isConstructor) {
     super(mustPreserve);
     this.name = name;
+    this.isConstructor = isConstructor;
     this.returnType = returnType;
 
     // Parameter and throws lists should be mutable, so copy them to be safe
@@ -190,6 +236,11 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
   @Override
   public String getName() {
     return name;
+  }
+
+  @Override
+  public boolean isConstructor() {
+    return isConstructor;
   }
 
   /**
@@ -287,9 +338,12 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
    * Return the content of the method. Note that the body of the method is stubbed out.
    *
    * @param type The type of the declaring type
+   * @param declaringTypeName The simple name of the declaring type. A constructor is declared under
+   *     this name (JLS 8.8.1), so it is read from the declaring type rather than stored.
    * @return the content of the method with the body stubbed out
    */
-  public String toString(UnsolvedClassOrInterfaceType type) {
+  public String toString(
+      UnsolvedClassOrInterfaceType type, @ClassGetSimpleName String declaringTypeName) {
     StringBuilder arguments = new StringBuilder();
     for (int i = 0; i < parameterList.size(); i++) {
       MemberType parameterType = parameterList.get(i);
@@ -319,7 +373,7 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
     if (!returnTypeAsString.isEmpty()) {
       signature.append(returnTypeAsString).append(" ");
     }
-    signature.append(name).append("(");
+    signature.append(isConstructor ? declaringTypeName : name).append("(");
     signature.append(arguments);
     signature.append(")");
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
@@ -10,9 +10,8 @@ import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
 
 /**
  * An UnsolvedMethod instance is a representation of a method that can not be solved by
- * SymbolSolver. The reason is that the class file of that method is not in the root directory. See
- * {@link UnsolvedConstructor} for the constructor case, which has neither a name nor a return type
- * of its own.
+ * SymbolSolver. The reason is that the class file of that method is not in the root directory. An
+ * instance of this class cannot represent a constructor; see {@link UnsolvedConstructor}.
  *
  * <p>Note for {@link #equals}: <strong>Use with caution: two UnsolvedMethods may return not equal
  * but they may belong to the same UnsolvedMethodAlternates. This could be the case when the same
@@ -25,6 +24,9 @@ public class UnsolvedMethod extends UnsolvedCallable {
 
   /** The return type of the method. */
   private MemberType returnType;
+
+  /** This field is set to true if this method is a static method. */
+  private boolean isStatic;
 
   /**
    * Create an instance of UnsolvedMethod.
@@ -119,9 +121,29 @@ public class UnsolvedMethod extends UnsolvedCallable {
       String accessModifier,
       boolean isStatic,
       List<String> typeVariableNames) {
-    super(parameterList, throwsList, mustPreserve, accessModifier, isStatic, typeVariableNames);
+    super(parameterList, throwsList, mustPreserve, accessModifier, typeVariableNames);
     this.name = name;
     this.returnType = returnType;
+    this.isStatic = isStatic;
+  }
+
+  /**
+   * Returns true if this method is static.
+   *
+   * @return True if the method is static
+   */
+  public boolean isStatic() {
+    return isStatic;
+  }
+
+  /** Set isStatic to true */
+  public void setStatic() {
+    isStatic = true;
+  }
+
+  @Override
+  protected String staticModifier() {
+    return isStatic ? "static " : "";
   }
 
   @Override

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
@@ -1,65 +1,30 @@
 package org.checkerframework.specimin.unsolved;
 
-import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.ast.type.Type;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
-import org.checkerframework.specimin.JavaParserUtil;
 
 /**
  * An UnsolvedMethod instance is a representation of a method that can not be solved by
- * SymbolSolver. The reason is that the class file of that method is not in the root directory.
+ * SymbolSolver. The reason is that the class file of that method is not in the root directory. See
+ * {@link UnsolvedConstructor} for the constructor case, which has neither a name nor a return type
+ * of its own.
  *
  * <p>Note for {@link #equals}: <strong>Use with caution: two UnsolvedMethods may return not equal
  * but they may belong to the same UnsolvedMethodAlternates. This could be the case when the same
  * unsolved method is called but there are multiple possibilities for a parameter type. When able
  * to, call .equals on UnsolvedMethodAlternates instead of here.</strong>
  */
-public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedMethodCommon {
-  /**
-   * The name of the method. For a constructor this is the simple name of the declaring type, which
-   * is where {@link #toString} takes it from instead: JLS 8.8.1 fixes a constructor's name to be
-   * that simple name, so it is not independent state and no caller supplies it.
-   */
+public class UnsolvedMethod extends UnsolvedCallable {
+  /** The name of the method. */
   private final String name;
-
-  /** Whether this is a constructor rather than an ordinary method. */
-  private final boolean isConstructor;
 
   /** The return type of the method. */
   private MemberType returnType;
-
-  /** The list of the types of the parameters of the method. */
-  private final List<MemberType> parameterList;
-
-  /** This field is set to true if this method is a static method */
-  private boolean isStatic;
-
-  /** The list of the types of the exceptions thrown by the method. */
-  private final List<MemberType> throwsList;
-
-  /**
-   * The names of this method's type variables, in declaration order.
-   *
-   * <p>These names are the state. Most of a method's type variables are invented by Specimin and
-   * named by {@link JavaParserUtil#getGeneratedTypeParameterName}, but one that {@link
-   * #declareTypeVariables} binds carries a name that is already written into the signature and
-   * cannot be renamed.
-   */
-  private final List<String> typeVariableNames;
-
-  /** The access modifier of the method. */
-  private String accessModifier;
-
-  /** The content of the method. */
-  private String content = "throw new java.lang.Error();";
 
   /**
    * Create an instance of UnsolvedMethod.
@@ -154,76 +119,12 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
       String accessModifier,
       boolean isStatic,
       List<String> typeVariableNames) {
-    this(
-        name,
-        returnType,
-        parameterList,
-        throwsList,
-        mustPreserve,
-        accessModifier,
-        isStatic,
-        typeVariableNames,
-        false);
-  }
-
-  /**
-   * Create an instance of UnsolvedMethod, which may be a constructor. Prefer {@link
-   * UnsolvedMethodAlternates#createConstructor} to calling this directly with {@code isConstructor}
-   * set: it derives the name from the declaring type, which is the only name JLS 8.8.1 permits.
-   *
-   * @param name the name of the method; for a constructor, the declaring type's simple name
-   * @param returnType the return type of the method; the empty type for a constructor
-   * @param parameterList the list of parameters for this method
-   * @param throwsList the list of exceptions thrown by this method
-   * @param accessModifier the access modifier of this method
-   * @param mustPreserve the set of nodes that must be preserved with this alternate
-   * @param isStatic whether this method is static
-   * @param typeVariableNames the names of this method's type variables, in declaration order
-   * @param isConstructor whether this is a constructor rather than an ordinary method
-   */
-  public UnsolvedMethod(
-      String name,
-      MemberType returnType,
-      List<MemberType> parameterList,
-      List<MemberType> throwsList,
-      Set<Node> mustPreserve,
-      String accessModifier,
-      boolean isStatic,
-      List<String> typeVariableNames,
-      boolean isConstructor) {
-    super(mustPreserve);
+    super(parameterList, throwsList, mustPreserve, accessModifier, isStatic, typeVariableNames);
     this.name = name;
-    this.isConstructor = isConstructor;
     this.returnType = returnType;
-
-    // Parameter and throws lists should be mutable, so copy them to be safe
-    this.parameterList = new ArrayList<>(parameterList);
-    this.throwsList = new ArrayList<>(throwsList);
-
-    this.accessModifier = accessModifier;
-    this.isStatic = isStatic;
-    this.typeVariableNames = new ArrayList<>(typeVariableNames);
   }
 
-  /**
-   * Returns the first {@code count} generated type variable names.
-   *
-   * @param count how many names to generate
-   * @return the generated names, in order
-   */
-  private static List<String> generatedTypeVariableNames(int count) {
-    List<String> names = new ArrayList<>(count);
-    for (int i = 0; i < count; i++) {
-      names.add(JavaParserUtil.getGeneratedTypeParameterName(i));
-    }
-    return names;
-  }
-
-  /**
-   * Get the return type of this method.
-   *
-   * @return the value of returnType
-   */
+  @Override
   public MemberType getReturnType() {
     return returnType;
   }
@@ -233,77 +134,25 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
    *
    * @return the name of this method
    */
-  @Override
   public String getName() {
     return name;
   }
 
   @Override
-  public boolean isConstructor() {
-    return isConstructor;
-  }
-
-  /**
-   * Getter for the parameter list. Note that the list is read-only.
-   *
-   * @return the parameter list
-   */
-  public List<MemberType> getParameterList() {
-    return Collections.unmodifiableList(parameterList);
-  }
-
-  /**
-   * Replaces the type of a parameter in the parameter list with a new type.
-   *
-   * @param oldType The old type
-   * @param newType The new type
-   */
-  public void replaceParameterType(MemberType oldType, MemberType newType) {
-    for (int i = 0; i < parameterList.size(); i++) {
-      if (parameterList.get(i).equals(oldType)) {
-        parameterList.set(i, newType);
-      }
-    }
-  }
-
-  /**
-   * Getter for the throws list. Note that the list is read-only.
-   *
-   * @return the throws list
-   */
-  @Override
-  public List<MemberType> getThrownExceptions() {
-    return Collections.unmodifiableList(throwsList);
+  protected String declaredName(@ClassGetSimpleName String declaringTypeName) {
+    return name;
   }
 
   @Override
-  public void addThrownException(MemberType exception) {
-    if (!throwsList.contains(exception)) {
-      throwsList.add(exception);
-    }
+  protected String returnTypePrefix() {
+    return returnType + " ";
   }
 
-  /** Set isStatic to true */
   @Override
-  public void setStatic() {
-    isStatic = true;
-  }
-
-  /**
-   * This method sets the number of type variables for the current class
-   *
-   * @param numberOfTypeVariables number of type variable in this class.
-   */
-  @Override
-  public void setNumberOfTypeVariables(int numberOfTypeVariables) {
-    // Resize rather than replace, so that a name bound by declareTypeVariables at an index below
-    // the new size survives.
-    while (typeVariableNames.size() > numberOfTypeVariables) {
-      typeVariableNames.remove(typeVariableNames.size() - 1);
-    }
-    while (typeVariableNames.size() < numberOfTypeVariables) {
-      typeVariableNames.add(JavaParserUtil.getGeneratedTypeParameterName(typeVariableNames.size()));
-    }
+  protected List<MemberType> typesInSignature() {
+    List<MemberType> types = new ArrayList<>(getParameterList());
+    types.add(returnType);
+    return types;
   }
 
   @Override
@@ -325,206 +174,12 @@ public class UnsolvedMethod extends UnsolvedSymbolAlternate implements UnsolvedM
       return false;
     }
     return other.name.equals(this.name)
-        && other.parameterList.equals(parameterList)
+        && other.getParameterList().equals(getParameterList())
         && other.returnType.equals(this.returnType);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, parameterList, returnType);
-  }
-
-  /**
-   * Return the content of the method. Note that the body of the method is stubbed out.
-   *
-   * @param type The type of the declaring type
-   * @param declaringTypeName The simple name of the declaring type. A constructor is declared under
-   *     this name (JLS 8.8.1), so it is read from the declaring type rather than stored.
-   * @return the content of the method with the body stubbed out
-   */
-  public String toString(
-      UnsolvedClassOrInterfaceType type, @ClassGetSimpleName String declaringTypeName) {
-    StringBuilder arguments = new StringBuilder();
-    for (int i = 0; i < parameterList.size(); i++) {
-      MemberType parameterType = parameterList.get(i);
-
-      arguments.append(parameterType).append(" ").append("parameter").append(i);
-      if (i < parameterList.size() - 1) {
-        arguments.append(", ");
-      }
-    }
-    StringBuilder signature = new StringBuilder();
-    if (accessModifier != null) {
-      signature.append(accessModifier);
-      signature.append(" ");
-    }
-
-    if (isStatic) {
-      signature.append("static ");
-    }
-
-    String typeVariables = getTypeVariablesAsString();
-
-    if (!typeVariables.isEmpty()) {
-      signature.append(getTypeVariablesAsString()).append(" ");
-    }
-
-    String returnTypeAsString = returnType.toString();
-    if (!returnTypeAsString.isEmpty()) {
-      signature.append(returnTypeAsString).append(" ");
-    }
-    signature.append(isConstructor ? declaringTypeName : name).append("(");
-    signature.append(arguments);
-    signature.append(")");
-
-    if (!throwsList.isEmpty()) {
-      signature.append(" throws ");
-    }
-
-    StringBuilder exceptions = new StringBuilder();
-    for (int i = 0; i < throwsList.size(); i++) {
-      MemberType exception = throwsList.get(i);
-      exceptions.append(exception);
-      if (i < throwsList.size() - 1) {
-        exceptions.append(", ");
-      }
-    }
-    signature.append(exceptions);
-
-    if (type == UnsolvedClassOrInterfaceType.ANNOTATION
-        || type == UnsolvedClassOrInterfaceType.INTERFACE) {
-      return "\n    " + signature + ";\n";
-    } else {
-      return "\n    " + signature + " {\n        " + content + "\n    }\n";
-    }
-  }
-
-  /**
-   * Gets the number of type variables.
-   *
-   * @return The number of type variables
-   */
-  @Override
-  public int getNumberOfTypeVariables() {
-    return typeVariableNames.size();
-  }
-
-  /**
-   * Returns the names of this method's type variables, in declaration order. Pass this to {@link
-   * #UnsolvedMethod(String, MemberType, List, List, Set, String, boolean, List)} when copying.
-   *
-   * @return the type variable names; the list is read-only
-   */
-  public List<String> getTypeVariableNames() {
-    return Collections.unmodifiableList(typeVariableNames);
-  }
-
-  /**
-   * Return a synthetic representation for type variables of the current class.
-   *
-   * @return the synthetic representation for type variables
-   */
-  private String getTypeVariablesAsString() {
-    if (typeVariableNames.isEmpty()) {
-      return "";
-    }
-
-    List<String> used = getTypeVariablesImpl();
-
-    // A type variable may be allocated for this method but end up used by no alternate's
-    // signature, in which case there is no type parameter section to print at all.
-    if (used.isEmpty()) {
-      return "";
-    }
-
-    return "<" + String.join(", ", used) + ">";
-  }
-
-  /** Gets a list of the type variable names that are used in this method. */
-  private List<String> getTypeVariablesImpl() {
-    // While it is better to have the exact type number of type variables
-    // on a per-alternate basis, it's easier for other parts of this codebase
-    // to deal with the same number of type variables for all alternates of a given method.
-    // So, we'll deal with that limitation here and not include any type variables
-    // that are not used in this specific alternate.
-
-    // Parse to properly handle type arguments (i.e., a class named TheUnsolved should not be
-    // considered to use T)
-    List<ClassOrInterfaceType> usedTypes = new ArrayList<>();
-    for (MemberType parameterType : parameterList) {
-      Type parsedType = StaticJavaParser.parseType(parameterType.toString());
-
-      if (!parsedType.isClassOrInterfaceType()) {
-        continue;
-      }
-
-      usedTypes.add(parsedType.asClassOrInterfaceType());
-    }
-
-    // A constructor's return type is the empty string, which is not parseable as a type.
-    if (returnType != null && !returnType.toString().isEmpty()) {
-      Type parsedType = StaticJavaParser.parseType(returnType.toString());
-
-      if (parsedType.isClassOrInterfaceType()) {
-        usedTypes.add(parsedType.asClassOrInterfaceType());
-      }
-    }
-
-    List<String> usedTypeVariableNames = new ArrayList<>();
-    for (String typeVariableName : typeVariableNames) {
-      for (ClassOrInterfaceType usedType : usedTypes) {
-        if (usedType.findAll(ClassOrInterfaceType.class).stream()
-            .anyMatch(t -> t.getNameAsString().equals(typeVariableName))) {
-          usedTypeVariableNames.add(typeVariableName);
-          break;
-        }
-      }
-    }
-    return usedTypeVariableNames;
-  }
-
-  /**
-   * Given the index of a type variable, return the name of that type variable.
-   *
-   * @param index The index
-   * @return the name of the type variable with the given index
-   * @throws IllegalArgumentException if the index is out of bounds
-   */
-  @Override
-  public String getTypeVariableName(int index) {
-    if (index < 0 || index >= typeVariableNames.size()) {
-      throw new IllegalArgumentException(
-          "Index out of bounds. There are only " + typeVariableNames.size() + " type variables.");
-    }
-    return typeVariableNames.get(index);
-  }
-
-  @Override
-  public void declareTypeVariables(List<String> names) {
-    for (String name : names) {
-      if (!typeVariableNames.contains(name)) {
-        typeVariableNames.add(name);
-      }
-    }
-  }
-
-  @Override
-  public String getAccessModifier() {
-    return accessModifier;
-  }
-
-  @Override
-  public void setAccessModifier(String accessModifier) {
-    this.accessModifier = accessModifier;
-  }
-
-  @Override
-  public void setContent(String content) {
-    this.content = content;
-  }
-
-  @Override
-  public boolean isStatic() {
-    return isStatic;
+    return Objects.hash(name, getParameterList(), returnType);
   }
 }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -297,6 +297,20 @@ public class UnsolvedMethodAlternates extends UnsolvedCallableAlternates<Unsolve
     return getAlternates().get(0).getName();
   }
 
+  /** Makes this method static. */
+  public void setStatic() {
+    applyToAllAlternates(UnsolvedMethod::setStatic);
+  }
+
+  /**
+   * Returns true if this method is static.
+   *
+   * @return True if the method is static
+   */
+  public boolean isStatic() {
+    return getAlternates().get(0).isStatic();
+  }
+
   /**
    * For all the alternates that have oldType as return type, replace it with newType.
    *

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.specimin.JavaParserUtil;
+import org.checkerframework.specimin.QualifiedTypeName;
 
 /**
  * /** Given a name, return type, a set of parameters and a set of potential encapsulating classes,
@@ -225,6 +226,82 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
   }
 
   /**
+   * Creates a new unsolved constructor declaration. There is no name parameter: JLS 8.8.1 requires
+   * a constructor to be declared under the simple name of its declaring type, so the name is read
+   * from the declaring type rather than supplied by the caller. Neither is there a return type
+   * parameter: a constructor declares none, which {@link UnsolvedMethod#toString} represents as the
+   * empty type.
+   *
+   * @param declaringTypes The types whose constructor this could be
+   * @param parameters Potential parameters of the constructor. Each set represents a possibility of
+   *     parameter types at that position
+   * @return The constructor definition
+   */
+  public static UnsolvedMethodAlternates createConstructor(
+      List<UnsolvedClassOrInterfaceAlternates> declaringTypes, List<Set<MemberType>> parameters) {
+    return withConstructorsMarked(
+        create(
+            declaringTypes.get(0).getClassName(),
+            Set.of(new SolvedMemberType("")),
+            declaringTypes,
+            parameters));
+  }
+
+  /**
+   * Creates a new unsolved constructor declaration, recording nodes that must be preserved if a
+   * given parameter type is chosen. See {@link #createConstructor} for why there is no name
+   * parameter.
+   *
+   * @param declaringTypes The types whose constructor this could be
+   * @param parameters Potential parameters of the constructor. Each map represents a possibility of
+   *     parameter types at that position, along with nodes that must be preserved if that type is
+   *     chosen
+   * @return The constructor definition
+   */
+  public static UnsolvedMethodAlternates createConstructorWithPreservation(
+      List<UnsolvedClassOrInterfaceAlternates> declaringTypes,
+      List<Map<MemberType, @Nullable Node>> parameters) {
+    return withConstructorsMarked(
+        createWithPreservation(
+            declaringTypes.get(0).getClassName(),
+            Set.of(new SolvedMemberType("")),
+            declaringTypes,
+            parameters,
+            List.of()));
+  }
+
+  /**
+   * Replaces every alternate of the given method with a copy marked as a constructor. The create
+   * methods build ordinary methods; this is how the constructor factories above turn their result
+   * into constructors.
+   *
+   * @param method the method whose alternates should be marked
+   * @return {@code method}, for chaining
+   */
+  private static UnsolvedMethodAlternates withConstructorsMarked(UnsolvedMethodAlternates method) {
+    List<UnsolvedMethod> alternates = method.getAlternates();
+
+    for (int i = 0; i < alternates.size(); i++) {
+      UnsolvedMethod alternate = alternates.get(i);
+
+      alternates.set(
+          i,
+          new UnsolvedMethod(
+              alternate.getName(),
+              alternate.getReturnType(),
+              alternate.getParameterList(),
+              alternate.getThrownExceptions(),
+              alternate.getMustPreserveNodes(),
+              alternate.getAccessModifier(),
+              alternate.isStatic(),
+              alternate.getTypeVariableNames(),
+              true));
+    }
+
+    return method;
+  }
+
+  /**
    * Updates return types and must preserve nodes. Saves the intersection of the previous and the
    * input, since we know more information to narrow potential return types down.
    *
@@ -256,7 +333,8 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
                   Set.of((Node) entry.getValue()),
                   old.getAccessModifier(),
                   old.isStatic(),
-                  old.getTypeVariableNames());
+                  old.getTypeVariableNames(),
+                  old.isConstructor());
           addAlternate(method);
         }
       }
@@ -292,9 +370,9 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
     Set<String> fqns = new LinkedHashSet<>();
 
     for (UnsolvedMethod methodAlternate : getAlternates()) {
-      StringBuilder methodSignature = new StringBuilder();
-
-      methodSignature.append(methodAlternate.getName()).append('(');
+      // The name is prepended below, once per declaring type: a constructor takes its name from
+      // the type that declares it, so it is not the same for every key built here.
+      StringBuilder methodSignature = new StringBuilder("(");
 
       List<MemberType> parameterList = methodAlternate.getParameterList();
       for (int i = 0; i < parameterList.size(); i++) {
@@ -314,7 +392,14 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
 
       for (UnsolvedClassOrInterfaceAlternates alternate : getAlternateDeclaringTypes()) {
         for (String fqn : alternate.getFullyQualifiedNames()) {
-          fqns.add(fqn + "#" + methodSignature);
+          // A constructor is named for the type that declares it (JLS 8.8.1), so every alternate
+          // declaring type contributes a key under its own simple name.
+          String name =
+              methodAlternate.isConstructor()
+                  ? QualifiedTypeName.parse(fqn).simpleName()
+                  : methodAlternate.getName();
+
+          fqns.add(fqn + "#" + name + methodSignature);
         }
       }
     }
@@ -430,6 +515,11 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
   }
 
   @Override
+  public boolean isConstructor() {
+    return getAlternates().get(0).isConstructor();
+  }
+
+  @Override
   public List<MemberType> getThrownExceptions() {
     return getAlternates().get(0).getThrownExceptions();
   }
@@ -471,7 +561,8 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
               alternate.getMustPreserveNodes(),
               alternate.getAccessModifier(),
               alternate.isStatic(),
-              alternate.getTypeVariableNames());
+              alternate.getTypeVariableNames(),
+              alternate.isConstructor());
       copy.addThrownException(exception);
       throwing.add(copy);
     }
@@ -554,7 +645,8 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
                 alternate.getMustPreserveNodes(),
                 alternate.getAccessModifier(),
                 alternate.isStatic(),
-                alternate.getTypeVariableNames());
+                alternate.getTypeVariableNames(),
+                alternate.isConstructor());
         addAlternate(newAlternate);
       }
 
@@ -596,7 +688,8 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
                   alternate.getMustPreserveNodes(),
                   alternate.getAccessModifier(),
                   alternate.isStatic(),
-                  alternate.getTypeVariableNames());
+                  alternate.getTypeVariableNames(),
+                  alternate.isConstructor());
 
           addAlternate(newAlternate);
         }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodAlternates.java
@@ -2,7 +2,6 @@ package org.checkerframework.specimin.unsolved;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -11,27 +10,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.specimin.JavaParserUtil;
-import org.checkerframework.specimin.QualifiedTypeName;
 
 /**
- * /** Given a name, return type, a set of parameters and a set of potential encapsulating classes,
- * this class allows for alternates of the same method to be generated in different locations. If a
- * class were:
- *
- * <pre><code>
- * class A extends B implements C {
- *    void x() {
- *      int y = a();
- *    }
- * }
- * </code></pre>
- *
- * where B and C are both unresolvable, method a() could be in either one.
- *
- * <p>For type parameters, you may always assume the following convention: T, T1, T2, ...
+ * Alternates of one synthetic method: everything {@link UnsolvedCallableAlternates} has, plus the
+ * name and return type that only a method has. See {@link UnsolvedConstructorAlternates} for the
+ * constructor case.
  */
-public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedMethod>
-    implements UnsolvedMethodCommon {
+public class UnsolvedMethodAlternates extends UnsolvedCallableAlternates<UnsolvedMethod> {
   /**
    * Creates a new instance of UnsolvedMethodAlternates. Private constructor; use the create
    * methods.
@@ -100,16 +85,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
       List<Set<MemberType>> parameters,
       List<MemberType> exceptions,
       String accessModifier) {
-    if (alternateDeclaringTypes.isEmpty()) {
-      throw new RuntimeException(
-          "Unsolved method must have at least one potential declaring type.");
-    }
-
-    if (types.isEmpty()) {
-      throw new RuntimeException("Unsolved method must have at least one potential return type.");
-    }
-
-    UnsolvedMethodAlternates result = new UnsolvedMethodAlternates(alternateDeclaringTypes);
+    UnsolvedMethodAlternates result = checkAndCreate(alternateDeclaringTypes, types);
 
     for (List<MemberType> parameterList : JavaParserUtil.generateAllCombinations(parameters)) {
       for (MemberType type : types) {
@@ -140,16 +116,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
       List<UnsolvedClassOrInterfaceAlternates> alternateDeclaringTypes,
       List<Map<MemberType, @Nullable Node>> parameters,
       List<MemberType> exceptions) {
-    if (alternateDeclaringTypes.isEmpty()) {
-      throw new RuntimeException(
-          "Unsolved method must have at least one potential declaring type.");
-    }
-
-    if (types.isEmpty()) {
-      throw new RuntimeException("Unsolved method must have at least one potential return type.");
-    }
-
-    UnsolvedMethodAlternates result = new UnsolvedMethodAlternates(alternateDeclaringTypes);
+    UnsolvedMethodAlternates result = checkAndCreate(alternateDeclaringTypes, types);
 
     for (List<Map.Entry<MemberType, @Nullable Node>> parameterList :
         JavaParserUtil.generateAllCombinationsForListOfMaps(parameters)) {
@@ -226,79 +193,25 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
   }
 
   /**
-   * Creates a new unsolved constructor declaration. There is no name parameter: JLS 8.8.1 requires
-   * a constructor to be declared under the simple name of its declaring type, so the name is read
-   * from the declaring type rather than supplied by the caller. Neither is there a return type
-   * parameter: a constructor declares none, which {@link UnsolvedMethod#toString} represents as the
-   * empty type.
+   * Checks that there is at least one declaring type and one return type, and creates an empty
+   * instance.
    *
-   * @param declaringTypes The types whose constructor this could be
-   * @param parameters Potential parameters of the constructor. Each set represents a possibility of
-   *     parameter types at that position
-   * @return The constructor definition
+   * @param alternateDeclaringTypes Potential declaring types of the method
+   * @param types The return types of the method
+   * @return an instance with no alternates yet
    */
-  public static UnsolvedMethodAlternates createConstructor(
-      List<UnsolvedClassOrInterfaceAlternates> declaringTypes, List<Set<MemberType>> parameters) {
-    return withConstructorsMarked(
-        create(
-            declaringTypes.get(0).getClassName(),
-            Set.of(new SolvedMemberType("")),
-            declaringTypes,
-            parameters));
-  }
-
-  /**
-   * Creates a new unsolved constructor declaration, recording nodes that must be preserved if a
-   * given parameter type is chosen. See {@link #createConstructor} for why there is no name
-   * parameter.
-   *
-   * @param declaringTypes The types whose constructor this could be
-   * @param parameters Potential parameters of the constructor. Each map represents a possibility of
-   *     parameter types at that position, along with nodes that must be preserved if that type is
-   *     chosen
-   * @return The constructor definition
-   */
-  public static UnsolvedMethodAlternates createConstructorWithPreservation(
-      List<UnsolvedClassOrInterfaceAlternates> declaringTypes,
-      List<Map<MemberType, @Nullable Node>> parameters) {
-    return withConstructorsMarked(
-        createWithPreservation(
-            declaringTypes.get(0).getClassName(),
-            Set.of(new SolvedMemberType("")),
-            declaringTypes,
-            parameters,
-            List.of()));
-  }
-
-  /**
-   * Replaces every alternate of the given method with a copy marked as a constructor. The create
-   * methods build ordinary methods; this is how the constructor factories above turn their result
-   * into constructors.
-   *
-   * @param method the method whose alternates should be marked
-   * @return {@code method}, for chaining
-   */
-  private static UnsolvedMethodAlternates withConstructorsMarked(UnsolvedMethodAlternates method) {
-    List<UnsolvedMethod> alternates = method.getAlternates();
-
-    for (int i = 0; i < alternates.size(); i++) {
-      UnsolvedMethod alternate = alternates.get(i);
-
-      alternates.set(
-          i,
-          new UnsolvedMethod(
-              alternate.getName(),
-              alternate.getReturnType(),
-              alternate.getParameterList(),
-              alternate.getThrownExceptions(),
-              alternate.getMustPreserveNodes(),
-              alternate.getAccessModifier(),
-              alternate.isStatic(),
-              alternate.getTypeVariableNames(),
-              true));
+  private static UnsolvedMethodAlternates checkAndCreate(
+      List<UnsolvedClassOrInterfaceAlternates> alternateDeclaringTypes, Set<MemberType> types) {
+    if (alternateDeclaringTypes.isEmpty()) {
+      throw new RuntimeException(
+          "Unsolved method must have at least one potential declaring type.");
     }
 
-    return method;
+    if (types.isEmpty()) {
+      throw new RuntimeException("Unsolved method must have at least one potential return type.");
+    }
+
+    return new UnsolvedMethodAlternates(alternateDeclaringTypes);
   }
 
   /**
@@ -333,8 +246,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
                   Set.of((Node) entry.getValue()),
                   old.getAccessModifier(),
                   old.isStatic(),
-                  old.getTypeVariableNames(),
-                  old.isConstructor());
+                  old.getTypeVariableNames());
           addAlternate(method);
         }
       }
@@ -365,113 +277,6 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
     }
   }
 
-  @Override
-  public Set<String> getFullyQualifiedNames() {
-    Set<String> fqns = new LinkedHashSet<>();
-
-    for (UnsolvedMethod methodAlternate : getAlternates()) {
-      // The name is prepended below, once per declaring type: a constructor takes its name from
-      // the type that declares it, so it is not the same for every key built here.
-      StringBuilder methodSignature = new StringBuilder("(");
-
-      List<MemberType> parameterList = methodAlternate.getParameterList();
-      for (int i = 0; i < parameterList.size(); i++) {
-        MemberType param = parameterList.get(i);
-
-        // This is safe because all simple names are the same for unsolved types
-        // and there is only one FQN for solved types
-        methodSignature.append(
-            JavaParserUtil.getSimpleNameFromQualifiedName(JavaParserUtil.erase(param.toString())));
-
-        if (i + 1 < parameterList.size()) {
-          methodSignature.append(", ");
-        }
-      }
-
-      methodSignature.append(')');
-
-      for (UnsolvedClassOrInterfaceAlternates alternate : getAlternateDeclaringTypes()) {
-        for (String fqn : alternate.getFullyQualifiedNames()) {
-          // A constructor is named for the type that declares it (JLS 8.8.1), so every alternate
-          // declaring type contributes a key under its own simple name.
-          String name =
-              methodAlternate.isConstructor()
-                  ? QualifiedTypeName.parse(fqn).simpleName()
-                  : methodAlternate.getName();
-
-          fqns.add(fqn + "#" + name + methodSignature);
-        }
-      }
-    }
-
-    return fqns;
-  }
-
-  /** Makes this method static. */
-  @Override
-  public void setStatic() {
-    applyToAllAlternates(UnsolvedMethod::setStatic);
-  }
-
-  /**
-   * Gets the number of type variables.
-   *
-   * @return The number of type variables
-   */
-  @Override
-  public int getNumberOfTypeVariables() {
-    return getAlternates().get(0).getNumberOfTypeVariables();
-  }
-
-  /**
-   * Sets the number of type variables.
-   *
-   * @param number The number of type variables
-   */
-  @Override
-  public void setNumberOfTypeVariables(int number) {
-    applyToAllAlternates(UnsolvedMethod::setNumberOfTypeVariables, number);
-  }
-
-  @Override
-  public String getTypeVariableName(int index) {
-    return getAlternates().get(0).getTypeVariableName(index);
-  }
-
-  @Override
-  public void declareTypeVariables(List<String> names) {
-    applyToAllAlternates(UnsolvedMethod::declareTypeVariables, names);
-  }
-
-  /**
-   * Returns whether the given type is one of the type variables bound by this method's own
-   * declaration (i.e. a name introduced by this method, such as the {@code T} in {@code <T> T
-   * get()}).
-   *
-   * <p>Such a name is only meaningful inside the declaration that binds it. Callers that are about
-   * to use a type outside of that declaration -- for example, to describe the type of an expression
-   * at a call site -- must not use the name, because it is not in scope there.
-   *
-   * @param type The type to check
-   * @return true if the type is a type variable bound by this method
-   */
-  public boolean isOwnTypeVariable(MemberType type) {
-    Set<String> fqns = type.getFullyQualifiedNames();
-    if (fqns.size() != 1 || !type.getTypeArguments().isEmpty()) {
-      return false;
-    }
-
-    String name = fqns.iterator().next();
-    for (UnsolvedMethod alternate : getAlternates()) {
-      for (int i = 0; i < alternate.getNumberOfTypeVariables(); i++) {
-        if (alternate.getTypeVariableName(i).equals(name)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
   /**
    * Gets the return types
    *
@@ -484,105 +289,12 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
   }
 
   /**
-   * Gets the parameter list, where each index contains a set of all possible parameter types at
-   * that index.
+   * Gets the name of this method.
    *
-   * @return The parameter list
+   * @return the name
    */
-  public List<Set<MemberType>> getParameterList() {
-    List<Set<MemberType>> parameterList = new ArrayList<>();
-
-    for (UnsolvedMethod alternate : getAlternates()) {
-      List<MemberType> parameters = alternate.getParameterList();
-
-      for (int i = 0; i < parameters.size(); i++) {
-        MemberType param = parameters.get(i);
-
-        if (parameterList.size() <= i) {
-          parameterList.add(new LinkedHashSet<>());
-        }
-
-        parameterList.get(i).add(param);
-      }
-    }
-
-    return parameterList;
-  }
-
-  @Override
   public String getName() {
     return getAlternates().get(0).getName();
-  }
-
-  @Override
-  public boolean isConstructor() {
-    return getAlternates().get(0).isConstructor();
-  }
-
-  @Override
-  public List<MemberType> getThrownExceptions() {
-    return getAlternates().get(0).getThrownExceptions();
-  }
-
-  @Override
-  public void addThrownException(MemberType exception) {
-    applyToAllAlternates(UnsolvedMethod::addThrownException, exception);
-  }
-
-  /**
-   * Records that this method might declare the given exception in its throws clause, by adding a
-   * copy of each existing alternate with the exception added. Use this instead of {@link
-   * #addThrownException} when it is not certain that this method is the one that throws the
-   * exception.
-   *
-   * <p>Note that {@link UnsolvedMethod#equals} ignores the throws clause, so a later call to {@link
-   * #removeDuplicateAlternates()} collapses the alternates added here back into whichever of the
-   * two possibilities comes first.
-   *
-   * @param exception the exception that this method might throw
-   * @param preferred whether the alternates that declare the exception should be preferred; if
-   *     true, they are placed before the alternates that do not declare it
-   */
-  public void addAlternatesWithThrownException(MemberType exception, boolean preferred) {
-    List<UnsolvedMethod> throwing = new ArrayList<>();
-
-    for (UnsolvedMethod alternate : getAlternates()) {
-      if (alternate.getThrownExceptions().contains(exception)) {
-        // This method is already known to throw the exception; there is no alternative to record.
-        return;
-      }
-
-      UnsolvedMethod copy =
-          new UnsolvedMethod(
-              alternate.getName(),
-              alternate.getReturnType(),
-              alternate.getParameterList(),
-              alternate.getThrownExceptions(),
-              alternate.getMustPreserveNodes(),
-              alternate.getAccessModifier(),
-              alternate.isStatic(),
-              alternate.getTypeVariableNames(),
-              alternate.isConstructor());
-      copy.addThrownException(exception);
-      throwing.add(copy);
-    }
-
-    if (preferred) {
-      getAlternates().addAll(0, throwing);
-    } else {
-      getAlternates().addAll(throwing);
-    }
-  }
-
-  /**
-   * Use with caution: this method sets all alternates' return types to the same type.
-   *
-   * <p>{@inheritDoc}
-   */
-  @Override
-  public void setReturnType(MemberType memberType) {
-    applyToAllAlternates(UnsolvedMethod::setReturnType, memberType);
-    removeDuplicateAlternates();
   }
 
   /**
@@ -645,8 +357,7 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
                 alternate.getMustPreserveNodes(),
                 alternate.getAccessModifier(),
                 alternate.isStatic(),
-                alternate.getTypeVariableNames(),
-                alternate.isConstructor());
+                alternate.getTypeVariableNames());
         addAlternate(newAlternate);
       }
 
@@ -654,66 +365,17 @@ public class UnsolvedMethodAlternates extends UnsolvedSymbolAlternates<UnsolvedM
     }
   }
 
-  /**
-   * Replaces a parameter type with new parameter types in all alternates.
-   *
-   * @param oldType The parameter type to replace
-   * @param newTypes The parameter types to replace with
-   */
-  public void replaceParameterType(MemberType oldType, Set<MemberType> newTypes) {
-    int originalSize = getAlternates().size();
-    for (int i = 0; i < originalSize; i++) {
-      UnsolvedMethod alternate = getAlternates().get(i);
-
-      List<MemberType> parameterList = alternate.getParameterList();
-      boolean hasOldType = parameterList.contains(oldType);
-
-      if (hasOldType) {
-        boolean isFirst = true;
-        for (MemberType newType : newTypes) {
-          if (isFirst) {
-            alternate.replaceParameterType(oldType, newType);
-            isFirst = false;
-            continue;
-          }
-
-          List<MemberType> newParameterList =
-              parameterList.stream().map(param -> param.equals(oldType) ? newType : param).toList();
-          UnsolvedMethod newAlternate =
-              new UnsolvedMethod(
-                  alternate.getName(),
-                  alternate.getReturnType(),
-                  newParameterList,
-                  alternate.getThrownExceptions(),
-                  alternate.getMustPreserveNodes(),
-                  alternate.getAccessModifier(),
-                  alternate.isStatic(),
-                  alternate.getTypeVariableNames(),
-                  alternate.isConstructor());
-
-          addAlternate(newAlternate);
-        }
-      }
-    }
-  }
-
   @Override
-  public String getAccessModifier() {
-    return getAlternates().get(0).getAccessModifier();
-  }
-
-  @Override
-  public void setAccessModifier(String accessModifier) {
-    applyToAllAlternates(UnsolvedMethod::setAccessModifier, accessModifier);
-  }
-
-  @Override
-  public void setContent(String content) {
-    applyToAllAlternates(UnsolvedMethod::setContent, content);
-  }
-
-  @Override
-  public boolean isStatic() {
-    return getAlternates().get(0).isStatic();
+  protected UnsolvedMethod copyWithParameters(
+      UnsolvedMethod alternate, List<MemberType> parameterList) {
+    return new UnsolvedMethod(
+        alternate.getName(),
+        alternate.getReturnType(),
+        parameterList,
+        alternate.getThrownExceptions(),
+        alternate.getMustPreserveNodes(),
+        alternate.getAccessModifier(),
+        alternate.isStatic(),
+        alternate.getTypeVariableNames());
   }
 }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodCommon.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethodCommon.java
@@ -16,6 +16,15 @@ public interface UnsolvedMethodCommon {
   String getName();
 
   /**
+   * Returns whether this is a constructor rather than an ordinary method. A constructor's name is
+   * not its own: JLS 8.8.1 requires it to be the simple name of the declaring type, so it is read
+   * from that type wherever the name is needed rather than trusted from {@link #getName}.
+   *
+   * @return true if this is a constructor
+   */
+  boolean isConstructor();
+
+  /**
    * Getter for the throws list.
    *
    * @return the throws list

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolEnumerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolEnumerator.java
@@ -23,8 +23,8 @@ public class UnsolvedSymbolEnumerator {
   /** The unsolved fields that must be included in the output. */
   private final Set<UnsolvedFieldAlternates> unsolvedFields = new LinkedHashSet<>();
 
-  /** The unsolved methods that must be included in the output. */
-  private final Set<UnsolvedMethodAlternates> unsolvedMethods = new LinkedHashSet<>();
+  /** The unsolved methods and constructors that must be included in the output. */
+  private final Set<UnsolvedCallableAlternates<?>> unsolvedMethods = new LinkedHashSet<>();
 
   /**
    * Creates a new instance of UnsolvedSymbolEnumerator.
@@ -41,12 +41,12 @@ public class UnsolvedSymbolEnumerator {
         }
 
         unsolvedFields.add(field);
-      } else if (unsolvedSymbol instanceof UnsolvedMethodAlternates method) {
+      } else if (unsolvedSymbol instanceof UnsolvedCallableAlternates<?> callable) {
         if (unsolvedSymbol.getAlternateDeclaringTypes().isEmpty()) {
           continue;
         }
 
-        unsolvedMethods.add(method);
+        unsolvedMethods.add(callable);
       }
     }
   }
@@ -98,10 +98,10 @@ public class UnsolvedSymbolEnumerator {
       addAllUsedTypesToSet(field.getType(), outerTypes, outerTypesToInnerTypes);
     }
 
-    Map<UnsolvedClassOrInterface, Set<UnsolvedMethod>> typesToMethods = new LinkedHashMap<>();
+    Map<UnsolvedClassOrInterface, Set<UnsolvedCallable>> typesToMethods = new LinkedHashMap<>();
 
-    for (UnsolvedMethodAlternates unsolved : unsolvedMethods) {
-      UnsolvedMethod method = unsolved.getAlternates().get(0);
+    for (UnsolvedCallableAlternates<?> unsolved : unsolvedMethods) {
+      UnsolvedCallable method = unsolved.getAlternates().get(0);
       UnsolvedClassOrInterfaceAlternates typeAlternates =
           unsolved.getAlternateDeclaringTypes().get(0);
       UnsolvedClassOrInterface type = typeAlternates.getAlternates().get(0);
@@ -113,7 +113,10 @@ public class UnsolvedSymbolEnumerator {
 
       typesToMethods.get(type).add(method);
 
-      addAllUsedTypesToSet(method.getReturnType(), outerTypes, outerTypesToInnerTypes);
+      // Only a method has a return type (JLS 8.8.1).
+      if (method instanceof UnsolvedMethod asMethod) {
+        addAllUsedTypesToSet(asMethod.getReturnType(), outerTypes, outerTypesToInnerTypes);
+      }
 
       for (MemberType parameterType : method.getParameterList()) {
         addAllUsedTypesToSet(parameterType, outerTypes, outerTypesToInnerTypes);
@@ -149,7 +152,7 @@ public class UnsolvedSymbolEnumerator {
   private String getTypeDeclarationAsString(
       UnsolvedClassOrInterface type,
       Map<UnsolvedClassOrInterface, Set<UnsolvedField>> typesToFields,
-      Map<UnsolvedClassOrInterface, Set<UnsolvedMethod>> typesToMethods,
+      Map<UnsolvedClassOrInterface, Set<UnsolvedCallable>> typesToMethods,
       Map<UnsolvedClassOrInterface, Set<UnsolvedClassOrInterface>> outerTypesToInnerTypes,
       Set<Node> ableToRemove,
       boolean isInnerClass) {
@@ -159,7 +162,7 @@ public class UnsolvedSymbolEnumerator {
       fields = Set.of();
     }
 
-    Set<UnsolvedMethod> methods = typesToMethods.get(type);
+    Set<UnsolvedCallable> methods = typesToMethods.get(type);
 
     if (methods == null) {
       methods = Set.of();
@@ -177,7 +180,7 @@ public class UnsolvedSymbolEnumerator {
       ableToRemove.removeAll(field.getMustPreserveNodes());
     }
 
-    for (UnsolvedMethod method : methods) {
+    for (UnsolvedCallable method : methods) {
       ableToRemove.removeAll(method.getMustPreserveNodes());
     }
 

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolEnumerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolEnumerator.java
@@ -6,7 +6,9 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.specimin.JavaParserUtil;
+import org.checkerframework.specimin.QualifiedTypeName;
 import org.checkerframework.specimin.Slicer;
 
 /**
@@ -252,6 +254,47 @@ public class UnsolvedSymbolEnumerator {
             .computeIfAbsent(declaringType.getAlternates().get(0), k -> new LinkedHashSet<>())
             .add(alternate);
       }
+
+      // A nested type is emitted only inside its enclosing type's declaration, so filing it above
+      // is not enough: the type that encloses it has to be placed as well, and it may be reachable
+      // by no other route. A single-type-import declaration may name a nested type (JLS 7.5.1), in
+      // which case the enclosing type is never written in the input at all.
+      //
+      // Only the enclosure of the alternate this best effort chose is placed. The other alternate
+      // declaring types are enclosures of the alternates it did not choose, and emitting those
+      // would emit whole types that nothing in the output refers to.
+      UnsolvedClassOrInterfaceAlternates enclosing = chosenEnclosingType(type);
+
+      if (enclosing != null) {
+        addTypeToCorrectDataStructure(enclosing, outerTypes, outerTypesToInnerTypes);
+      }
     }
+  }
+
+  /**
+   * Returns the alternate declaring type that encloses the alternate of {@code type} that this best
+   * effort chose, i.e. the one whose fully-qualified name is that alternate's qualifier.
+   *
+   * @param type a type that has at least one alternate declaring type
+   * @return the enclosing type of the chosen alternate, or null if no alternate declaring type is
+   *     that alternate's qualifier
+   */
+  private @Nullable UnsolvedClassOrInterfaceAlternates chosenEnclosingType(
+      UnsolvedClassOrInterfaceAlternates type) {
+    QualifiedTypeName enclosingName =
+        QualifiedTypeName.parse(type.getAlternates().get(0).getFullyQualifiedName())
+            .enclosingName();
+
+    if (enclosingName == null) {
+      return null;
+    }
+
+    for (UnsolvedClassOrInterfaceAlternates declaringType : type.getAlternateDeclaringTypes()) {
+      if (declaringType.getFullyQualifiedNames().contains(enclosingName.toString())) {
+        return declaringType;
+      }
+    }
+
+    return null;
   }
 }

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -71,7 +71,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -80,6 +79,7 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.specimin.JavaLangUtils;
 import org.checkerframework.specimin.JavaParserUtil;
+import org.checkerframework.specimin.QualifiedTypeName;
 import org.checkerframework.specimin.Resolver;
 
 /**
@@ -216,7 +216,6 @@ public class UnsolvedSymbolGenerator {
     } else if (node instanceof ObjectCreationExpr
         || node instanceof ExplicitConstructorInvocationStmt) {
       UnsolvedClassOrInterfaceAlternates scope;
-      String constructorName;
       List<Expression> arguments;
       int numberOfTypeParams = 0;
       // The type being instantiated plays the role a receiver's type plays for a method call: it
@@ -235,7 +234,6 @@ public class UnsolvedSymbolGenerator {
         // Do not generate here; that should be taken care of in the inferContextImpl call above.
         scope = (UnsolvedClassOrInterfaceAlternates) findExistingAndUpdateFQNs(instantiatedType);
 
-        constructorName = constructor.getTypeAsString();
         arguments = constructor.getArguments();
 
         // While rare, constructors can have type parameters, just like how a method can define
@@ -262,7 +260,6 @@ public class UnsolvedSymbolGenerator {
           // Do not generate here; that should be taken care of in the inferContextImpl call above.
           scope = (UnsolvedClassOrInterfaceAlternates) findExistingAndUpdateFQNs(instantiatedType);
 
-          constructorName = superClass.getNameAsString();
           arguments = constructor.getArguments();
         } else {
           // We should never reach this case unless the user inputted a bad program (i.e.
@@ -280,14 +277,7 @@ public class UnsolvedSymbolGenerator {
       // A constructor call indicates a class
       scope.setType(UnsolvedClassOrInterfaceType.CLASS);
 
-      handleConstructorCall(
-          scope,
-          JavaParserUtil.erase(constructorName),
-          arguments,
-          numberOfTypeParams,
-          node,
-          instantiatedType,
-          result);
+      handleConstructorCall(scope, arguments, numberOfTypeParams, node, instantiatedType, result);
     } else if (node instanceof MethodDeclaration methodDecl) {
       handleMethodDeclarationWithOverride(methodDecl, result);
     }
@@ -1588,7 +1578,6 @@ public class UnsolvedSymbolGenerator {
    * constructor invocation statements (super/this) and constructor calls (new ...()).
    *
    * @param location The location of the constructor
-   * @param constructorName The name of the constructor
    * @param arguments The arguments of the constructor call
    * @param numberOfTypeParams The number of type parameters of the constructor only
    * @param callSite The constructor call, used to find the calling context's type variables
@@ -1598,7 +1587,6 @@ public class UnsolvedSymbolGenerator {
    */
   private void handleConstructorCall(
       UnsolvedClassOrInterfaceAlternates location,
-      String constructorName,
       List<Expression> arguments,
       int numberOfTypeParams,
       Node callSite,
@@ -1649,7 +1637,7 @@ public class UnsolvedSymbolGenerator {
         potentialFQNs.add(
             potentialScopeFQN
                 + "#"
-                + constructorName
+                + QualifiedTypeName.parse(potentialScopeFQN).simpleName()
                 + "("
                 + String.join(", ", simpleNamesCombo)
                 + ")");
@@ -1670,12 +1658,8 @@ public class UnsolvedSymbolGenerator {
               argumentToParameterPotentialFQNsWithMethodRefsHandled);
 
       UnsolvedMethodAlternates generatedMethod =
-          UnsolvedMethodAlternates.createWithPreservation(
-              constructorName,
-              Set.of(new SolvedMemberType("")),
-              List.of(location),
-              parametersToMustPreserve,
-              List.of());
+          UnsolvedMethodAlternates.createConstructorWithPreservation(
+              List.of(location), parametersToMustPreserve);
 
       addNewSymbolToGeneratedSymbolsMap(generatedMethod);
 
@@ -2494,8 +2478,12 @@ public class UnsolvedSymbolGenerator {
 
       for (Set<String> set : potentialScopeFQNs) {
         for (String potentialScopeFQN : set) {
+          // A constructor is named for the type that declares it (JLS 8.8.1).
+          String name =
+              isConstructor ? QualifiedTypeName.parse(potentialScopeFQN).simpleName() : methodName;
+
           potentialFQNs.add(
-              potentialScopeFQN + "#" + methodName + "(" + String.join(", ", simpleNames) + ")");
+              potentialScopeFQN + "#" + name + "(" + String.join(", ", simpleNames) + ")");
         }
       }
 
@@ -2503,8 +2491,10 @@ public class UnsolvedSymbolGenerator {
 
       if (generated == null) {
         UnsolvedMethodAlternates generatedMethod =
-            UnsolvedMethodAlternates.create(
-                methodName, Set.of(returnType), scope, parametersAsMemberType);
+            isConstructor
+                ? UnsolvedMethodAlternates.createConstructor(scope, parametersAsMemberType)
+                : UnsolvedMethodAlternates.create(
+                    methodName, Set.of(returnType), scope, parametersAsMemberType);
 
         if (isStatic) {
           generatedMethod.setStatic();
@@ -2793,7 +2783,7 @@ public class UnsolvedSymbolGenerator {
                 continue;
               }
 
-              if (!Objects.equals(method.getName(), syntheticType.getClassName())) {
+              if (!method.isConstructor()) {
                 continue;
               }
 
@@ -2803,11 +2793,7 @@ public class UnsolvedSymbolGenerator {
 
             if (!foundConstructor) {
               UnsolvedMethodAlternates constructor =
-                  UnsolvedMethodAlternates.create(
-                      syntheticType.getClassName(),
-                      Set.of(new SolvedMemberType("")),
-                      List.of(syntheticType),
-                      List.of());
+                  UnsolvedMethodAlternates.createConstructor(List.of(syntheticType), List.of());
 
               constructor.setContent(superCall);
               toAdd.add(constructor);
@@ -5126,7 +5112,6 @@ public class UnsolvedSymbolGenerator {
    */
   private Set<String> getFQNsForUnsolvableConstructor(Node node) {
     UnsolvedClassOrInterfaceAlternates scope;
-    String constructorName;
     List<Expression> arguments;
 
     if (node instanceof ObjectCreationExpr constructor) {
@@ -5135,7 +5120,6 @@ public class UnsolvedSymbolGenerator {
               findExistingAndUpdateFQNs(
                   fullyQualifiedNameGenerator.getFQNsFromType(constructor.getType()));
 
-      constructorName = constructor.getTypeAsString();
       arguments = constructor.getArguments();
     } else if (node instanceof ExplicitConstructorInvocationStmt constructor) {
       // If it's unresolvable, it's a constructor in the unsolved parent class
@@ -5147,7 +5131,6 @@ public class UnsolvedSymbolGenerator {
             (UnsolvedClassOrInterfaceAlternates)
                 findExistingAndUpdateFQNs(fullyQualifiedNameGenerator.getFQNsFromType(superClass));
 
-        constructorName = superClass.getNameAsString();
         arguments = constructor.getArguments();
       } else {
         // We should never reach this case unless the user inputted a bad program (i.e.
@@ -5164,9 +5147,6 @@ public class UnsolvedSymbolGenerator {
     if (scope == null) {
       throw new RuntimeException("Scope not created when it should've been");
     }
-
-    constructorName =
-        JavaParserUtil.getSimpleNameFromQualifiedName(JavaParserUtil.erase(constructorName));
 
     List<Set<String>> simpleNames = new ArrayList<>();
 
@@ -5187,7 +5167,7 @@ public class UnsolvedSymbolGenerator {
         potentialFQNs.add(
             potentialScopeFQN
                 + "#"
-                + constructorName
+                + QualifiedTypeName.parse(potentialScopeFQN).simpleName()
                 + "("
                 + String.join(", ", simpleNameList)
                 + ")");

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -2406,15 +2406,15 @@ public class UnsolvedSymbolGenerator {
             FunctionalInterfaceHelper.getReturnTypeFromNormalizedFunctionalInterface(normalized);
       }
 
-      MemberType returnType;
+      // Null for a constructor reference, which resolves to a declaration that has no return type
+      // at all (JLS 8.8.1).
+      @Nullable MemberType returnType = null;
 
       boolean isVoid = false;
       if (isConstructor) {
         if (returnTypeFromTypeArgs != null) {
           parameters.remove(parameters.size() - 1);
         }
-
-        returnType = new SolvedMemberType("");
       } else {
         if (returnTypeFromTypeArgs != null) {
           parameters.remove(parameters.size() - 1);
@@ -2490,16 +2490,27 @@ public class UnsolvedSymbolGenerator {
       UnsolvedSymbolAlternates<?> generated = findExistingAndUpdateFQNs(potentialFQNs);
 
       if (generated == null) {
-        UnsolvedCallableAlternates<?> generatedMethod =
-            isConstructor
-                ? UnsolvedConstructorAlternates.create(scope, parametersAsMemberType)
-                : UnsolvedMethodAlternates.create(
-                    methodName, Set.of(returnType), scope, parametersAsMemberType);
+        UnsolvedCallableAlternates<?> generatedMethod;
 
-        // isStatic is only ever set for a method: a constructor reference's scope is never a
-        // receiver, so the branch that computes it is skipped for one.
-        if (isStatic) {
-          generatedMethod.setStatic();
+        if (isConstructor) {
+          generatedMethod = UnsolvedConstructorAlternates.create(scope, parametersAsMemberType);
+        } else {
+          if (returnType == null) {
+            throw new RuntimeException(
+                "A method reference that is not a constructor reference must have a return type: "
+                    + methodRef);
+          }
+
+          UnsolvedMethodAlternates asMethod =
+              UnsolvedMethodAlternates.create(
+                  methodName, Set.of(returnType), scope, parametersAsMemberType);
+
+          // Only a method can be static (JLS 8.8).
+          if (isStatic) {
+            asMethod.setStatic();
+          }
+
+          generatedMethod = asMethod;
         }
 
         if (methodRef.getTypeArguments().isPresent()) {
@@ -3281,7 +3292,6 @@ public class UnsolvedSymbolGenerator {
                 nodeWithArgs, fqnsToCompilationUnits);
 
         if (withUnresolvableArgs.isEmpty()) {
-          // Only the parameter types are read below, which a constructor has just as a method does.
           UnsolvedCallableAlternates<?> genMethod;
           if (node instanceof MethodCallExpr methodCall) {
             Collection<Set<String>> methodScope =

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -1646,7 +1646,7 @@ public class UnsolvedSymbolGenerator {
 
     UnsolvedSymbolAlternates<?> generated = findExistingAndUpdateFQNs(potentialFQNs);
 
-    if (!(generated instanceof UnsolvedMethodAlternates)) {
+    if (!(generated instanceof UnsolvedConstructorAlternates)) {
       for (Expression argument : arguments) {
         inferContextImpl(argument, result);
       }
@@ -1657,8 +1657,8 @@ public class UnsolvedSymbolGenerator {
               argumentToParameterPotentialFQNs,
               argumentToParameterPotentialFQNsWithMethodRefsHandled);
 
-      UnsolvedMethodAlternates generatedMethod =
-          UnsolvedMethodAlternates.createConstructorWithPreservation(
+      UnsolvedConstructorAlternates generatedMethod =
+          UnsolvedConstructorAlternates.createWithPreservation(
               List.of(location), parametersToMustPreserve);
 
       addNewSymbolToGeneratedSymbolsMap(generatedMethod);
@@ -2490,12 +2490,14 @@ public class UnsolvedSymbolGenerator {
       UnsolvedSymbolAlternates<?> generated = findExistingAndUpdateFQNs(potentialFQNs);
 
       if (generated == null) {
-        UnsolvedMethodAlternates generatedMethod =
+        UnsolvedCallableAlternates<?> generatedMethod =
             isConstructor
-                ? UnsolvedMethodAlternates.createConstructor(scope, parametersAsMemberType)
+                ? UnsolvedConstructorAlternates.create(scope, parametersAsMemberType)
                 : UnsolvedMethodAlternates.create(
                     methodName, Set.of(returnType), scope, parametersAsMemberType);
 
+        // isStatic is only ever set for a method: a constructor reference's scope is never a
+        // receiver, so the branch that computes it is skipped for one.
         if (isStatic) {
           generatedMethod.setStatic();
         }
@@ -2778,22 +2780,18 @@ public class UnsolvedSymbolGenerator {
             boolean foundConstructor = false;
 
             for (UnsolvedSymbolAlternates<?> alternate : generatedSymbols.values()) {
-              if (!(alternate instanceof UnsolvedMethodAlternates method)
+              if (!(alternate instanceof UnsolvedConstructorAlternates constructor)
                   || !alternate.getAlternateDeclaringTypes().contains(syntheticType)) {
                 continue;
               }
 
-              if (!method.isConstructor()) {
-                continue;
-              }
-
               foundConstructor = true;
-              method.setContent(superCall);
+              constructor.setContent(superCall);
             }
 
             if (!foundConstructor) {
-              UnsolvedMethodAlternates constructor =
-                  UnsolvedMethodAlternates.createConstructor(List.of(syntheticType), List.of());
+              UnsolvedConstructorAlternates constructor =
+                  UnsolvedConstructorAlternates.create(List.of(syntheticType), List.of());
 
               constructor.setContent(superCall);
               toAdd.add(constructor);
@@ -3283,7 +3281,8 @@ public class UnsolvedSymbolGenerator {
                 nodeWithArgs, fqnsToCompilationUnits);
 
         if (withUnresolvableArgs.isEmpty()) {
-          UnsolvedMethodAlternates genMethod;
+          // Only the parameter types are read below, which a constructor has just as a method does.
+          UnsolvedCallableAlternates<?> genMethod;
           if (node instanceof MethodCallExpr methodCall) {
             Collection<Set<String>> methodScope =
                 fullyQualifiedNameGenerator.getFQNsForExpressionLocation(methodCall);
@@ -3341,7 +3340,7 @@ public class UnsolvedSymbolGenerator {
               return UnsolvedGenerationResult.EMPTY;
             }
             genMethod =
-                (UnsolvedMethodAlternates)
+                (UnsolvedConstructorAlternates)
                     findExistingAndUpdateFQNs(getFQNsForUnsolvableConstructor(node));
 
             // The synthetic constructor's parameter types are computed from the current (best
@@ -3985,13 +3984,15 @@ public class UnsolvedSymbolGenerator {
     }
 
     for (UnsolvedSymbolAlternates<?> symbol : generatedSymbols.values()) {
-      if (symbol instanceof UnsolvedMethodAlternates method) {
-        if (method.getAlternates().stream()
+      if (symbol instanceof UnsolvedCallableAlternates<?> callable) {
+        if (callable.getAlternates().stream()
             .anyMatch(alt -> alt.getParameterList().contains(syntheticType))) {
-          oldFQNsToUpdated.put(method.getFullyQualifiedNames(), method);
-          method.replaceParameterType(syntheticType, Set.of(replaceWith));
+          oldFQNsToUpdated.put(callable.getFullyQualifiedNames(), callable);
+          callable.replaceParameterType(syntheticType, Set.of(replaceWith));
         }
-        if (method.getReturnTypes().contains(syntheticType)) {
+        // Only a method has a return type to replace (JLS 8.8.1).
+        if (callable instanceof UnsolvedMethodAlternates method
+            && method.getReturnTypes().contains(syntheticType)) {
           method.replaceReturnType(syntheticType, Set.of(replaceWith));
         }
       } else if (symbol instanceof UnsolvedFieldAlternates field) {
@@ -5410,22 +5411,26 @@ public class UnsolvedSymbolGenerator {
     }
 
     Set<String> keysToRemove = new HashSet<>();
-    Set<UnsolvedMethodAlternates> methodsWithChangedSignatures = new HashSet<>();
+    Set<UnsolvedCallableAlternates<?>> methodsWithChangedSignatures = new HashSet<>();
     for (UnsolvedSymbolAlternates<?> symbol : generatedSymbols.values()) {
-      if (symbol instanceof UnsolvedMethodAlternates method) {
-        for (MemberType returnType : method.getReturnTypes()) {
-          if (returnType instanceof UnsolvedMemberType unsolvedReturn) {
-            UnsolvedClassOrInterfaceAlternates unsolvedType = unsolvedReturn.getUnsolvedType();
-            SolvedMemberType correct = typeCorrect.get(unsolvedType);
-            if (correct != null) {
-              method.replaceReturnType(unsolvedReturn, correct);
+      if (symbol instanceof UnsolvedCallableAlternates<?> callable) {
+        // Only a method has a return type to correct (JLS 8.8.1); a constructor's parameters are
+        // corrected below just like a method's.
+        if (callable instanceof UnsolvedMethodAlternates method) {
+          for (MemberType returnType : method.getReturnTypes()) {
+            if (returnType instanceof UnsolvedMemberType unsolvedReturn) {
+              UnsolvedClassOrInterfaceAlternates unsolvedType = unsolvedReturn.getUnsolvedType();
+              SolvedMemberType correct = typeCorrect.get(unsolvedType);
+              if (correct != null) {
+                method.replaceReturnType(unsolvedReturn, correct);
+              }
             }
           }
         }
 
-        Set<String> oldSignatures = method.getFullyQualifiedNames();
+        Set<String> oldSignatures = callable.getFullyQualifiedNames();
         boolean signatureChanged = false;
-        for (UnsolvedMethod alternate : method.getAlternates()) {
+        for (UnsolvedCallable alternate : callable.getAlternates()) {
           for (MemberType paramType : alternate.getParameterList()) {
             if (paramType instanceof UnsolvedMemberType unsolvedParam) {
               UnsolvedClassOrInterfaceAlternates unsolvedType = unsolvedParam.getUnsolvedType();
@@ -5440,10 +5445,10 @@ public class UnsolvedSymbolGenerator {
 
         if (signatureChanged) {
           keysToRemove.addAll(oldSignatures);
-          methodsWithChangedSignatures.add(method);
+          methodsWithChangedSignatures.add(callable);
         }
 
-        method.removeDuplicateAlternates();
+        callable.removeDuplicateAlternates();
       } else if (symbol instanceof UnsolvedFieldAlternates field) {
         for (MemberType fieldType : field.getTypes()) {
           if (fieldType instanceof UnsolvedMemberType unsolvedType) {
@@ -5463,7 +5468,7 @@ public class UnsolvedSymbolGenerator {
       generatedSymbols.remove(signatureToRemove);
     }
 
-    for (UnsolvedMethodAlternates method : methodsWithChangedSignatures) {
+    for (UnsolvedCallableAlternates<?> method : methodsWithChangedSignatures) {
       addNewSymbolToGeneratedSymbolsMap(method);
     }
 

--- a/src/test/java/org/checkerframework/specimin/ConstructorParamPlaceholderReplacedTest.java
+++ b/src/test/java/org/checkerframework/specimin/ConstructorParamPlaceholderReplacedTest.java
@@ -1,0 +1,21 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that a synthetic constructor's parameter type is the type that the argument
+ * expression turns out to have, rather than the placeholder Specimin invents before it knows.
+ * {@code Helper.make()} has no declared type to read, so its result starts as a placeholder; the
+ * assignment on the next line settles it as {@code String}. The constructor must end up taking
+ * {@code String}, and no placeholder class may be left in the output.
+ */
+public class ConstructorParamPlaceholderReplacedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "constructorparamplaceholderreplaced",
+        new String[] {"example/Target.java"},
+        new String[] {"example.Target#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/ConstructorParamThrowableCorrectedTest.java
+++ b/src/test/java/org/checkerframework/specimin/ConstructorParamThrowableCorrectedTest.java
@@ -1,0 +1,22 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that making a synthetic type extend {@code Throwable} corrects the parameter
+ * types of synthetic <em>constructors</em>, not only of synthetic methods. Catching {@code
+ * UnsolvedException} forces it to extend {@code Throwable} (JLS 11.2), at which point {@code
+ * getMessage()} is Throwable's and returns {@code String}, so the placeholder Specimin invented for
+ * its result is withdrawn. The constructor that took that placeholder as a parameter has to be
+ * corrected too, or it names a type that is never emitted.
+ */
+public class ConstructorParamThrowableCorrectedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "constructorparamthrowablecorrected",
+        new String[] {"example/Target.java"},
+        new String[] {"example.Target#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/ConstructorRefAlreadyGeneratedTest.java
+++ b/src/test/java/org/checkerframework/specimin/ConstructorRefAlreadyGeneratedTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that a {@code ::new} reference to an already-generated synthetic constructor
+ * does not acquire a leading receiver parameter. An unbound reference to an <em>instance
+ * method</em> takes the receiver as an extra first parameter, but a constructor reference does not:
+ * its scope names the type being instantiated rather than a receiver, so the functional interface's
+ * parameters are the constructor's one for one (JLS 15.13.1). Applying the instance-method
+ * adjustment to a constructor invents a functional interface of the wrong arity, and Specimin then
+ * cannot find the method it just generated for {@code register}.
+ *
+ * <p>Specimin's choice of a no-argument {@code Supplier} here, rather than reusing the {@code
+ * Widget(String)} constructor established on the line above, is imprecise but compilable: nothing
+ * in the input says what shape {@code Registry.register} expects.
+ */
+public class ConstructorRefAlreadyGeneratedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "constructorrefalreadygenerated",
+        new String[] {"example/Target.java"},
+        new String[] {"example.Target#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NestedConstructorTest.java
+++ b/src/test/java/org/checkerframework/specimin/NestedConstructorTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that Specimin produces a compilable constructor when it must synthesize a nested
+ * class (here, {@code library.Outer.Nested}) whose constructor is invoked by the target method. A
+ * constructor's name is a simple name (JLS 8.8.1), so the synthetic constructor must be named
+ * {@code Nested}, not {@code Outer.Nested}.
+ */
+public class NestedConstructorTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nestedconstructor",
+        new String[] {"example/Target.java"},
+        new String[] {"example.Target#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NestedTypeImportedTest.java
+++ b/src/test/java/org/checkerframework/specimin/NestedTypeImportedTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that Specimin emits the enclosing type of a synthetic nested type even when the
+ * enclosing type is never named in the input. A single-type-import declaration may name a nested
+ * type (JLS 7.5.1), so {@code library.Outer} appears nowhere except as the enclosure of {@code
+ * Nested}; it still has to be declared for the output to compile.
+ */
+public class NestedTypeImportedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nestedtypeimported",
+        new String[] {"example/Target.java"},
+        new String[] {"example.Target#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/NestedTypeMethodRefTest.java
+++ b/src/test/java/org/checkerframework/specimin/NestedTypeMethodRefTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that Specimin can handle a method reference whose scope is a qualified,
+ * unsolvable nested type ({@code library.Outer.Nested}). The scope's leftmost identifier is {@code
+ * Outer}, which is what the import must be matched against (JLS 6.5.5.2); treating the whole name
+ * {@code Outer.Nested} as the identifier to look up loses the import.
+ */
+public class NestedTypeMethodRefTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nestedtypemethodref",
+        new String[] {"example/Target.java"},
+        new String[] {"example.Target#target()"});
+  }
+}

--- a/src/test/resources/constructorparamplaceholderreplaced/expected/example/Target.java
+++ b/src/test/resources/constructorparamplaceholderreplaced/expected/example/Target.java
@@ -1,0 +1,13 @@
+package example;
+
+import library.Helper;
+import library.Widget;
+
+public final class Target {
+
+    public void target() {
+        Widget widget = new Widget(Helper.make());
+        String actual = Helper.make();
+        System.out.println(widget + actual);
+    }
+}

--- a/src/test/resources/constructorparamplaceholderreplaced/expected/library/Helper.java
+++ b/src/test/resources/constructorparamplaceholderreplaced/expected/library/Helper.java
@@ -1,0 +1,8 @@
+package library;
+
+public class Helper {
+
+    public static java.lang.String make() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constructorparamplaceholderreplaced/expected/library/Widget.java
+++ b/src/test/resources/constructorparamplaceholderreplaced/expected/library/Widget.java
@@ -1,0 +1,8 @@
+package library;
+
+public class Widget {
+
+    public Widget(java.lang.String parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constructorparamplaceholderreplaced/input/example/Target.java
+++ b/src/test/resources/constructorparamplaceholderreplaced/input/example/Target.java
@@ -1,0 +1,12 @@
+package example;
+
+import library.Helper;
+import library.Widget;
+
+public final class Target {
+    public void target() {
+        Widget widget = new Widget(Helper.make());
+        String actual = Helper.make();
+        System.out.println(widget + actual);
+    }
+}

--- a/src/test/resources/constructorparamthrowablecorrected/expected/example/Target.java
+++ b/src/test/resources/constructorparamthrowablecorrected/expected/example/Target.java
@@ -1,0 +1,15 @@
+package example;
+
+import library.UnsolvedException;
+import library.Widget;
+
+public final class Target {
+
+    public void target() {
+        try {
+            Widget.risky();
+        } catch (UnsolvedException e) {
+            System.out.println(new Widget(e.getMessage()));
+        }
+    }
+}

--- a/src/test/resources/constructorparamthrowablecorrected/expected/library/LibraryWidgetRiskyReturnType.java
+++ b/src/test/resources/constructorparamthrowablecorrected/expected/library/LibraryWidgetRiskyReturnType.java
@@ -1,0 +1,4 @@
+package library;
+
+public class LibraryWidgetRiskyReturnType {
+}

--- a/src/test/resources/constructorparamthrowablecorrected/expected/library/UnsolvedException.java
+++ b/src/test/resources/constructorparamthrowablecorrected/expected/library/UnsolvedException.java
@@ -1,0 +1,4 @@
+package library;
+
+public class UnsolvedException extends java.lang.Exception {
+}

--- a/src/test/resources/constructorparamthrowablecorrected/expected/library/Widget.java
+++ b/src/test/resources/constructorparamthrowablecorrected/expected/library/Widget.java
@@ -1,0 +1,12 @@
+package library;
+
+public class Widget {
+
+    public Widget(java.lang.String parameter0) {
+        throw new java.lang.Error();
+    }
+
+    public static library.LibraryWidgetRiskyReturnType risky() throws library.UnsolvedException {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constructorparamthrowablecorrected/input/example/Target.java
+++ b/src/test/resources/constructorparamthrowablecorrected/input/example/Target.java
@@ -1,0 +1,14 @@
+package example;
+
+import library.UnsolvedException;
+import library.Widget;
+
+public final class Target {
+    public void target() {
+        try {
+            Widget.risky();
+        } catch (UnsolvedException e) {
+            System.out.println(new Widget(e.getMessage()));
+        }
+    }
+}

--- a/src/test/resources/constructorrefalreadygenerated/expected/example/Target.java
+++ b/src/test/resources/constructorrefalreadygenerated/expected/example/Target.java
@@ -1,0 +1,13 @@
+package example;
+
+import library.Registry;
+import library.Widget;
+
+public final class Target {
+
+    public void target() {
+        Widget seeded = new Widget("seed");
+        Registry.register(Widget::new);
+        System.out.println(seeded);
+    }
+}

--- a/src/test/resources/constructorrefalreadygenerated/expected/library/LibraryRegistryRegisterReturnType.java
+++ b/src/test/resources/constructorrefalreadygenerated/expected/library/LibraryRegistryRegisterReturnType.java
@@ -1,0 +1,4 @@
+package library;
+
+public class LibraryRegistryRegisterReturnType {
+}

--- a/src/test/resources/constructorrefalreadygenerated/expected/library/Registry.java
+++ b/src/test/resources/constructorrefalreadygenerated/expected/library/Registry.java
@@ -1,0 +1,8 @@
+package library;
+
+public class Registry {
+
+    public static <T> library.LibraryRegistryRegisterReturnType register(java.util.function.Supplier<T> parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constructorrefalreadygenerated/expected/library/Widget.java
+++ b/src/test/resources/constructorrefalreadygenerated/expected/library/Widget.java
@@ -1,0 +1,12 @@
+package library;
+
+public class Widget {
+
+    public Widget() {
+        throw new java.lang.Error();
+    }
+
+    public Widget(java.lang.String parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constructorrefalreadygenerated/input/example/Target.java
+++ b/src/test/resources/constructorrefalreadygenerated/input/example/Target.java
@@ -1,0 +1,12 @@
+package example;
+
+import library.Registry;
+import library.Widget;
+
+public final class Target {
+    public void target() {
+        Widget seeded = new Widget("seed");
+        Registry.register(Widget::new);
+        System.out.println(seeded);
+    }
+}

--- a/src/test/resources/nestedconstructor/expected/example/Target.java
+++ b/src/test/resources/nestedconstructor/expected/example/Target.java
@@ -1,0 +1,18 @@
+package example;
+
+import library.Outer;
+
+public final class Target {
+
+    private Outer.Nested nested;
+
+    private library.Outer.Nested alsoNested;
+
+    private Outer.Mid.Deeper deeper;
+
+    public void target() {
+        nested = new Outer.Nested();
+        alsoNested = new library.Outer.Nested();
+        deeper = new Outer.Mid.Deeper();
+    }
+}

--- a/src/test/resources/nestedconstructor/expected/library/Outer.java
+++ b/src/test/resources/nestedconstructor/expected/library/Outer.java
@@ -1,0 +1,21 @@
+package library;
+
+public class Outer {
+
+    public static class Mid {
+
+        public static class Deeper {
+
+            public Deeper() {
+                throw new java.lang.Error();
+            }
+        }
+    }
+
+    public static class Nested {
+
+        public Nested() {
+            throw new java.lang.Error();
+        }
+    }
+}

--- a/src/test/resources/nestedconstructor/input/example/Target.java
+++ b/src/test/resources/nestedconstructor/input/example/Target.java
@@ -1,0 +1,15 @@
+package example;
+
+import library.Outer;
+
+public final class Target {
+    private Outer.Nested nested;
+    private library.Outer.Nested alsoNested;
+    private Outer.Mid.Deeper deeper;
+
+    public void target() {
+        nested = new Outer.Nested();
+        alsoNested = new library.Outer.Nested();
+        deeper = new Outer.Mid.Deeper();
+    }
+}

--- a/src/test/resources/nestedtypeimported/expected/example/Target.java
+++ b/src/test/resources/nestedtypeimported/expected/example/Target.java
@@ -1,0 +1,12 @@
+package example;
+
+import library.Outer.Nested;
+
+public final class Target {
+
+    private Nested nested;
+
+    public void target() {
+        nested = new Nested();
+    }
+}

--- a/src/test/resources/nestedtypeimported/expected/library/Outer.java
+++ b/src/test/resources/nestedtypeimported/expected/library/Outer.java
@@ -1,0 +1,11 @@
+package library;
+
+public class Outer {
+
+    public static class Nested {
+
+        public Nested() {
+            throw new java.lang.Error();
+        }
+    }
+}

--- a/src/test/resources/nestedtypeimported/input/example/Target.java
+++ b/src/test/resources/nestedtypeimported/input/example/Target.java
@@ -1,0 +1,11 @@
+package example;
+
+import library.Outer.Nested;
+
+public final class Target {
+    private Nested nested;
+
+    public void target() {
+        nested = new Nested();
+    }
+}

--- a/src/test/resources/nestedtypemethodref/expected/example/Target.java
+++ b/src/test/resources/nestedtypemethodref/expected/example/Target.java
@@ -1,0 +1,12 @@
+package example;
+
+import java.util.function.Supplier;
+import library.Outer;
+
+public final class Target {
+
+    public void target() {
+        Supplier<String> s = Outer.Nested::foo;
+        s.get();
+    }
+}

--- a/src/test/resources/nestedtypemethodref/expected/library/Outer.java
+++ b/src/test/resources/nestedtypemethodref/expected/library/Outer.java
@@ -1,0 +1,11 @@
+package library;
+
+public class Outer {
+
+    public static class Nested {
+
+        public static java.lang.String foo() {
+            throw new java.lang.Error();
+        }
+    }
+}

--- a/src/test/resources/nestedtypemethodref/input/example/Target.java
+++ b/src/test/resources/nestedtypemethodref/input/example/Target.java
@@ -1,0 +1,11 @@
+package example;
+
+import java.util.function.Supplier;
+import library.Outer;
+
+public final class Target {
+    public void target() {
+        Supplier<String> s = Outer.Nested::foo;
+        s.get();
+    }
+}


### PR DESCRIPTION
Fixes #526.

Two major parts:
* better model how names are represented via the new `QualifiedTypeName` class. This class answers questions about names that can be precisely answered without a classpath, like "what's the first identifier" or "what's the simple name". This is most of what's needed for fixing #526, but we still need a way to distinguish methods and constructors. A simpler version of this PR (in my initial draft) added an `isConstructor` flag to `UnsolvedMethod`, but that's a bad way to do it: constructors and methods aren't quite the same, and that ought to be represented in the type system. That motivates:
* better model unsolved constructors vs methods. This is a pretty significant refactor that splits the old `UnsolvedMethod` and its related classes into three: a shared `UnsolvedCallable` (with most of the old `UnsolvedMethod` logic) and then its subclasses `UnsolvedMethod` and `UnsolvedConstructor`. This change makes the incorrect behavior in #526 no longer representable at all, and is the right thing to do in general - it should make a whole class of similar bugs unrepresentable (assuming I got it right).

Especially because of the second part of the change, this PR feels pretty high-risk to me. So, I'm going to run a few small experiments re:compilability before merging. New tests besides the regression test for #526 mostly cover things that I had to reason through during the second refactor that the existing suite didn't cover.