### PR TITLE
Unary operators constrain their operands

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -275,15 +275,29 @@ public final class JavaLangUtils {
     JavaLangUtils.javaLangThrowableMethods = Collections.unmodifiableMap(javaLangThrowableMethods);
   }
 
-  /** The integral primitives. */
+  /** The integral primitives (and their boxes). */
   private static final String[] INTEGRAL_PRIMITIVES =
-      new String[] {"int", "Integer", "long", "Long", "byte", "Byte", "short", "Short"};
+      new String[] {
+        "int", "Integer", "long", "Long", "byte", "Byte", "short", "Short", "char", "Character"
+      };
 
-  /** The numeric primitives. */
+  /** The numeric primitives (and their boxes): the integral ones plus the floating-point ones. */
   private static final String[] NUMERIC_PRIMITIVES =
       new String[] {
-        "int", "Integer", "long", "Long", "byte", "Byte", "short", "Short", "float", "Float",
-        "double", "Double"
+        "int",
+        "Integer",
+        "long",
+        "Long",
+        "byte",
+        "Byte",
+        "short",
+        "Short",
+        "char",
+        "Character",
+        "float",
+        "Float",
+        "double",
+        "Double"
       };
 
   /**
@@ -292,8 +306,21 @@ public final class JavaLangUtils {
    */
   private static final String[] NUMERIC_PRIMITIVES_AND_STRING =
       new String[] {
-        "int", "Integer", "long", "Long", "byte", "Byte", "short", "Short", "float", "Float",
-        "double", "Double", "String"
+        "int",
+        "Integer",
+        "long",
+        "Long",
+        "byte",
+        "Byte",
+        "short",
+        "Short",
+        "char",
+        "Character",
+        "float",
+        "Float",
+        "double",
+        "Double",
+        "String"
       };
 
   /** The booleans. */
