### PR TITLE
Make `Resolver#resolve`'s return type accurately reflect when it doesn't return a compatible instance, and add appropriate checks where it doesn't

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -960,9 +960,11 @@ public class JavaParserUtil {
         return resolved instanceof ReflectionFieldDeclaration;
       }
     } else if (expr.isMethodCallExpr()) {
-      ResolvedMethodDeclaration resolvedScopeMethod = Resolver.resolve(expr.asMethodCallExpr());
-
-      if (resolvedScopeMethod == null) {
+      // A call on an annotation member resolves to that member rather than to a method (JLS
+      // 9.6.1), which has no declared type to read here; treat it as unhandled, as for a call
+      // that does not resolve at all.
+      if (!(Resolver.resolve(expr.asMethodCallExpr())
+          instanceof ResolvedMethodDeclaration resolvedScopeMethod)) {
         return false;
       }
 
@@ -1689,9 +1691,9 @@ public class JavaParserUtil {
 
     TypeDeclaration<?> enclosingClass;
 
-    ResolvedEnumConstantDeclaration resolvedDecl = Resolver.resolve(enumConstant);
-
-    if (resolvedDecl == null) {
+    // An enum constant whose arguments are unresolvable resolves to the enum's constructor
+    // instead (see Resolver#WIDENED_NODE_KINDS), which is not a constant to read a type from.
+    if (!(Resolver.resolve(enumConstant) instanceof ResolvedEnumConstantDeclaration resolvedDecl)) {
       return List.of();
     }
     ResolvedType type = resolvedDecl.getType();
@@ -2653,9 +2655,9 @@ public class JavaParserUtil {
         }
       } else if (methodCallParent.getParentNode().orElse(null) instanceof MethodCallExpr methodCall
           && methodCall.getArguments().contains(methodCallParent)) {
-        ResolvedMethodDeclaration methodDecl = Resolver.resolve(methodCall);
-
-        if (methodDecl != null) {
+        // An annotation member (JLS 9.6.1) declares no parameters, so it cannot supply the
+        // parameter type this looks for.
+        if (Resolver.resolve(methodCall) instanceof ResolvedMethodDeclaration methodDecl) {
           int argPos = methodCall.getArgumentPosition(methodCallParent);
 
           try {

--- a/src/main/java/org/checkerframework/specimin/Resolver.java
+++ b/src/main/java/org/checkerframework/specimin/Resolver.java
@@ -292,7 +292,7 @@ public class Resolver {
   @SuppressWarnings("unchecked")
   // Safe for the same reason as in resolve: anything that is not a T has already been discarded.
   public static <T> @NonNull T resolveGuaranteeNonNull(Resolvable<T> toResolve) {
-    return (T) resolveGuaranteeNonNullWidened(toResolve);
+    return (@NonNull T) resolveGuaranteeNonNullWidened(toResolve);
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/Resolver.java
+++ b/src/main/java/org/checkerframework/specimin/Resolver.java
@@ -4,6 +4,7 @@ import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.TypeDeclaration;
@@ -29,9 +30,12 @@ import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
+import java.lang.reflect.ParameterizedType;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -97,31 +101,178 @@ public class Resolver {
   }
 
   /**
+   * Node kinds whose resolution can legitimately produce a declaration other than the one their
+   * {@code Resolvable<T>} type argument names, because JavaParser has no node for the declaration
+   * that is actually referred to. A record's constructor call names the record declaration, since a
+   * canonical constructor is implicitly declared (JLS 8.10.4); an enum constant names the enum's
+   * constructor; a constructor reference names a constructor rather than a method; and a call on an
+   * annotation member names that member (JLS 9.6.1), which is a value, not a method.
+   *
+   * <p>{@link #resolve} and {@link #resolveGuaranteeNonNull} are overloaded to return {@code
+   * Object} for exactly these kinds, so that callers are forced to dispatch on the runtime type.
+   * Any other kind of mismatch is rejected by {@link #discardIfWrongKind}, which keeps the generic
+   * signature honest. Adding a widening recovery path for a new node kind means adding the kind
+   * here <em>and</em> adding the matching overloads; {@code ResolverKindContractTest} enforces that
+   * the two stay in step.
+   */
+  private static final Set<Class<? extends Node>> WIDENED_NODE_KINDS =
+      Set.of(
+          ObjectCreationExpr.class,
+          MethodCallExpr.class,
+          MethodReferenceExpr.class,
+          EnumConstantDeclaration.class);
+
+  /** Cache for {@link #declaredResolvedKind}, which is reflective and called per recovery. */
+  private static final Map<Class<?>, Optional<Class<?>>> DECLARED_RESOLVED_KINDS =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Returns the type argument that {@code nodeClass} supplies to {@link Resolvable}, that is, the
+   * kind of declaration (or type) that resolving such a node is declared to produce.
+   *
+   * @param nodeClass The class of the node being resolved
+   * @return That type argument, or null if it cannot be determined
+   */
+  private static @Nullable Class<?> declaredResolvedKind(Class<?> nodeClass) {
+    return DECLARED_RESOLVED_KINDS
+        .computeIfAbsent(nodeClass, Resolver::computeDeclaredResolvedKind)
+        .orElse(null);
+  }
+
+  /**
+   * Computes the value cached by {@link #declaredResolvedKind}, by walking {@code nodeClass}'s
+   * supertypes for the {@link Resolvable} interface.
+   *
+   * @param nodeClass The class of the node being resolved
+   * @return That type argument, or an empty Optional if it cannot be determined
+   */
+  private static Optional<Class<?>> computeDeclaredResolvedKind(Class<?> nodeClass) {
+    for (Class<?> current = nodeClass; current != null; current = current.getSuperclass()) {
+      for (java.lang.reflect.Type itf : current.getGenericInterfaces()) {
+        if (itf instanceof ParameterizedType parameterized
+            && parameterized.getRawType() == Resolvable.class
+            && parameterized.getActualTypeArguments()[0] instanceof Class<?> argument) {
+          return Optional.of(argument);
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Discards a recovery-path result that is not what resolving {@code node} is declared to produce,
+   * unless {@code node} is one of the {@link #WIDENED_NODE_KINDS}.
+   *
+   * <p>Without this, the unchecked cast in {@link #resolve} reaches the caller as a {@code
+   * ClassCastException}. Null is the right answer for a discarded result rather than an exception:
+   * a recovery path that produces the wrong kind of thing has not found the declaration, and "not
+   * resolvable" is what every caller already handles. The type-versus-declaration case is the one
+   * that motivated this check -- {@link JavaParserUtil#tryResolveNodeIfInAnonymousClass} falls back
+   * to the node's <em>type</em>, which is no answer to "what declaration does this name?".
+   *
+   * @param node The node that was being resolved
+   * @param result The result a recovery path produced, possibly null
+   * @return {@code result}, or null if it is not a kind that {@code node} can resolve to
+   */
+  private static @Nullable Object discardIfWrongKind(Node node, @Nullable Object result) {
+    if (result == null || WIDENED_NODE_KINDS.stream().anyMatch(kind -> kind.isInstance(node))) {
+      return result;
+    }
+    Class<?> declared = declaredResolvedKind(node.getClass());
+    return declared == null || declared.isInstance(result) ? result : null;
+  }
+
+  /**
    * Resolves a resolvable node. Use instead of {@link Resolvable#resolve()} because this handles
    * all known exceptions, and returns null when otherwise unresolvable.
+   *
+   * <p>Overloads returning {@code Object} shadow this method for the node kinds whose resolution
+   * can widen; see {@link #WIDENED_NODE_KINDS}. For every other kind the result really is a {@code
+   * T}, because {@link #discardIfWrongKind} drops anything else.
    *
    * @param toResolve The node to resolve
    * @return The resolved object, or null if not resolvable
    * @param <T> The type to resolve to
    */
   @SuppressWarnings("unchecked")
-  // All casts to T are ok. It's not possible for toResolve to suddenly resolve to a different type.
+  // Safe: discardIfWrongKind has already dropped any result that is not a T, and the node kinds
+  // for which it permits a wider result are shadowed by the Object-returning overloads below.
   public static <T> @Nullable T resolve(Resolvable<T> toResolve) {
+    return (T) resolveWidened(toResolve);
+  }
+
+  /**
+   * Resolves an object creation expression. Returns {@code Object} rather than a {@code
+   * ResolvedConstructorDeclaration} because constructing a record resolves to the record's
+   * declaration; see {@link #WIDENED_NODE_KINDS}.
+   *
+   * @param toResolve The node to resolve
+   * @return The resolved object, or null if not resolvable
+   */
+  public static @Nullable Object resolve(ObjectCreationExpr toResolve) {
+    return resolveWidened(toResolve);
+  }
+
+  /**
+   * Resolves a method call. Returns {@code Object} rather than a {@code ResolvedMethodDeclaration}
+   * because a call on an annotation member resolves to that member; see {@link
+   * #WIDENED_NODE_KINDS}.
+   *
+   * @param toResolve The node to resolve
+   * @return The resolved object, or null if not resolvable
+   */
+  public static @Nullable Object resolve(MethodCallExpr toResolve) {
+    return resolveWidened(toResolve);
+  }
+
+  /**
+   * Resolves a method reference. Returns {@code Object} rather than a {@code
+   * ResolvedMethodDeclaration} because a constructor reference resolves to a constructor; see
+   * {@link #WIDENED_NODE_KINDS}.
+   *
+   * @param toResolve The node to resolve
+   * @return The resolved object, or null if not resolvable
+   */
+  public static @Nullable Object resolve(MethodReferenceExpr toResolve) {
+    return resolveWidened(toResolve);
+  }
+
+  /**
+   * Resolves an enum constant. Returns {@code Object} rather than a {@code
+   * ResolvedEnumConstantDeclaration} because an enum constant resolves to the enum's constructor
+   * when its arguments are unresolvable; see {@link #WIDENED_NODE_KINDS}.
+   *
+   * @param toResolve The node to resolve
+   * @return The resolved object, or null if not resolvable
+   */
+  public static @Nullable Object resolve(EnumConstantDeclaration toResolve) {
+    return resolveWidened(toResolve);
+  }
+
+  /**
+   * Implementation of every {@code resolve} overload: resolves the node, recovering from the
+   * exceptions JavaParser throws for cases it cannot handle.
+   *
+   * @param toResolve The node to resolve
+   * @return The resolved object, or null if not resolvable
+   */
+  private static @Nullable Object resolveWidened(Resolvable<?> toResolve) {
     if (fqnToCompilationUnits == null) {
       throw new UnsupportedOperationException(
           "fqnToCompilationUnits must be set before calling resolve");
     }
 
+    Node node = (Node) toResolve;
     try {
       return toResolve.resolve();
     } catch (UnsolvedSymbolException ex) {
-      return (T) tryAlternativeResolutionForUnsolvableNode((Node) toResolve);
+      return discardIfWrongKind(node, tryAlternativeResolutionForUnsolvableNode(node));
     } catch (IllegalStateException ex) {
-      return (T) Resolver.handleIllegalStateException(ex, (Node) toResolve);
+      return discardIfWrongKind(node, Resolver.handleIllegalStateException(ex, node));
     } catch (MethodAmbiguityException ex) {
-      return (T) Resolver.handleMethodAmbiguityException(ex, (Node) toResolve);
+      return discardIfWrongKind(node, Resolver.handleMethodAmbiguityException(ex, node));
     } catch (UnsupportedOperationException ex) {
-      return (T) Resolver.handleUnsupportedOperationException(ex, (Node) toResolve);
+      return discardIfWrongKind(node, Resolver.handleUnsupportedOperationException(ex, node));
     }
   }
 
@@ -131,49 +282,108 @@ public class Resolver {
    * exception if it is not. Typically used with declarations, since those are almost always
    * solvable.
    *
+   * <p>As with {@link #resolve}, overloads returning {@code Object} shadow this method for the node
+   * kinds whose resolution can widen; see {@link #WIDENED_NODE_KINDS}.
+   *
    * @param toResolve The node to resolve
    * @return The resolved object
    * @param <T> The type to resolve to
    */
   @SuppressWarnings("unchecked")
-  // All casts to T are ok. It's not possible for toResolve to suddenly resolve to a different type.
+  // Safe for the same reason as in resolve: anything that is not a T has already been discarded.
   public static <T> @NonNull T resolveGuaranteeNonNull(Resolvable<T> toResolve) {
-    T result;
+    return (T) resolveGuaranteeNonNullWidened(toResolve);
+  }
+
+  /**
+   * Resolves an object creation expression, throwing if it is not resolvable. Returns {@code
+   * Object} for the reason given on {@link #resolve(ObjectCreationExpr)}.
+   *
+   * @param toResolve The node to resolve
+   * @return The resolved object
+   */
+  public static @NonNull Object resolveGuaranteeNonNull(ObjectCreationExpr toResolve) {
+    return resolveGuaranteeNonNullWidened(toResolve);
+  }
+
+  /**
+   * Resolves a method call, throwing if it is not resolvable. Returns {@code Object} for the reason
+   * given on {@link #resolve(MethodCallExpr)}.
+   *
+   * @param toResolve The node to resolve
+   * @return The resolved object
+   */
+  public static @NonNull Object resolveGuaranteeNonNull(MethodCallExpr toResolve) {
+    return resolveGuaranteeNonNullWidened(toResolve);
+  }
+
+  /**
+   * Resolves a method reference, throwing if it is not resolvable. Returns {@code Object} for the
+   * reason given on {@link #resolve(MethodReferenceExpr)}.
+   *
+   * @param toResolve The node to resolve
+   * @return The resolved object
+   */
+  public static @NonNull Object resolveGuaranteeNonNull(MethodReferenceExpr toResolve) {
+    return resolveGuaranteeNonNullWidened(toResolve);
+  }
+
+  /**
+   * Resolves an enum constant, throwing if it is not resolvable. Returns {@code Object} for the
+   * reason given on {@link #resolve(EnumConstantDeclaration)}.
+   *
+   * @param toResolve The node to resolve
+   * @return The resolved object
+   */
+  public static @NonNull Object resolveGuaranteeNonNull(EnumConstantDeclaration toResolve) {
+    return resolveGuaranteeNonNullWidened(toResolve);
+  }
+
+  /**
+   * Implementation of every {@code resolveGuaranteeNonNull} overload.
+   *
+   * @param toResolve The node to resolve
+   * @return The resolved object
+   */
+  private static @NonNull Object resolveGuaranteeNonNullWidened(Resolvable<?> toResolve) {
+    Node node = (Node) toResolve;
+    Object result;
 
     try {
       result = toResolve.resolve();
     } catch (UnsolvedSymbolException ex) {
-      Object resolved = Resolver.tryAlternativeResolutionForUnsolvableNode((Node) toResolve);
+      Object resolved = discardIfWrongKind(node, tryAlternativeResolutionForUnsolvableNode(node));
 
       if (resolved == null) {
         throw ex;
       }
 
-      result = (T) resolved;
+      result = resolved;
     } catch (IllegalStateException ex) {
-      Object resolved = Resolver.handleIllegalStateException(ex, (Node) toResolve);
+      Object resolved = discardIfWrongKind(node, Resolver.handleIllegalStateException(ex, node));
 
       if (resolved == null) {
         throw ex;
       }
 
-      result = (T) resolved;
+      result = resolved;
     } catch (MethodAmbiguityException ex) {
-      Object resolved = Resolver.handleMethodAmbiguityException(ex, (Node) toResolve);
+      Object resolved = discardIfWrongKind(node, Resolver.handleMethodAmbiguityException(ex, node));
 
       if (resolved == null) {
         throw ex;
       }
 
-      result = (T) resolved;
+      result = resolved;
     } catch (UnsupportedOperationException ex) {
-      Object resolved = Resolver.handleUnsupportedOperationException(ex, (Node) toResolve);
+      Object resolved =
+          discardIfWrongKind(node, Resolver.handleUnsupportedOperationException(ex, node));
 
       if (resolved == null) {
         throw ex;
       }
 
-      result = (T) resolved;
+      result = resolved;
     }
 
     if (result == null) {
@@ -306,7 +516,9 @@ public class Resolver {
 
   /**
    * Tries alternative resolution strategies for a node that cannot be resolved through JavaParser's
-   * symbol solver.
+   * symbol solver. Callers are responsible for passing the result through {@link
+   * #discardIfWrongKind}: some of these strategies answer with the node's type rather than with a
+   * declaration.
    *
    * @param unsolvable The unsolvable node
    * @return The resolved version of the node, or null if not resolvable.

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -1109,9 +1109,10 @@ public class UnsolvedSymbolGenerator {
    */
   private void handleMethodCallExpr(
       MethodCallExpr methodCall, List<UnsolvedSymbolAlternates<?>> result) {
-    ResolvedMethodDeclaration resolvedMethodDeclaration = Resolver.resolve(methodCall);
-
-    if (resolvedMethodDeclaration != null) {
+    // A call on an annotation member resolves to that member (JLS 9.6.1) rather than to a
+    // method; fall through to the unsolved handling below, as for a call that does not resolve.
+    if (Resolver.resolve(methodCall)
+        instanceof ResolvedMethodDeclaration resolvedMethodDeclaration) {
       Node node =
           JavaParserUtil.tryFindAttachedNode(resolvedMethodDeclaration, fqnsToCompilationUnits);
 
@@ -3301,7 +3302,13 @@ public class UnsolvedSymbolGenerator {
 
       ResolvedMethodLikeDeclaration resolved = null;
       if (!(node instanceof EnumConstantDeclaration)) {
-        resolved = (ResolvedMethodLikeDeclaration) Resolver.resolve((Resolvable<?>) nodeWithArgs);
+        // The upcast to Resolvable<?> bypasses the Object-returning overloads, so this has to
+        // check for itself: constructing a record answers with the record's declaration, which is
+        // not a callable at all (see Resolver#WIDENED_NODE_KINDS).
+        if (Resolver.resolve((Resolvable<?>) nodeWithArgs)
+            instanceof ResolvedMethodLikeDeclaration methodLike) {
+          resolved = methodLike;
+        }
       }
 
       if (resolved == null && node instanceof MethodCallExpr methodCall) {
@@ -4204,7 +4211,10 @@ public class UnsolvedSymbolGenerator {
    */
   private void matchMethodReturnTypesToKnownChildClasses(MethodCallExpr methodCall) {
     Collection<Set<String>> potentialScopeFQNs = null;
-    ResolvedMethodDeclaration resolvedMethod = Resolver.resolve(methodCall);
+    // An annotation member (JLS 9.6.1) has no declaring class to walk ancestors of, so treat it
+    // as unresolved and fall back to the call site's own location.
+    ResolvedMethodDeclaration resolvedMethod =
+        Resolver.resolve(methodCall) instanceof ResolvedMethodDeclaration method ? method : null;
     Node ast = null;
 
     if (resolvedMethod == null) {
@@ -4678,9 +4688,8 @@ public class UnsolvedSymbolGenerator {
     }
 
     for (MethodCallExpr call : tryStmt.getTryBlock().findAll(MethodCallExpr.class)) {
-      ResolvedMethodDeclaration resolved = Resolver.resolve(call);
-
-      if (resolved != null) {
+      // An annotation member (JLS 9.6.1) has no throws clause, so there is nothing to add.
+      if (Resolver.resolve(call) instanceof ResolvedMethodDeclaration resolved) {
         addSpecifiedExceptions(resolved, result);
         continue;
       }
@@ -4696,9 +4705,10 @@ public class UnsolvedSymbolGenerator {
     }
 
     for (ObjectCreationExpr creation : tryStmt.getTryBlock().findAll(ObjectCreationExpr.class)) {
-      ResolvedConstructorDeclaration resolved = Resolver.resolve(creation);
-
-      if (resolved != null) {
+      // Constructing a record resolves to the record's declaration (see
+      // Resolver#WIDENED_NODE_KINDS); a canonical constructor is implicitly declared (JLS
+      // 8.10.4) and so has no throws clause to add.
+      if (Resolver.resolve(creation) instanceof ResolvedConstructorDeclaration resolved) {
         addSpecifiedExceptions(resolved, result);
       }
       // Synthetic constructors are never generated with a throws clause, so there is nothing to

--- a/src/test/java/org/checkerframework/specimin/RecordConstructorInTryBlockTest.java
+++ b/src/test/java/org/checkerframework/specimin/RecordConstructorInTryBlockTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that constructing a record inside a try block does not crash Specimin when the
+ * constructor call has an unresolvable argument.
+ *
+ * <p>A canonical constructor is implicitly declared (JLS 8.10.4), so JavaParser has no {@code
+ * ConstructorDeclaration} node for it and Specimin answers the constructor call with the record's
+ * own declaration instead. Collecting the exceptions a try block can throw used to narrow that
+ * answer to a {@code ResolvedConstructorDeclaration} without checking. The unresolvable argument is
+ * what makes this reachable: without it the call resolves normally and the widening never happens.
+ */
+public class RecordConstructorInTryBlockTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "recordconstructorintryblock",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#foo()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/ResolverKindContractTest.java
+++ b/src/test/java/org/checkerframework/specimin/ResolverKindContractTest.java
@@ -1,0 +1,109 @@
+package org.checkerframework.specimin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.javaparser.ast.Node;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Checks that {@code Resolver}'s set of node kinds whose resolution can widen stays in step with
+ * the {@code Object}-returning overloads that force callers of those kinds to check the runtime
+ * type.
+ *
+ * <p>The two can drift apart in either direction, and both directions are silent bugs. A kind added
+ * to the set without an overload leaves the generic {@code <T> T} signature promising a {@code T}
+ * it does not deliver, which is a {@code ClassCastException} at some caller. An overload without a
+ * corresponding entry in the set means the widened value is discarded before it reaches the caller
+ * that the overload was added for, so the widening silently stops working.
+ */
+public class ResolverKindContractTest {
+
+  /**
+   * Returns the node kinds that {@code Resolver} sanctions as able to resolve to something other
+   * than their declared kind.
+   *
+   * @return that set
+   * @throws ReflectiveOperationException if the field cannot be read
+   */
+  @SuppressWarnings("unchecked")
+  private Set<Class<? extends Node>> sanctionedKinds() throws ReflectiveOperationException {
+    Field field = Resolver.class.getDeclaredField("WIDENED_NODE_KINDS");
+    field.setAccessible(true);
+    return (Set<Class<? extends Node>>) field.get(null);
+  }
+
+  /**
+   * Returns the parameter types of the overloads of {@code name} that return {@code Object}.
+   *
+   * @param name The method name to look for
+   * @return the node kinds those overloads accept
+   */
+  private Set<Class<?>> objectReturningOverloads(String name) {
+    Set<Class<?>> result = new LinkedHashSet<>();
+    for (Method method : Resolver.class.getDeclaredMethods()) {
+      if (method.getName().equals(name)
+          && method.getReturnType() == Object.class
+          && method.getParameterCount() == 1
+          && Node.class.isAssignableFrom(method.getParameterTypes()[0])) {
+        result.add(method.getParameterTypes()[0]);
+      }
+    }
+    return result;
+  }
+
+  @Test
+  public void resolveOverloadsCoverEverySanctionedKind() throws ReflectiveOperationException {
+    assertEquals(
+        sanctionedKinds(),
+        objectReturningOverloads("resolve"),
+        "Resolver.resolve's Object-returning overloads must match WIDENED_NODE_KINDS exactly");
+  }
+
+  @Test
+  public void resolveGuaranteeNonNullOverloadsCoverEverySanctionedKind()
+      throws ReflectiveOperationException {
+    assertEquals(
+        sanctionedKinds(),
+        objectReturningOverloads("resolveGuaranteeNonNull"),
+        "Resolver.resolveGuaranteeNonNull's Object-returning overloads must match"
+            + " WIDENED_NODE_KINDS exactly");
+  }
+
+  @Test
+  public void everySanctionedKindActuallyDeclaresANarrowerResolvedKind()
+      throws ReflectiveOperationException {
+    // A kind belongs in the set only because its Resolvable type argument is narrower than what
+    // resolution can produce. One that resolves to Object already would be pointless to list.
+    for (Class<? extends Node> kind : sanctionedKinds()) {
+      Method method = Resolver.class.getDeclaredMethod("declaredResolvedKind", Class.class);
+      method.setAccessible(true);
+      Object declared = method.invoke(null, kind);
+      assertTrue(
+          declared != null && declared != Object.class,
+          kind.getSimpleName()
+              + " is listed as a widening node kind but does not declare a Resolvable type"
+              + " argument, so nothing about it can widen");
+    }
+  }
+
+  @Test
+  public void sanctionedKindsAreDocumented() throws ReflectiveOperationException {
+    // Guards against quietly adding a kind: the set is small and each entry needs a JLS-grounded
+    // reason on WIDENED_NODE_KINDS, so a change here should be a deliberate, reviewed one.
+    assertEquals(
+        Set.of(
+            "EnumConstantDeclaration",
+            "MethodCallExpr",
+            "MethodReferenceExpr",
+            "ObjectCreationExpr"),
+        sanctionedKinds().stream().map(Class::getSimpleName).collect(Collectors.toSet()),
+        "Adding or removing a widening node kind means updating the reasons documented on"
+            + " Resolver.WIDENED_NODE_KINDS and this test together");
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/StaticScopeResolvedAsTypeTest.java
+++ b/src/test/java/org/checkerframework/specimin/StaticScopeResolvedAsTypeTest.java
@@ -1,0 +1,28 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that a method call whose scope is a {@code NameExpr} denoting a type, rather
+ * than a value, does not crash Specimin when it appears inside an anonymous class.
+ *
+ * <p>Such a scope does not resolve to a {@link
+ * com.github.javaparser.resolution.declarations.ResolvedValueDeclaration}, so inside an anonymous
+ * class Specimin retries the resolution by hoisting the name out of the class. That fallback ends
+ * at {@code calculateResolvedType}, which reports the scope's <em>type</em> -- not an answer to
+ * "what declaration does this name?", and not what a caller expecting a declaration can use.
+ *
+ * <p>The unsolved {@code Helper.normalize} call is what makes the crash reachable: without some
+ * generated symbol in the slice, {@code Slicer#buildSlice} skips the post-processing pass that
+ * inspects the {@code Integer.parseInt} call at all.
+ */
+public class StaticScopeResolvedAsTypeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "staticscoperesolvedastype",
+        new String[] {"org/example/AtlasData.java"},
+        new String[] {"org.example.AtlasData#load(Page)"});
+  }
+}

--- a/src/test/resources/recordconstructorintryblock/expected/com/example/Foo.java
+++ b/src/test/resources/recordconstructorintryblock/expected/com/example/Foo.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import external.Unsolved;
+
+public class Foo {
+
+  void foo() {
+    try {
+      MyOtherRecord other = new MyOtherRecord(Unsolved.thing());
+    } catch (Exception e) {
+    }
+  }
+}

--- a/src/test/resources/recordconstructorintryblock/expected/com/example/MyOtherRecord.java
+++ b/src/test/resources/recordconstructorintryblock/expected/com/example/MyOtherRecord.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public record MyOtherRecord(String str) {}

--- a/src/test/resources/recordconstructorintryblock/expected/external/Unsolved.java
+++ b/src/test/resources/recordconstructorintryblock/expected/external/Unsolved.java
@@ -1,0 +1,7 @@
+package external;
+public class Unsolved {
+
+    public static java.lang.String thing() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/recordconstructorintryblock/input/com/example/Foo.java
+++ b/src/test/resources/recordconstructorintryblock/input/com/example/Foo.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import external.Unsolved;
+
+public class Foo {
+    void foo() {
+        try {
+            MyOtherRecord other = new MyOtherRecord(Unsolved.thing());
+        } catch (Exception e) {
+        }
+    }
+}

--- a/src/test/resources/recordconstructorintryblock/input/com/example/MyOtherRecord.java
+++ b/src/test/resources/recordconstructorintryblock/input/com/example/MyOtherRecord.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public record MyOtherRecord(String str) {
+}

--- a/src/test/resources/staticscoperesolvedastype/expected/external/Helper.java
+++ b/src/test/resources/staticscoperesolvedastype/expected/external/Helper.java
@@ -1,0 +1,7 @@
+package external;
+public class Helper {
+
+    public static java.lang.String normalize(java.lang.String parameter0) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/staticscoperesolvedastype/expected/org/example/AtlasData.java
+++ b/src/test/resources/staticscoperesolvedastype/expected/org/example/AtlasData.java
@@ -1,0 +1,31 @@
+package org.example;
+
+import external.Helper;
+
+public class AtlasData {
+
+  public interface Field<T> {
+
+    void parse(T object);
+  }
+
+  public static class Page {
+
+    public int width;
+
+    public String name;
+  }
+
+  public void load(Page page) {
+    final String[] entry = new String[5];
+    Field<Page> field =
+        new Field<Page>() {
+
+          public void parse(Page page) {
+            page.width = Integer.parseInt(entry[1]);
+            page.name = Helper.normalize(entry[0]);
+          }
+        };
+    field.parse(page);
+  }
+}

--- a/src/test/resources/staticscoperesolvedastype/input/org/example/AtlasData.java
+++ b/src/test/resources/staticscoperesolvedastype/input/org/example/AtlasData.java
@@ -1,0 +1,29 @@
+package org.example;
+
+import external.Helper;
+
+public class AtlasData {
+
+  public interface Field<T> {
+    void parse(T object);
+  }
+
+  public static class Page {
+    public int width;
+    public String name;
+  }
+
+  public void load(Page page) {
+    final String[] entry = new String[5];
+    Field<Page> field =
+        new Field<Page>() {
+          public void parse(Page page) {
+            // The scope `Integer` is a NameExpr denoting a type, not a value.
+            page.width = Integer.parseInt(entry[1]);
+            // An unsolved call, so a stub is generated and addInformation runs.
+            page.name = Helper.normalize(entry[0]);
+          }
+        };
+    field.parse(page);
+  }
+}


### PR DESCRIPTION
Fixes #540.

`Resolver#resolve` type is `Resolvable<T> -> T` in almost all cases, but there a few exceptions - for example, the implicit constructor on a record resolves to the record itself, which is not in fact a constructor. This change adjusts how `Resolver#resolve` is typed so that for _most_ calls, when it is guaranteed to return a `T`, it still does - but when it doesn't we've overloaded it so that the best, most-specific return type is used. That required 1) adding some `instanceof` checks at call sites where a `T` isn't guaranteed, and 2) adding a regression test that checks that the overload list is correct. #540 was a crash caused by one of the non-`T` cases that just did a cast without a check.