### PR TITLE
Add defaulting to synthetic annotations in the easy cases

### DIFF
--- a/src/main/java/org/checkerframework/specimin/unsolved/SpeciminGenerationUtils.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/SpeciminGenerationUtils.java
@@ -100,17 +100,14 @@ public class SpeciminGenerationUtils {
    * whose type is the given one, or null if no such value can be named.
    *
    * <p>An element of an annotation type must have a default, or every use site of the annotation
-   * has to supply a value for it (JLS 9.7.1, and 9.7.2 and 9.7.3 for the marker and single-element
-   * shorthands). Specimin cannot recover the real default of an annotation type it never saw, but
-   * it does not need to: an annotation element value is not usable in a constant expression, so no
-   * typing judgment about the target can depend on which commensurate value (JLS 9.7) is chosen.
+   * has to supply a value for it. Specimin cannot recover the real default of an annotation type it
+   * never saw, but it does not need to: an annotation element value is not usable in a constant
+   * expression, so no typing judgment about the target can depend on which commensurate value is
+   * chosen.
    *
    * <p>A value is produced only for the element types that can be defaulted from the type alone:
-   * primitives, {@code String}, an unbounded or raw {@code Class}, and any array type. The two
-   * legal element types that are missing -- an enum type, which needs one of its constants, and an
-   * annotation type, which is only usable as a default if every one of <em>its</em> elements has a
-   * default -- both require knowing the members of another generated type, which is not available
-   * here.
+   * primitives, {@code String}, an unbounded or raw {@code Class}, and any array type. Null is
+   * returned otherwise.
    *
    * @param elementType the element's type
    * @return a value commensurate with that type, or null if none can be named
@@ -118,8 +115,6 @@ public class SpeciminGenerationUtils {
   public static @Nullable String getAnnotationElementDefaultValue(MemberType elementType) {
     String asWritten = elementType.toString();
 
-    // An empty ElementValueArrayInitializer is commensurate with every array type (JLS 9.7),
-    // whatever the component type turned out to be.
     if (asWritten.endsWith("[]")) {
       return "{}";
     }
@@ -127,8 +122,6 @@ public class SpeciminGenerationUtils {
     Set<String> fqns = elementType.getFullyQualifiedNames();
 
     if (fqns.size() != 1) {
-      // The alternates disagree about the element's type, so there is no one type to be
-      // commensurate with.
       return null;
     }
 
@@ -139,11 +132,13 @@ public class SpeciminGenerationUtils {
     }
 
     // A class literal is commensurate with a Class element type when its type is assignment
-    // compatible with the element type (JLS 9.7.1), which Class<Object> is for these two forms and
-    // need not be for a bounded one such as Class<? extends Number>.
+    // compatible with the element type (JLS 9.7.1), which Class<Object> is for these two forms.
     if (asWritten.equals("java.lang.Class") || asWritten.equals("java.lang.Class<?>")) {
       return "java.lang.Object.class";
     }
+
+    // TODO: handle bounded Class types (e.g., Class<? extends Number>), enums, and annotations.
+    // Right now, all three of these forms result in failed compilations.
 
     return null;
   }

--- a/src/main/java/org/checkerframework/specimin/unsolved/SpeciminGenerationUtils.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/SpeciminGenerationUtils.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.specimin.JavaLangUtils;
 import org.checkerframework.specimin.JavaParserUtil;
 
@@ -92,6 +93,59 @@ public class SpeciminGenerationUtils {
     String simple = JavaParserUtil.getSimpleNameFromQualifiedName(JavaParserUtil.erase(name));
 
     return name.equals(simple) && hasNoTypeArguments && !JavaLangUtils.isPrimitive(simple);
+  }
+
+  /**
+   * Returns a value that can be used as the default of an element of a synthetic annotation type
+   * whose type is the given one, or null if no such value can be named.
+   *
+   * <p>An element of an annotation type must have a default, or every use site of the annotation
+   * has to supply a value for it (JLS 9.7.1, and 9.7.2 and 9.7.3 for the marker and single-element
+   * shorthands). Specimin cannot recover the real default of an annotation type it never saw, but
+   * it does not need to: an annotation element value is not usable in a constant expression, so no
+   * typing judgment about the target can depend on which commensurate value (JLS 9.7) is chosen.
+   *
+   * <p>A value is produced only for the element types that can be defaulted from the type alone:
+   * primitives, {@code String}, an unbounded or raw {@code Class}, and any array type. The two
+   * legal element types that are missing -- an enum type, which needs one of its constants, and an
+   * annotation type, which is only usable as a default if every one of <em>its</em> elements has a
+   * default -- both require knowing the members of another generated type, which is not available
+   * here.
+   *
+   * @param elementType the element's type
+   * @return a value commensurate with that type, or null if none can be named
+   */
+  public static @Nullable String getAnnotationElementDefaultValue(MemberType elementType) {
+    String asWritten = elementType.toString();
+
+    // An empty ElementValueArrayInitializer is commensurate with every array type (JLS 9.7),
+    // whatever the component type turned out to be.
+    if (asWritten.endsWith("[]")) {
+      return "{}";
+    }
+
+    Set<String> fqns = elementType.getFullyQualifiedNames();
+
+    if (fqns.size() != 1) {
+      // The alternates disagree about the element's type, so there is no one type to be
+      // commensurate with.
+      return null;
+    }
+
+    String fqn = fqns.iterator().next();
+
+    if (JavaLangUtils.isPrimitive(fqn) || JavaLangUtils.isJavaLangString(fqn)) {
+      return JavaParserUtil.getConstantInitializerRHS(fqn);
+    }
+
+    // A class literal is commensurate with a Class element type when its type is assignment
+    // compatible with the element type (JLS 9.7.1), which Class<Object> is for these two forms and
+    // need not be for a bounded one such as Class<? extends Number>.
+    if (asWritten.equals("java.lang.Class") || asWritten.equals("java.lang.Class<?>")) {
+      return "java.lang.Object.class";
+    }
+
+    return null;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallable.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedCallable.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
 import org.checkerframework.specimin.JavaParserUtil;
 
@@ -230,12 +231,30 @@ public abstract class UnsolvedCallable extends UnsolvedSymbolAlternate
     }
     signature.append(exceptions);
 
+    if (type == UnsolvedClassOrInterfaceType.ANNOTATION) {
+      String defaultValue = annotationElementDefaultValue();
+      if (defaultValue != null) {
+        signature.append(" default ").append(defaultValue);
+      }
+    }
+
     if (type == UnsolvedClassOrInterfaceType.ANNOTATION
         || type == UnsolvedClassOrInterfaceType.INTERFACE) {
       return "\n    " + signature + ";\n";
     } else {
       return "\n    " + signature + " {\n        " + content + "\n    }\n";
     }
+  }
+
+  /**
+   * Returns the value to declare as this callable's default, when it is being printed as a member
+   * of a synthetic annotation type. Only a method can be such a member (JLS 9.6), so the default
+   * implementation names no value.
+   *
+   * @return a value commensurate with this member's type (JLS 9.7), or null if none can be named
+   */
+  protected @Nullable String annotationElementDefaultValue() {
+    return null;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedMethod.java
@@ -171,6 +171,11 @@ public class UnsolvedMethod extends UnsolvedCallable {
   }
 
   @Override
+  protected @Nullable String annotationElementDefaultValue() {
+    return SpeciminGenerationUtils.getAnnotationElementDefaultValue(returnType);
+  }
+
+  @Override
   protected List<MemberType> typesInSignature() {
     List<MemberType> types = new ArrayList<>(getParameterList());
     types.add(returnType);

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -462,8 +462,6 @@ public class UnsolvedSymbolGenerator {
    * @param result The result of inferContext
    */
   private void handleAnnotationExpr(AnnotationExpr anno, List<UnsolvedSymbolAlternates<?>> result) {
-    // TODO: handle default values when necessary
-
     if (Resolver.resolve(anno) != null) {
       return;
     }

--- a/src/test/java/org/checkerframework/specimin/AnnotationDisjointElementsTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationDisjointElementsTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Two use sites of the same synthetic annotation type supply disjoint sets of elements, so each
+ * element is omitted by one of them and both therefore need defaults (JLS 9.7.1). Unlike {@link
+ * AnnotationElementWithoutDefaultTest}, neither use site is a marker or single-element annotation,
+ * which shows that it is the omission and not the shorthand that requires the default.
+ */
+public class AnnotationDisjointElementsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "annotationdisjointelements",
+        new String[] {"org/example/Simple.java"},
+        new String[] {"org.example.Simple#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AnnotationElementDefaultValuesTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationElementDefaultValuesTest.java
@@ -1,0 +1,23 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Checks the default value that a synthetic annotation type's element gets for each of the element
+ * types that Specimin can name a value for: a primitive, {@code String}, {@code Class}, and an
+ * array. The marker use site is what makes all four defaults necessary (JLS 9.7.2).
+ *
+ * <p>The two remaining legal element types (JLS 9.6.1) -- an enum type and an annotation type --
+ * are deliberately absent, because Specimin does not default them; see {@link
+ * org.checkerframework.specimin.unsolved.SpeciminGenerationUtils#getAnnotationElementDefaultValue}.
+ */
+public class AnnotationElementDefaultValuesTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "annotationelementdefaultvalues",
+        new String[] {"org/example/Simple.java"},
+        new String[] {"org.example.Simple#target()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AnnotationElementDefaultValuesTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationElementDefaultValuesTest.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
  * types that Specimin can name a value for: a primitive, {@code String}, {@code Class}, and an
  * array. The marker use site is what makes all four defaults necessary (JLS 9.7.2).
  *
- * <p>The two remaining legal element types (JLS 9.6.1) -- an enum type and an annotation type --
- * are deliberately absent, because Specimin does not default them; see {@link
- * org.checkerframework.specimin.unsolved.SpeciminGenerationUtils#getAnnotationElementDefaultValue}.
+ * <p>TODO: Other legal forms: an enum type, an annotation type, or a bounded Class type like
+ * {@code Class<? extends Number>} are not tested, because Specimin does not currently support
+ * them. Add them to this test when support for them is added.
  */
 public class AnnotationElementDefaultValuesTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/AnnotationElementWithoutDefaultTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationElementWithoutDefaultTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A synthetic annotation type that is used both with and without an argument needs a default value
+ * for the corresponding element, or the argument-less use site does not compile (JLS 9.7.1).
+ */
+public class AnnotationElementWithoutDefaultTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "annotationelementwithoutdefault",
+        new String[] {"org/example/ClassInfo.java"},
+        new String[] {"org.example.ClassInfo#getPackage()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AnnotationElementWithoutDefaultTest.java
+++ b/src/test/java/org/checkerframework/specimin/AnnotationElementWithoutDefaultTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 /**
  * A synthetic annotation type that is used both with and without an argument needs a default value
  * for the corresponding element, or the argument-less use site does not compile (JLS 9.7.1).
+ *
+ * Regression test for <a href="https://github.com/njit-jerse/specimin/issues/542">#542</a>.
  */
 public class AnnotationElementWithoutDefaultTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/SyntheticAnnotationsTest.java
+++ b/src/test/java/org/checkerframework/specimin/SyntheticAnnotationsTest.java
@@ -3,7 +3,14 @@ package org.checkerframework.specimin;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
-/** This test checks if synthetic annotations are correctly generated for unsolved annotations. */
+/**
+ * This test checks if synthetic annotations are correctly generated for unsolved annotations.
+ *
+ * <p>Every element here is given a default value except {@code Foo.x()}, whose type is a real
+ * annotation type: a nested annotation is usable as a default only if all of <em>its</em> elements
+ * have defaults, which Specimin cannot check for a type it did not generate. That asymmetry is
+ * harmless in this input, since the single use site of {@code @Foo} supplies {@code x}.
+ */
 public class SyntheticAnnotationsTest {
   @Test
   public void runTest() throws IOException {

--- a/src/test/resources/annoingenericarg/expected/org/checkerframework/checker/nullness/KeyFor.java
+++ b/src/test/resources/annoingenericarg/expected/org/checkerframework/checker/nullness/KeyFor.java
@@ -3,5 +3,5 @@ package org.checkerframework.checker.nullness;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
 public @interface KeyFor {
 
-    public java.lang.String value();
+    public java.lang.String value() default "";
 }

--- a/src/test/resources/annotationargconstant/expected/external/Header.java
+++ b/src/test/resources/annotationargconstant/expected/external/Header.java
@@ -3,5 +3,5 @@ package external;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER })
 public @interface Header {
 
-    public java.lang.String value();
+    public java.lang.String value() default "";
 }

--- a/src/test/resources/annotationargconstantandenum/expected/external/HeaderParam.java
+++ b/src/test/resources/annotationargconstantandenum/expected/external/HeaderParam.java
@@ -2,5 +2,5 @@ package external;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
 public @interface HeaderParam {
 
-    public java.lang.String value();
+    public java.lang.String value() default "";
 }

--- a/src/test/resources/annotationargconstanttransitive/expected/external/Header.java
+++ b/src/test/resources/annotationargconstanttransitive/expected/external/Header.java
@@ -3,5 +3,5 @@ package external;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER })
 public @interface Header {
 
-    public java.lang.String value();
+    public java.lang.String value() default "";
 }

--- a/src/test/resources/annotationargenumandconstant/expected/external/HeaderParam.java
+++ b/src/test/resources/annotationargenumandconstant/expected/external/HeaderParam.java
@@ -2,5 +2,5 @@ package external;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
 public @interface HeaderParam {
 
-    public java.lang.String value();
+    public java.lang.String value() default "";
 }

--- a/src/test/resources/annotationdisjointelements/expected/external/Anno.java
+++ b/src/test/resources/annotationdisjointelements/expected/external/Anno.java
@@ -1,7 +1,8 @@
-package com.example;
-
+package external;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
 public @interface Anno {
 
-    public int value() default 0;
+    public java.lang.String text() default "";
+
+    public int number() default 0;
 }

--- a/src/test/resources/annotationdisjointelements/expected/org/example/Simple.java
+++ b/src/test/resources/annotationdisjointelements/expected/org/example/Simple.java
@@ -1,0 +1,16 @@
+package org.example;
+
+import external.Anno;
+
+public class Simple {
+
+  @Anno(number = 1)
+  private int x;
+
+  @Anno(text = "s")
+  private int y;
+
+  public int target() {
+    return x + y;
+  }
+}

--- a/src/test/resources/annotationdisjointelements/input/org/example/Simple.java
+++ b/src/test/resources/annotationdisjointelements/input/org/example/Simple.java
@@ -1,0 +1,16 @@
+package org.example;
+
+import external.Anno;
+
+public class Simple {
+
+  @Anno(number = 1)
+  private int x;
+
+  @Anno(text = "s")
+  private int y;
+
+  public int target() {
+    return x + y;
+  }
+}

--- a/src/test/resources/annotationelementdefaultvalues/expected/external/Anno.java
+++ b/src/test/resources/annotationelementdefaultvalues/expected/external/Anno.java
@@ -1,7 +1,12 @@
-package com.example;
-
+package external;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
 public @interface Anno {
 
-    public int value() default 0;
+    public java.lang.Class<?> theClass() default java.lang.Object.class;
+
+    public int[] theArray() default {};
+
+    public java.lang.String theString() default "";
+
+    public int theInt() default 0;
 }

--- a/src/test/resources/annotationelementdefaultvalues/expected/org/example/Simple.java
+++ b/src/test/resources/annotationelementdefaultvalues/expected/org/example/Simple.java
@@ -1,0 +1,19 @@
+package org.example;
+
+import external.Anno;
+
+public class Simple {
+
+  @Anno(
+      theClass = String.class,
+      theArray = {1, 2},
+      theString = "str",
+      theInt = 5)
+  private int x;
+
+  @Anno private int y;
+
+  public int target() {
+    return x + y;
+  }
+}

--- a/src/test/resources/annotationelementdefaultvalues/input/org/example/Simple.java
+++ b/src/test/resources/annotationelementdefaultvalues/input/org/example/Simple.java
@@ -1,0 +1,19 @@
+package org.example;
+
+import external.Anno;
+
+public class Simple {
+
+  @Anno(
+      theClass = String.class,
+      theArray = {1, 2},
+      theString = "str",
+      theInt = 5)
+  private int x;
+
+  @Anno private int y;
+
+  public int target() {
+    return x + y;
+  }
+}

--- a/src/test/resources/annotationelementwithoutdefault/expected/external/Nullable.java
+++ b/src/test/resources/annotationelementwithoutdefault/expected/external/Nullable.java
@@ -1,7 +1,7 @@
-package com.example;
+package external;
 
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
-public @interface Anno {
+public @interface Nullable {
 
-    public int value() default 0;
+    public java.lang.String value() default "";
 }

--- a/src/test/resources/annotationelementwithoutdefault/expected/org/example/ClassInfo.java
+++ b/src/test/resources/annotationelementwithoutdefault/expected/org/example/ClassInfo.java
@@ -1,0 +1,21 @@
+package org.example;
+
+import external.Nullable;
+
+public final class ClassInfo {
+
+  @Nullable("for inner classes")
+  private String pkg;
+
+  @Nullable private ClassInfo parentClass;
+
+  public String getPackage() {
+    if (parentClass != null) {
+      return parentClass.getPackage();
+    }
+    if (pkg == null) {
+      throw new RuntimeException("Package is null for not inner class");
+    }
+    return pkg;
+  }
+}

--- a/src/test/resources/annotationelementwithoutdefault/input/org/example/ClassInfo.java
+++ b/src/test/resources/annotationelementwithoutdefault/input/org/example/ClassInfo.java
@@ -1,0 +1,21 @@
+package org.example;
+
+import external.Nullable;
+
+public final class ClassInfo {
+
+  @Nullable("for inner classes")
+  private String pkg;
+
+  @Nullable private ClassInfo parentClass;
+
+  public String getPackage() {
+    if (parentClass != null) {
+      return parentClass.getPackage();
+    }
+    if (pkg == null) {
+      throw new RuntimeException("Package is null for not inner class");
+    }
+    return pkg;
+  }
+}

--- a/src/test/resources/instanceconstanttransitive/expected/external/Header.java
+++ b/src/test/resources/instanceconstanttransitive/expected/external/Header.java
@@ -3,5 +3,5 @@ package external;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER })
 public @interface Header {
 
-    public java.lang.String value();
+    public java.lang.String value() default "";
 }

--- a/src/test/resources/syntheticannotations/expected/com/example/Bar.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Bar.java
@@ -3,5 +3,5 @@ package com.example;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
 public @interface Bar {
 
-    public int value();
+    public int value() default 0;
 }

--- a/src/test/resources/syntheticannotations/expected/com/example/Baz.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Baz.java
@@ -3,7 +3,7 @@ package com.example;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
 public @interface Baz {
 
-    public java.lang.String foo();
+    public java.lang.String foo() default "";
 
-    public java.lang.Class<?> bar();
+    public java.lang.Class<?> bar() default java.lang.Object.class;
 }

--- a/src/test/resources/syntheticannotations/expected/com/example/Foo.java
+++ b/src/test/resources/syntheticannotations/expected/com/example/Foo.java
@@ -5,5 +5,5 @@ public @interface Foo {
 
     public java.lang.Deprecated x();
 
-    public com.example.Anno[] y();
+    public com.example.Anno[] y() default {};
 }

--- a/src/test/resources/syntheticenumfromanno/expected/com/example/Anno.java
+++ b/src/test/resources/syntheticenumfromanno/expected/com/example/Anno.java
@@ -3,5 +3,5 @@ package com.example;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
 public @interface Anno {
 
-    public com.example.MyEnum[] myEnum();
+    public com.example.MyEnum[] myEnum() default {};
 }

--- a/src/test/resources/syntheticenumwithconstructor/expected/org/example/Header.java
+++ b/src/test/resources/syntheticenumwithconstructor/expected/org/example/Header.java
@@ -3,5 +3,5 @@ package org.example;
 @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE_USE, java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.FIELD, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.CONSTRUCTOR, java.lang.annotation.ElementType.LOCAL_VARIABLE, java.lang.annotation.ElementType.ANNOTATION_TYPE, java.lang.annotation.ElementType.PACKAGE, java.lang.annotation.ElementType.TYPE_PARAMETER})
 public @interface Header {
 
-    public int value();
+    public int value() default 0;
 }


### PR DESCRIPTION
This should fix #542, based on the MWE, but it is not a complete fix - I only dealt with the low-hanging fruit. In particular, Specimin will still produce non-compiling output for annotations that need defaults with types that are:
* bounded class literal types, like `Class<? extends Foo>`
* enum types
* other annotation types

I'll file a follow-up issue to track those in a few minutes and link it from here (edit: #550). The reason that I didn't deal with those now is that materializing defaults for those types is much, much more difficult: we need the types to be solvable, and to be able to call their constructors etc. Until I see the need to do that in a real code base, I'm going to hold off on doing the work.

This change resulted in changes to a number of old tests' expected outputs (to add a `default` that wasn't there before); I think that's fine, because although it loses a bit of minimality it means that this fix is _much_ simpler than it would need to be if we wanted to keep that precision (we'd need to track which annotations are used in ways that make their default values relevant; this fix doesn't actually do that and just materializes defaults whenever it's easy to do so).