@@ -302,8 +329,22 @@ public final class JavaLangUtils {
   /** The numeric primitives and booleans. */
   private static final String[] NUMERIC_PRIMITIVES_AND_BOOLEANS =
       new String[] {
-        "int", "Integer", "long", "Long", "byte", "Byte", "short", "Short", "float", "Float",
-        "double", "Double", "boolean", "Boolean"
+        "int",
+        "Integer",
+        "long",
+        "Long",
+        "byte",
+        "Byte",
+        "short",
+        "Short",
+        "char",
+        "Character",
+        "float",
+        "Float",
+        "double",
+        "Double",
+        "boolean",
+        "Boolean"
       };
 
   /**

--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -349,6 +349,33 @@ public final class JavaLangUtils {
   }
 
   /**
+   * Given the string representation of a unary operator, what are the possible operand types? As in
+   * {@link #getTypesForOp(String)}, the first element of the result is assumed to be the default if
+   * no other information is available.
+   *
+   * <p>Unlike a binary operator, every unary operator constrains its operand, so this method never
+   * has to report "no information".
+   *
+   * @param unaryOp a string representation of a unary operator, such as "!"
+   * @return the array of compatible types, such as ["boolean", "Boolean"]
+   */
+  public static String[] getTypesForUnaryOp(String unaryOp) {
+    return switch (unaryOp) {
+      // JLS 15.15.6
+      case "!" -> BOOLEANS;
+
+      // JLS 15.15.5: unary numeric promotion (JLS 5.6.1) to an integral type
+      case "~" -> INTEGRAL_PRIMITIVES;
+
+      // JLS 15.15.3 and 15.15.4 (unary + and -), and JLS 15.14.2, 15.14.3, 15.15.1 and 15.15.2
+      // (the increment and decrement operators, whose operand must be a variable of numeric type)
+      case "+", "-", "++", "--" -> NUMERIC_PRIMITIVES;
+
+      default -> throw new IllegalArgumentException("unexpected unary operator: " + unaryOp);
+    };
+  }
+
+  /**
    * Is a type primitive (int, char, boolean, etc.)? This method returns false for boxed types
    * (Integer, Character, Boolean, etc.)
    *

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -2356,7 +2356,23 @@ public class FullyQualifiedNameGenerator {
         }
       }
     } else if (parentNode instanceof UnaryExpr unary) {
-      return toFQNSets(JavaLangUtils.getTypesForUnaryOp(unary.getOperator().asString()));
+      String unaryOp = unary.getOperator().asString();
+      Set<FullyQualifiedNameSet> permitted = toFQNSets(JavaLangUtils.getTypesForUnaryOp(unaryOp));
+
+      if (!unaryOp.equals("++") && !unaryOp.equals("--")) {
+        // Every other unary operator promotes its operand (JLS 5.6.1), so the type of the
+        // expression as a whole says nothing about the operand, and all we know is that the
+        // operand is one of the types the operator permits.
+        return permitted;
+      }
+
+      // The type of an increment or decrement expression is the type of its operand, not the
+      // promoted type: JLS 15.14.2, 15.14.3, 15.15.1 and 15.15.2 all undo the promotion with an
+      // implicit narrowing cast. Whatever the surrounding context requires of `++x` it therefore
+      // requires of `x` itself, which matters because the permitted set defaults to int and would
+      // otherwise turn `char c = ++x;` into an assignment that does not compile.
+      return restrictToPermittedTypes(
+          unary.hasParentNode() ? getFQNsFromSurroundingContextType(unary) : null, permitted);
     } else if (parentNode instanceof ReturnStmt returnStmt) {
       Node methodOrLambda = JavaParserUtil.findClosestMethodOrLambdaAncestor(returnStmt);
 
@@ -2447,14 +2463,32 @@ public class FullyQualifiedNameGenerator {
    */
   private Set<FullyQualifiedNameSet> getFQNsFromOperatorResultType(
       BinaryExpr binary, Operator operator) {
-    Set<FullyQualifiedNameSet> permitted =
-        toFQNSets(JavaLangUtils.getTypesForOp(operator.asString()));
-    Set<FullyQualifiedNameSet> resultType = getFQNsForExpressionType(binary);
-    String soleResultFqn = FullyQualifiedNameSet.getSoleErasedFqn(resultType);
+    return restrictToPermittedTypes(
+        getFQNsForExpressionType(binary),
+        toFQNSets(JavaLangUtils.getTypesForOp(operator.asString())));
+  }
 
-    return soleResultFqn != null && permitted.contains(new FullyQualifiedNameSet(soleResultFqn))
-        ? resultType
-        : permitted;
+  /**
+   * Returns the given candidate type if an operator permits it as an operand type, and the set of
+   * types that operator permits otherwise. A candidate that the operator does not permit is not
+   * evidence about the operand at all, since the operand could not have had that type.
+   *
+   * @param candidate the type suggested by an operator expression's own type or context, or null if
+   *     there is none
+   * @param permitted the types the operator permits its operand to have; the first is the default
+   * @return whichever of the two better describes the operand
+   */
+  private static Set<FullyQualifiedNameSet> restrictToPermittedTypes(
+      @Nullable Set<FullyQualifiedNameSet> candidate, Set<FullyQualifiedNameSet> permitted) {
+    if (candidate != null) {
+      String soleCandidateFqn = FullyQualifiedNameSet.getSoleErasedFqn(candidate);
+
+      if (soleCandidateFqn != null
+          && permitted.contains(new FullyQualifiedNameSet(soleCandidateFqn))) {
+        return candidate;
+      }
+    }
+    return permitted;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.SwitchExpr;
+import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithCondition;
 import com.github.javaparser.ast.nodeTypes.NodeWithExtends;
@@ -739,15 +740,7 @@ public class FullyQualifiedNameGenerator {
           return rightType;
         }
 
-        Set<FullyQualifiedNameSet> result = new LinkedHashSet<>();
-        for (String validType : JavaLangUtils.getTypesForOp(operator.asString())) {
-          if (JavaParserUtil.isAClassName(validType)) {
-            validType = "java.lang." + validType;
-          }
-          result.add(new FullyQualifiedNameSet(validType));
-        }
-
-        return result;
+        return toFQNSets(JavaLangUtils.getTypesForOp(operator.asString()));
       }
     }
 
@@ -2308,6 +2301,16 @@ public class FullyQualifiedNameGenerator {
       // Boolean
       if (operator == BinaryExpr.Operator.AND || operator == BinaryExpr.Operator.OR) {
         return Set.of(new FullyQualifiedNameSet("boolean"));
+      } else if (!isExpressionNotInProgress(other)
+          && isExpressionNotInProgress(binary)
+          && operator != BinaryExpr.Operator.EQUALS
+          && operator != BinaryExpr.Operator.NOT_EQUALS) {
+        // The other operand is already being computed, which happens when it is structurally
+        // identical to this one (`x & x`). Asking for its type would not terminate, and since it
+        // *is* this expression it has nothing new to say anyway -- but the type of the whole
+        // expression still does. == and != are excluded because their result is boolean whatever
+        // their operands are (JLS 15.21), so it says nothing about them.
+        return getFQNsFromOperatorResultType(binary, operator);
       } else if (isExpressionNotInProgress(other) && isExpressionNotInProgress(binary)) {
         // Treat all other cases; type on one side is equal to the other
         Set<FullyQualifiedNameSet> otherType = getFQNsForExpressionType(other);
@@ -2347,19 +2350,16 @@ public class FullyQualifiedNameGenerator {
         otherType = getFQNsForExpressionType(binary);
 
         if (otherType.size() > 1 || otherType.iterator().next().erasedFqns().size() > 1) {
-          Set<FullyQualifiedNameSet> result = new LinkedHashSet<>();
-          for (String validType : JavaLangUtils.getTypesForOp(operator.asString())) {
-            if (JavaParserUtil.isAClassName(validType)) {
-              validType = "java.lang." + validType;
-            }
-            result.add(new FullyQualifiedNameSet(validType));
-          }
-
-          return result;
+          return toFQNSets(JavaLangUtils.getTypesForOp(operator.asString()));
         } else {
           return otherType;
         }
       }
+    }
+    // Every unary operator constrains its operand's type (see JavaLangUtils#getTypesForUnaryOp),
+    // so -- unlike a cast or a string concatenation -- this context always says something.
+    else if (parentNode instanceof UnaryExpr unary) {
+      return toFQNSets(JavaLangUtils.getTypesForUnaryOp(unary.getOperator().asString()));
     } else if (parentNode instanceof ReturnStmt returnStmt) {
       Node methodOrLambda = JavaParserUtil.findClosestMethodOrLambdaAncestor(returnStmt);
 
@@ -2433,6 +2433,49 @@ public class FullyQualifiedNameGenerator {
       }
     }
     return null;
+  }
+
+  /**
+   * Returns the types the operands of the given binary expression may have, given the type of the
+   * expression as a whole. The result type of an operator is a legal operand type for it whenever
+   * the operands are subject to the same promotion as the result -- {@code int} for {@code &},
+   * {@code String} for a concatenating {@code +} -- and in that case the whole expression's type is
+   * the best evidence available about its operands. When it is not a legal operand type, as for the
+   * comparison operators (whose result is boolean but whose operands must be numeric, JLS 15.20.1),
+   * it is no evidence at all, and the operator's own permitted types are reported instead.
+   *
+   * @param binary a binary expression
+   * @param operator its operator
+   * @return the FQNs that an operand of the expression may have
+   */
+  private Set<FullyQualifiedNameSet> getFQNsFromOperatorResultType(
+      BinaryExpr binary, Operator operator) {
+    Set<FullyQualifiedNameSet> permitted =
+        toFQNSets(JavaLangUtils.getTypesForOp(operator.asString()));
+    Set<FullyQualifiedNameSet> resultType = getFQNsForExpressionType(binary);
+    String soleResultFqn = FullyQualifiedNameSet.getSoleErasedFqn(resultType);
+
+    return soleResultFqn != null && permitted.contains(new FullyQualifiedNameSet(soleResultFqn))
+        ? resultType
+        : permitted;
+  }
+
+  /**
+   * Converts the simple type names that {@link JavaLangUtils} reports for an operator into FQN
+   * sets, qualifying the boxed types (which it reports unqualified) with {@code java.lang}.
+   *
+   * @param types simple type names, such as those returned by {@link
+   *     JavaLangUtils#getTypesForOp(String)}
+   * @return one FQN set per type, in the same order
+   */
+  private static Set<FullyQualifiedNameSet> toFQNSets(String[] types) {
+    Set<FullyQualifiedNameSet> result = new LinkedHashSet<>();
+    for (String type : types) {
+      result.add(
+          new FullyQualifiedNameSet(
+              JavaParserUtil.isAClassName(type) ? "java.lang." + type : type));
+    }
+    return result;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/FullyQualifiedNameGenerator.java
@@ -2355,10 +2355,7 @@ public class FullyQualifiedNameGenerator {
           return otherType;
         }
       }
-    }
-    // Every unary operator constrains its operand's type (see JavaLangUtils#getTypesForUnaryOp),
-    // so -- unlike a cast or a string concatenation -- this context always says something.
-    else if (parentNode instanceof UnaryExpr unary) {
+    } else if (parentNode instanceof UnaryExpr unary) {
       return toFQNSets(JavaLangUtils.getTypesForUnaryOp(unary.getOperator().asString()));
     } else if (parentNode instanceof ReturnStmt returnStmt) {
       Node methodOrLambda = JavaParserUtil.findClosestMethodOrLambdaAncestor(returnStmt);

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -34,6 +34,7 @@ import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.PatternExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
+import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithParameters;
@@ -3650,14 +3651,17 @@ public class UnsolvedSymbolGenerator {
         }
       }
     }
+    // If the node is a unary expression, its operand's type is constrained: !x means x is a
+    // boolean, -x that it is numeric, etc.
+    else if (node instanceof UnaryExpr unaryExpr) {
+      constrainOperandType(
+          unaryExpr.getExpression(),
+          toMemberTypes(JavaLangUtils.getTypesForUnaryOp(unaryExpr.getOperator().asString())));
+    }
     // If the node is a binary expression, sometimes we can get more type constraints
     // i.e., x < y means x and y must be numbers
     else if (node instanceof BinaryExpr binaryExpr) {
       BinaryExpr.Operator operator = binaryExpr.getOperator();
-      Expression left = binaryExpr.getLeft();
-      Expression right = binaryExpr.getRight();
-
-      Set<MemberType> typesToReplace = new LinkedHashSet<>();
 
       // == and != are inconclusive for types, and so is a + that is a string concatenation: JLS
       // 15.18.1 allows the other operand of a concatenation to have any type at all, so unlike
@@ -3668,40 +3672,63 @@ public class UnsolvedSymbolGenerator {
       if (operator != BinaryExpr.Operator.EQUALS
           && operator != BinaryExpr.Operator.NOT_EQUALS
           && !isDefinitelyStringConcatenation(binaryExpr)) {
-        for (String validType : JavaLangUtils.getTypesForOp(operator.asString())) {
-          if (JavaParserUtil.isAClassName(validType)) {
-            validType = "java.lang." + validType;
-          }
-          typesToReplace.add(new SolvedMemberType(validType));
-        }
-      }
-
-      if (!typesToReplace.isEmpty()) {
-        for (Expression side : Set.of(left, right)) {
-          if (side.isMethodCallExpr()) {
-            UnsolvedMethodAlternates methodAlternates =
-                findGeneratedMethodFromMethodCall(side.asMethodCallExpr());
-
-            if (methodAlternates != null
-                && methodAlternates.getReturnTypes().stream().noneMatch(typesToReplace::contains)) {
-              // Set all to same return type which removes duplicates; then we can add
-              // our whole set to make sure that all the old types are gone
-              methodAlternates.setReturnType(typesToReplace.iterator().next());
-              methodAlternates.addReturnTypes(typesToReplace);
-            }
-          } else if (side.isFieldAccessExpr() || side.isNameExpr()) {
-            UnsolvedFieldAlternates fieldAlternates = findGeneratedFieldFromUsage(side);
-
-            if (fieldAlternates != null
-                && fieldAlternates.getTypes().stream().noneMatch(typesToReplace::contains)) {
-              fieldAlternates.replaceAllOldFieldTypes(typesToReplace);
-            }
-          }
-        }
+        Set<MemberType> typesToReplace =
+            toMemberTypes(JavaLangUtils.getTypesForOp(operator.asString()));
+        constrainOperandType(binaryExpr.getLeft(), typesToReplace);
+        constrainOperandType(binaryExpr.getRight(), typesToReplace);
       }
     }
 
     return new UnsolvedGenerationResult(toAdd, toRemove);
+  }
+
+  /**
+   * Converts the simple type names that {@link JavaLangUtils} reports for an operator into member
+   * types, qualifying the boxed types (which it reports unqualified) with {@code java.lang}.
+   *
+   * @param types simple type names, such as those returned by {@link
+   *     JavaLangUtils#getTypesForOp(String)}
+   * @return one member type per type, in the same order
+   */
+  private static Set<MemberType> toMemberTypes(String[] types) {
+    Set<MemberType> result = new LinkedHashSet<>();
+    for (String type : types) {
+      result.add(
+          new SolvedMemberType(JavaParserUtil.isAClassName(type) ? "java.lang." + type : type));
+    }
+    return result;
+  }
+
+  /**
+   * If the given operand of an operator is a generated method call or field access whose type is
+   * not one that the operator permits, replaces that type with the permitted ones. Does nothing
+   * when the operand is not a generated symbol or already has a permitted type, so that a type
+   * established by the symbol's other use sites survives.
+   *
+   * @param operand an operand of an operator
+   * @param permittedTypes the types that the operator permits its operand to have; the first is
+   *     used as the default
+   */
+  private void constrainOperandType(Expression operand, Set<MemberType> permittedTypes) {
+    if (operand.isMethodCallExpr()) {
+      UnsolvedMethodAlternates methodAlternates =
+          findGeneratedMethodFromMethodCall(operand.asMethodCallExpr());
+
+      if (methodAlternates != null
+          && methodAlternates.getReturnTypes().stream().noneMatch(permittedTypes::contains)) {
+        // Set all to same return type which removes duplicates; then we can add
+        // our whole set to make sure that all the old types are gone
+        methodAlternates.setReturnType(permittedTypes.iterator().next());
+        methodAlternates.addReturnTypes(permittedTypes);
+      }
+    } else if (operand.isFieldAccessExpr() || operand.isNameExpr()) {
+      UnsolvedFieldAlternates fieldAlternates = findGeneratedFieldFromUsage(operand);
+
+      if (fieldAlternates != null
+          && fieldAlternates.getTypes().stream().noneMatch(permittedTypes::contains)) {
+        fieldAlternates.replaceAllOldFieldTypes(permittedTypes);
+      }
+    }
   }
 
   /**
@@ -5846,6 +5873,7 @@ public class UnsolvedSymbolGenerator {
         || node instanceof ReturnStmt
         || node instanceof VariableDeclarator
         || node instanceof BinaryExpr
+        || node instanceof UnaryExpr
         || node instanceof LambdaExpr
         || node instanceof ObjectCreationExpr
         || node instanceof ExplicitConstructorInvocationStmt

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -3651,7 +3651,7 @@ public class UnsolvedSymbolGenerator {
         }
       }
     }
-    // If the node is a unary expression, its operand's type is constrained: !x means x is a
+    // The operand type of a unary expression is constrained: !x means x is a
     // boolean, -x that it is numeric, etc.
     else if (node instanceof UnaryExpr unaryExpr) {
       constrainOperandType(

--- a/src/test/java/org/checkerframework/specimin/DuplicateBinaryOperandsTest.java
+++ b/src/test/java/org/checkerframework/specimin/DuplicateBinaryOperandsTest.java
@@ -1,0 +1,26 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * JavaParser's {@code Node#equals} is structural, so the two operands of {@code x + x} are equal
+ * even though they are distinct nodes. Specimin used to crash on such an expression, because it
+ * collected the operands into a {@code Set.of(left, right)}, which rejects duplicates.
+ *
+ * <p>Structural equality also makes the second operand look like it is already being computed, so
+ * the type of the operands has to come from the type of the expression as a whole: {@code int} for
+ * the {@code +}, since the enclosing method returns {@code int}, and {@code boolean} for the {@code
+ * &}, since JLS 15.22.2 makes a {@code &} whose result is boolean a boolean logical operator.
+ */
+public class DuplicateBinaryOperandsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "duplicatebinaryoperands",
+        new String[] {"org/example/Target.java"},
+        new String[] {
+          "org.example.Target#twice(Metrics)", "org.example.Target#bothSides(Metrics)"
+        });
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/UnaryOperandTypeTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnaryOperandTypeTest.java
@@ -1,0 +1,26 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every unary operator constrains its operand's type, so a synthetic member used as one must be
+ * given a type the operator accepts: boolean for {@code !} (JLS 15.15.6), an integral type for
+ * {@code ~} (JLS 15.15.5), and a numeric type for {@code -} and {@code ++} (JLS 15.15.4, 15.14.2).
+ * Specimin used to ignore unary expressions entirely, so the operand kept whatever synthetic type
+ * it would have had in an unconstraining context, and the output did not compile.
+ */
+public class UnaryOperandTypeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unaryoperandtype",
+        new String[] {"org/example/Target.java"},
+        new String[] {
+          "org.example.Target#createDefaultApplicationContext()",
+          "org.example.Target#mask(Flags)",
+          "org.example.Target#tick(Counter)",
+          "org.example.Target#negate(Counter)"
+        });
+  }
+}

--- a/src/test/resources/duplicatebinaryoperands/expected/external/Metrics.java
+++ b/src/test/resources/duplicatebinaryoperands/expected/external/Metrics.java
@@ -1,0 +1,8 @@
+package external;
+public class Metrics {
+    public boolean flag;
+
+    public int value() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/duplicatebinaryoperands/expected/org/example/Target.java
+++ b/src/test/resources/duplicatebinaryoperands/expected/org/example/Target.java
@@ -1,0 +1,14 @@
+package org.example;
+
+import external.Metrics;
+
+public class Target {
+
+  public int twice(Metrics metrics) {
+    return metrics.value() + metrics.value();
+  }
+
+  public boolean bothSides(Metrics metrics) {
+    return metrics.flag & metrics.flag;
+  }
+}

--- a/src/test/resources/duplicatebinaryoperands/input/org/example/Target.java
+++ b/src/test/resources/duplicatebinaryoperands/input/org/example/Target.java
@@ -1,0 +1,14 @@
+package org.example;
+
+import external.Metrics;
+
+public class Target {
+
+  public int twice(Metrics metrics) {
+    return metrics.value() + metrics.value();
+  }
+
+  public boolean bothSides(Metrics metrics) {
+    return metrics.flag & metrics.flag;
+  }
+}

--- a/src/test/resources/unaryoperandtype/expected/external/AotDetector.java
+++ b/src/test/resources/unaryoperandtype/expected/external/AotDetector.java
@@ -1,0 +1,7 @@
+package external;
+public class AotDetector {
+
+    public static boolean useGeneratedArtifacts() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/unaryoperandtype/expected/external/Counter.java
+++ b/src/test/resources/unaryoperandtype/expected/external/Counter.java
@@ -1,0 +1,8 @@
+package external;
+public class Counter {
+    public int count;
+
+    public int scale() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/unaryoperandtype/expected/external/Flags.java
+++ b/src/test/resources/unaryoperandtype/expected/external/Flags.java
@@ -1,0 +1,7 @@
+package external;
+public class Flags {
+
+    public int bits() {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/unaryoperandtype/expected/org/example/Target.java
+++ b/src/test/resources/unaryoperandtype/expected/org/example/Target.java
@@ -1,0 +1,27 @@
+package org.example;
+
+import external.AotDetector;
+import external.Counter;
+import external.Flags;
+
+public class Target {
+
+  public String createDefaultApplicationContext() {
+    if (!AotDetector.useGeneratedArtifacts()) {
+      return "annotation-config";
+    }
+    return "generic";
+  }
+
+  public int mask(Flags flags) {
+    return ~flags.bits();
+  }
+
+  public void tick(Counter counter) {
+    counter.count++;
+  }
+
+  public double negate(Counter counter) {
+    return -counter.scale();
+  }
+}

--- a/src/test/resources/unaryoperandtype/input/org/example/Target.java
+++ b/src/test/resources/unaryoperandtype/input/org/example/Target.java
@@ -1,0 +1,27 @@
+package org.example;
+
+import external.AotDetector;
+import external.Counter;
+import external.Flags;
+
+public class Target {
+
+  public String createDefaultApplicationContext() {
+    if (!AotDetector.useGeneratedArtifacts()) {
+      return "annotation-config";
+    }
+    return "generic";
+  }
+
+  public int mask(Flags flags) {
+    return ~flags.bits();
+  }
+
+  public void tick(Counter counter) {
+    counter.count++;
+  }
+
+  public double negate(Counter counter) {
+    return -counter.scale();
+  }
+}


### PR DESCRIPTION
Fixes issue #543. Specimin just completely lacked handling of unary operators before this - I guess we missed it in our prototype, and it has never come up (somehow).

Incidentally, I fixed a bug related to binary operators (which I discovered while factoring the shared logic between unary and binary operators into a helper): when the two halves of a binary operator were structurally equal (e.g., `x + x`), Specimin would crash. The second regression test in this PR covers that case.