### PR TITLE
Use "approximate" signatures for abstract methods with unsolved parameters that need to be preserved

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -85,6 +85,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -3536,6 +3537,12 @@ public class JavaParserUtil {
    * MethodMatch.APPROXIMATE} for the latter), so that callers can decline to act on an approximate
    * match where a wrong answer would introduce unsoundness.
    *
+   * <p>A caller must consider all of a type's declared methods and prefer an exact match, rather
+   * than stopping at the first match of either kind: a type may declare both an exact and an
+   * approximate match for the same method, as two overloads whose parameter types share a simple
+   * name when only one of the two is on the source path. {@link #findMustImplementMatches} does
+   * this; prefer it to calling this method in a loop of your own.
+   *
    * @param candidate The method that might be a declaration of {@code mustImplement}
    * @param mustImplement The method that must be implemented
    * @param typeParametersMap The type variables map from {@code mustImplement}'s declaring type to
@@ -3563,6 +3570,126 @@ public class JavaParserUtil {
   }
 
   /**
+   * The methods of one type that might be a declaration of some method that must be implemented,
+   * together with how they were matched.
+   *
+   * @param methods the matching methods; empty if nothing matched. An exact match is unique (JLS
+   *     8.4.2 forbids two methods of one type from sharing a signature), so this holds a single
+   *     method whenever {@code kind} is {@code EXACT}
+   * @param kind how the methods were matched
+   */
+  private record MustImplementMatches(List<ResolvedMethodDeclaration> methods, MethodMatch kind) {}
+
+  /**
+   * Finds the methods of {@code declaration} that could be a declaration of {@code mustImplement}.
+   *
+   * <p>If there is an exact match, it is the only thing returned. Failing that, every approximate
+   * match is returned: the approximation cannot tell two overloads apart (see {@link
+   * #matchAgainstMustImplementMethod}), and preserving all the candidates keeps whichever is the
+   * real implementation, at the (minimality) cost of preserving the others too.
+   *
+   * @param declaration The type whose declared methods to search
+   * @param mustImplement The method that must be implemented
+   * @param typeParametersMap The type variables map from {@code mustImplement}'s declaring type to
+   *     {@code declaration}
+   * @return the matching methods
+   */
+  private static MustImplementMatches findMustImplementMatches(
+      ResolvedReferenceTypeDeclaration declaration,
+      ResolvedMethodDeclaration mustImplement,
+      List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeParametersMap) {
+    List<ResolvedMethodDeclaration> approximate = new ArrayList<>();
+
+    for (ResolvedMethodDeclaration candidate : getDeclaredMethodsInOrder(declaration)) {
+      switch (matchAgainstMustImplementMethod(candidate, mustImplement, typeParametersMap)) {
+        case EXACT -> {
+          return new MustImplementMatches(List.of(candidate), MethodMatch.EXACT);
+        }
+        case APPROXIMATE -> approximate.add(candidate);
+        case NONE -> {}
+      }
+    }
+
+    return new MustImplementMatches(
+        approximate, approximate.isEmpty() ? MethodMatch.NONE : MethodMatch.APPROXIMATE);
+  }
+
+  /**
+   * Returns a type's declared methods in a deterministic order. {@link
+   * ResolvedReferenceTypeDeclaration#getDeclaredMethods()} returns a set, and JavaParser rebuilds
+   * the declarations in it on each call, so its iteration order follows fresh identity hash codes
+   * and differs from one call to the next. Iterating it directly makes whatever the caller computes
+   * depend on that order.
+   *
+   * @param declaration The type
+   * @return the type's declared methods, ordered by {@link #getDeclaredMethodOrderKey}
+   */
+  public static List<ResolvedMethodDeclaration> getDeclaredMethodsInOrder(
+      ResolvedReferenceTypeDeclaration declaration) {
+    List<ResolvedMethodDeclaration> methods = new ArrayList<>(declaration.getDeclaredMethods());
+    methods.sort(Comparator.comparing(JavaParserUtil::getDeclaredMethodOrderKey));
+    return methods;
+  }
+
+  /**
+   * Returns a sort key that orders a type's declared methods reproducibly. The key is the most
+   * precise description of the method that can be obtained without resolving anything that might
+   * not be on the source path, so it distinguishes overloads that {@link #getApproximateSignature}
+   * alone would conflate.
+   *
+   * <p>Two methods can still share a key, if neither has a signature nor an AST and their
+   * approximations agree, but the sort is still stable because those two methods are
+   * indistinguishable to Specimin.
+   *
+   * @param method The method
+   * @return the method's sort key
+   */
+  private static String getDeclaredMethodOrderKey(ResolvedMethodDeclaration method) {
+    StringBuilder key =
+        new StringBuilder(method.getName()).append('/').append(method.getNumberOfParams());
+
+    try {
+      return key.append('/').append(method.getSignature()).toString();
+    } catch (UnsolvedSymbolException ex) {
+      // The signature is unavailable exactly when a parameter type is off the source path. Such a
+      // method is nearly always one Specimin parsed, so its source text is available and tells it
+      // apart from an overload whose parameters merely share their simple names.
+      return key.append('/')
+          .append(
+              method.toAst().orElse(null) instanceof MethodDeclaration ast
+                  ? ast.getDeclarationAsString(false, false, false)
+                  : getApproximateSignature(method))
+          .toString();
+    }
+  }
+
+  /**
+   * Checks whether a list already holds a particular declaration, by identity rather than by
+   * equality. {@link com.github.javaparser.ast.Node#equals} is structural, so two distinct
+   * declarations that happen to have the same shape compare equal and {@link List#contains} cannot
+   * tell them apart.
+   *
+   * @param methods The list to search
+   * @param method The method to look for
+   * @return true if {@code method} itself is already in {@code methods}
+   */
+  private static boolean containsIdentical(
+      List<MethodDeclaration> methods, MethodDeclaration method) {
+    for (MethodDeclaration existing : methods) {
+      // Reference equality is intentional: the same declaration can be reached along more than one
+      // inheritance path, and it should be preserved once. No interning is okay because this is a
+      // pointer-equality check.
+      // Extracted into a local variable to minimize suppression scope.
+      @SuppressWarnings({"ReferenceEquality", "not.interned"})
+      boolean isSameDeclaration = existing == method;
+      if (isSameDeclaration) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Helper method for getAllMustImplementMethods. Given a set of JDK methods that must be
    * implemented, find the closest method declaration to preserve (i.e., first check this class,
    * then check its parent, then its grandparent, and so on.)
@@ -3585,7 +3712,7 @@ public class JavaParserUtil {
       List<List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>>> typeParametersMaps =
           new ArrayList<>();
 
-      MethodDeclaration earliestMethod = null;
+      List<MethodDeclaration> earliestMethods = new ArrayList<>();
       int locationInPath = -1;
       boolean hasJdkDefinition = false;
       for (List<ResolvedReferenceType> path : typesInBetween) {
@@ -3622,30 +3749,36 @@ public class JavaParserUtil {
             continue;
           }
 
-          for (ResolvedMethodDeclaration resolvedMethod : declaration.getDeclaredMethods()) {
-            MethodMatch match =
-                matchAgainstMustImplementMethod(
-                    resolvedMethod, resolvedMethodDecl, typeParametersMap);
+          MustImplementMatches matches =
+              findMustImplementMatches(declaration, resolvedMethodDecl, typeParametersMap);
 
-            if (match == MethodMatch.NONE) {
-              continue;
-            }
+          // Set only once all of the matches have been considered, so that the result does not
+          // depend on order. A JDK definition satisfies the
+          // obligation only if every match is concrete, because such a match suppresses
+          // preservation entirely.
+          boolean matchedInJdk = false;
+          boolean everyJdkMatchIsConcrete = true;
 
+          for (ResolvedMethodDeclaration resolvedMethod : matches.methods()) {
             MethodDeclaration methodDecl =
                 (MethodDeclaration) tryFindAttachedNode(resolvedMethod, fqnToCompilationUnits);
 
             if (methodDecl != null) {
               if (!resolvedMethod.isAbstract()) {
                 if (i > locationInPath) {
-                  earliestMethod = methodDecl;
+                  earliestMethods.clear();
                   locationInPath = i;
+                }
+                if (i == locationInPath && !containsIdentical(earliestMethods, methodDecl)) {
+                  earliestMethods.add(methodDecl);
                 }
               }
             } else {
               // We travel the path from the furthest ancestor to the closest ancestor, so if we
               // find an abstract definition, set hasJdkDefinition to false since the abstract
               // will override the concrete definition we may have found earlier in the path.
-              hasJdkDefinition = !resolvedMethod.isAbstract();
+              matchedInJdk = true;
+              everyJdkMatchIsConcrete &= !resolvedMethod.isAbstract();
             }
 
             // Only an exact match may discharge the obligation: an approximate match can conflate
@@ -3653,14 +3786,16 @@ public class JavaParserUtil {
             // costs a missing declaration in the output, while wrongly keeping the obligation
             // costs only a redundant one. Both signatures are computable here, because an exact
             // match means both were just computed.
-            if (match == MethodMatch.EXACT
+            if (matches.kind() == MethodMatch.EXACT
                 && !resolvedMethod
                     .getQualifiedSignature()
                     .equals(resolvedMethodDecl.getQualifiedSignature())) {
               methodsThatMustBeImplemented.remove(resolvedMethodDecl);
             }
+          }
 
-            break;
+          if (matchedInJdk) {
+            hasJdkDefinition = everyJdkMatchIsConcrete;
           }
         }
 
@@ -3715,36 +3850,41 @@ public class JavaParserUtil {
                 typeParametersMap =
                     composeTypeParameterMap(type.getTypeParametersMap(), typeParametersMap);
 
-                for (ResolvedMethodDeclaration resolvedMethod :
-                    path.get(i).getTypeDeclaration().get().getDeclaredMethods()) {
-                  MethodMatch match =
-                      matchAgainstMustImplementMethod(
-                          resolvedMethod, resolvedMethodDecl, typeParametersMap);
+                MustImplementMatches matches =
+                    findMustImplementMatches(
+                        path.get(i).getTypeDeclaration().get(),
+                        resolvedMethodDecl,
+                        typeParametersMap);
 
-                  if (match == MethodMatch.NONE) {
-                    continue;
-                  }
+                // Deferred until every match has been seen, as in the loop above.
+                boolean matchedInJdk = false;
+                boolean everyJdkMatchIsConcrete = true;
 
+                for (ResolvedMethodDeclaration resolvedMethod : matches.methods()) {
                   MethodDeclaration methodDecl =
                       (MethodDeclaration)
                           tryFindAttachedNode(resolvedMethod, fqnToCompilationUnits);
 
                   if (methodDecl != null) {
                     if (i > locationInPath) {
-                      earliestMethod = methodDecl;
+                      earliestMethods.clear();
                       locationInPath = i;
+                    }
+                    if (i == locationInPath && !containsIdentical(earliestMethods, methodDecl)) {
+                      earliestMethods.add(methodDecl);
                     }
                   } else {
                     // We travel the path from the furthest ancestor to the closest ancestor, so
                     // if we find an abstract definition, set hasJdkDefinition to false since
                     // the abstract will override the concrete definition we may have found
                     // earlier in the path.
-                    hasJdkDefinition = !resolvedMethod.isAbstract();
+                    matchedInJdk = true;
+                    everyJdkMatchIsConcrete &= !resolvedMethod.isAbstract();
                   }
 
                   // See the identical condition in the loop above for why an approximate match
                   // may not discharge the obligation.
-                  if (match == MethodMatch.EXACT
+                  if (matches.kind() == MethodMatch.EXACT
                       && resolvedMethod.isAbstract()
                       && !resolvedMethod
                           .getQualifiedSignature()
@@ -3752,8 +3892,10 @@ public class JavaParserUtil {
                       && resolvedMethodDecl.declaringType().isAssignableBy(ancestor)) {
                     methodsThatMustBeImplemented.remove(resolvedMethodDecl);
                   }
+                }
 
-                  break;
+                if (matchedInJdk) {
+                  hasJdkDefinition = everyJdkMatchIsConcrete;
                 }
               }
             }
@@ -3762,9 +3904,7 @@ public class JavaParserUtil {
       }
 
       if (!hasJdkDefinition) {
-        if (earliestMethod != null) {
-          result.add(earliestMethod);
-        }
+        result.addAll(earliestMethods);
       }
     }
 

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -3528,12 +3528,13 @@ public class JavaParserUtil {
    * Decides whether {@code candidate} is a declaration of {@code mustImplement}, i.e. whether it
    * declares or overrides it.
    *
-   * <p>The exact comparison is by signature, but computing a signature resolves every parameter
-   * type, so it fails for a method with a parameter whose type is not on the source path. Falling
-   * back to {@link #getApproximateSignatureWithTypeVariablesMap} keeps such a method from being
-   * dropped, at the cost of not distinguishing overloads whose parameter types share a simple name.
-   * The result says which comparison succeeded, so that callers can decline to act on an
-   * approximate match where a wrong answer would cost them more than a missed one.
+   * <p>First, it tries an exact comparison via signature, but computing a signature resolves every
+   * parameter type, which fails for a method with a parameter whose type is not on the source path.
+   * It falls back to {@link #getApproximateSignatureWithTypeVariablesMap}, which may not
+   * distinguish overloads whose parameter types share a simple name. The result is an enum
+   * indicating which comparison succeeded ({@code MethodMatch.EXACT} for the former, {@code
+   * MethodMatch.APPROXIMATE} for the latter), so that callers can decline to act on an approximate
+   * match where a wrong answer would introduce unsoundness.
    *
    * @param candidate The method that might be a declaration of {@code mustImplement}
    * @param mustImplement The method that must be implemented
@@ -3869,10 +3870,10 @@ public class JavaParserUtil {
    * the source path. Such a parameter is routine in Specimin: it names exactly the kind of type
    * that Specimin synthesizes.
    *
-   * <p>Each parameter type is reduced to its simple name with its type arguments stripped, so the
-   * result conflates overloads whose parameter types differ only in their package or in their type
-   * arguments. That is coarser than the override-equivalence of JLS 8.4.2, which compares erasures
-   * but not simple names, so use this only where the exact signature is unavailable.
+   * <p>Each parameter type is reduced by {@link #erase} to its simple name, so the result conflates
+   * overloads whose parameter types differ only in their package or in their type arguments. That
+   * is coarser than the override-equivalence of JLS 8.4.2, which compares erasures but not simple
+   * names, so use this only where the exact signature is unavailable.
    *
    * @param method The method
    * @return an approximation of the method's signature, in the form {@code name(Simple1, Simple2)}
@@ -3882,8 +3883,8 @@ public class JavaParserUtil {
   }
 
   /**
-   * Stands to {@link #getSignatureFromResolvedMethodWithTypeVariablesMap(ResolvedMethodDeclaration,
-   * List)} as {@link #getApproximateSignature(ResolvedMethodDeclaration)} stands to {@link
+   * Like {@link #getSignatureFromResolvedMethodWithTypeVariablesMap(ResolvedMethodDeclaration,
+   * List)} as {@link #getApproximateSignature(ResolvedMethodDeclaration)} is like {@link
    * ResolvedMethodLikeDeclaration#getSignature()}: it substitutes away the type variables of a
    * declaring type, and it never throws. Use it to compare a method against one declared in an
    * ancestor of its declaring type.
@@ -3915,8 +3916,7 @@ public class JavaParserUtil {
         // caller could compare it against except another equally-unknown parameter.
         described = ast == null ? UNKNOWN_PARAMETER_TYPE : ast.getParameter(i).getType().toString();
       }
-      parameters.add(
-          getSimpleNameFromQualifiedName(eraseTypeArguments(described)) + (variadic ? "..." : ""));
+      parameters.add(getSimpleNameFromQualifiedName(erase(described)) + (variadic ? "..." : ""));
     }
     return parameters.toString();
   }
@@ -3933,7 +3933,7 @@ public class JavaParserUtil {
     StringJoiner parameters = new StringJoiner(", ", method.getNameAsString() + "(", ")");
     for (Parameter parameter : method.getParameters()) {
       parameters.add(
-          getSimpleNameFromQualifiedName(eraseTypeArguments(parameter.getType().toString()))
+          getSimpleNameFromQualifiedName(erase(parameter.getType().toString()))
               + (parameter.isVarArgs() ? "..." : ""));
     }
     return parameters.toString();
@@ -3964,33 +3964,6 @@ public class JavaParserUtil {
   public static boolean areMethodsLikelyEqual(
       ResolvedMethodDeclaration resolved, MethodDeclaration ast) {
     return getApproximateSignature(resolved).equals(getApproximateSignature(ast));
-  }
-
-  /**
-   * Removes every type argument list from a type's string form, which is most of what erasure (JLS
-   * 4.6) does to a parameterized type. Nested type arguments are removed with their enclosing list,
-   * and anything that follows the list, such as an array's brackets, is kept.
-   *
-   * @param type The string form of a type
-   * @return the same string with all {@code <...>} sections removed
-   */
-  private static String eraseTypeArguments(String type) {
-    if (type.indexOf('<') == -1) {
-      return type;
-    }
-    StringBuilder erased = new StringBuilder(type.length());
-    int depth = 0;
-    for (int i = 0; i < type.length(); i++) {
-      char c = type.charAt(i);
-      if (c == '<') {
-        depth++;
-      } else if (c == '>') {
-        depth--;
-      } else if (depth == 0) {
-        erased.append(c);
-      }
-    }
-    return erased.toString();
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -94,6 +94,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
@@ -130,6 +131,13 @@ public class JavaParserUtil {
    * solver in {@link #getResolvablePlaceholderType(int)}.
    */
   private static final Set<String> generatedResolvedPlaceholderTypes = new HashSet<>();
+
+  /**
+   * Stands in for a parameter type that {@link #getApproximateSignature(ResolvedMethodDeclaration)}
+   * can neither resolve nor read out of an AST. It is not a legal Java type name, so it cannot
+   * collide with a real one.
+   */
+  private static final String UNKNOWN_PARAMETER_TYPE = "?unknown";
 
   /**
    * Set the SpeciminTypeSolvers instance to be used.
@@ -3506,6 +3514,53 @@ public class JavaParserUtil {
         typeDecl, methodsThatMustBeImplemented, fqnToCompilationUnits);
   }
 
+  /** How closely a candidate method matched a method that must be implemented. */
+  private enum MethodMatch {
+    /** The two signatures are equal, after substituting away the supertype's type variables. */
+    EXACT,
+    /** The signatures could not be computed, but the approximations of them are equal. */
+    APPROXIMATE,
+    /** The two are different methods. */
+    NONE
+  }
+
+  /**
+   * Decides whether {@code candidate} is a declaration of {@code mustImplement}, i.e. whether it
+   * declares or overrides it.
+   *
+   * <p>The exact comparison is by signature, but computing a signature resolves every parameter
+   * type, so it fails for a method with a parameter whose type is not on the source path. Falling
+   * back to {@link #getApproximateSignatureWithTypeVariablesMap} keeps such a method from being
+   * dropped, at the cost of not distinguishing overloads whose parameter types share a simple name.
+   * The result says which comparison succeeded, so that callers can decline to act on an
+   * approximate match where a wrong answer would cost them more than a missed one.
+   *
+   * @param candidate The method that might be a declaration of {@code mustImplement}
+   * @param mustImplement The method that must be implemented
+   * @param typeParametersMap The type variables map from {@code mustImplement}'s declaring type to
+   *     {@code candidate}'s
+   * @return how the two matched
+   */
+  private static MethodMatch matchAgainstMustImplementMethod(
+      ResolvedMethodDeclaration candidate,
+      ResolvedMethodDeclaration mustImplement,
+      List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeParametersMap) {
+    try {
+      return candidate
+              .getSignature()
+              .equals(
+                  getSignatureFromResolvedMethodWithTypeVariablesMap(
+                      mustImplement, typeParametersMap))
+          ? MethodMatch.EXACT
+          : MethodMatch.NONE;
+    } catch (UnsolvedSymbolException ex) {
+      return getApproximateSignature(candidate)
+              .equals(getApproximateSignatureWithTypeVariablesMap(mustImplement, typeParametersMap))
+          ? MethodMatch.APPROXIMATE
+          : MethodMatch.NONE;
+    }
+  }
+
   /**
    * Helper method for getAllMustImplementMethods. Given a set of JDK methods that must be
    * implemented, find the closest method declaration to preserve (i.e., first check this class,
@@ -3567,42 +3622,44 @@ public class JavaParserUtil {
           }
 
           for (ResolvedMethodDeclaration resolvedMethod : declaration.getDeclaredMethods()) {
-            try {
-              if (resolvedMethod
-                  .getSignature()
-                  .equals(
-                      getSignatureFromResolvedMethodWithTypeVariablesMap(
-                          resolvedMethodDecl, typeParametersMap))) {
+            MethodMatch match =
+                matchAgainstMustImplementMethod(
+                    resolvedMethod, resolvedMethodDecl, typeParametersMap);
 
-                MethodDeclaration methodDecl =
-                    (MethodDeclaration) tryFindAttachedNode(resolvedMethod, fqnToCompilationUnits);
+            if (match == MethodMatch.NONE) {
+              continue;
+            }
 
-                if (methodDecl != null) {
-                  if (!resolvedMethod.isAbstract()) {
-                    if (i > locationInPath) {
-                      earliestMethod = methodDecl;
-                      locationInPath = i;
-                    }
-                  }
-                } else {
-                  // We travel the path from the furthest ancestor to the closest ancestor, so if we
-                  // find an abstract definition, set hasJdkDefinition to false since the abstract
-                  // will override the concrete definition we may have found earlier in the path.
-                  hasJdkDefinition = !resolvedMethod.isAbstract();
+            MethodDeclaration methodDecl =
+                (MethodDeclaration) tryFindAttachedNode(resolvedMethod, fqnToCompilationUnits);
+
+            if (methodDecl != null) {
+              if (!resolvedMethod.isAbstract()) {
+                if (i > locationInPath) {
+                  earliestMethod = methodDecl;
+                  locationInPath = i;
                 }
+              }
+            } else {
+              // We travel the path from the furthest ancestor to the closest ancestor, so if we
+              // find an abstract definition, set hasJdkDefinition to false since the abstract
+              // will override the concrete definition we may have found earlier in the path.
+              hasJdkDefinition = !resolvedMethod.isAbstract();
+            }
 
-                if (!resolvedMethod
+            // Only an exact match may discharge the obligation: an approximate match can conflate
+            // two overloads, and wrongly concluding that this method is already declared elsewhere
+            // costs a missing declaration in the output, while wrongly keeping the obligation
+            // costs only a redundant one. Both signatures are computable here, because an exact
+            // match means both were just computed.
+            if (match == MethodMatch.EXACT
+                && !resolvedMethod
                     .getQualifiedSignature()
                     .equals(resolvedMethodDecl.getQualifiedSignature())) {
-                  methodsThatMustBeImplemented.remove(resolvedMethodDecl);
-                }
-
-                break;
-              }
-            } catch (UnsolvedSymbolException ex) {
-              // It's possible that a method could reference an unsolved symbol; in this case, just
-              // skip it
+              methodsThatMustBeImplemented.remove(resolvedMethodDecl);
             }
+
+            break;
           }
         }
 
@@ -3659,39 +3716,43 @@ public class JavaParserUtil {
 
                 for (ResolvedMethodDeclaration resolvedMethod :
                     path.get(i).getTypeDeclaration().get().getDeclaredMethods()) {
-                  if (resolvedMethod
-                      .getSignature()
-                      .equals(
-                          getSignatureFromResolvedMethodWithTypeVariablesMap(
-                              resolvedMethodDecl, typeParametersMap))) {
+                  MethodMatch match =
+                      matchAgainstMustImplementMethod(
+                          resolvedMethod, resolvedMethodDecl, typeParametersMap);
 
-                    MethodDeclaration methodDecl =
-                        (MethodDeclaration)
-                            tryFindAttachedNode(resolvedMethod, fqnToCompilationUnits);
-
-                    if (methodDecl != null) {
-                      if (i > locationInPath) {
-                        earliestMethod = methodDecl;
-                        locationInPath = i;
-                      }
-                    } else {
-                      // We travel the path from the furthest ancestor to the closest ancestor, so
-                      // if we find an abstract definition, set hasJdkDefinition to false since
-                      // the abstract will override the concrete definition we may have found
-                      // earlier in the path.
-                      hasJdkDefinition = !resolvedMethod.isAbstract();
-                    }
-
-                    if (resolvedMethod.isAbstract()
-                        && !resolvedMethod
-                            .getQualifiedSignature()
-                            .equals(resolvedMethodDecl.getQualifiedSignature())
-                        && resolvedMethodDecl.declaringType().isAssignableBy(ancestor)) {
-                      methodsThatMustBeImplemented.remove(resolvedMethodDecl);
-                    }
-
-                    break;
+                  if (match == MethodMatch.NONE) {
+                    continue;
                   }
+
+                  MethodDeclaration methodDecl =
+                      (MethodDeclaration)
+                          tryFindAttachedNode(resolvedMethod, fqnToCompilationUnits);
+
+                  if (methodDecl != null) {
+                    if (i > locationInPath) {
+                      earliestMethod = methodDecl;
+                      locationInPath = i;
+                    }
+                  } else {
+                    // We travel the path from the furthest ancestor to the closest ancestor, so
+                    // if we find an abstract definition, set hasJdkDefinition to false since
+                    // the abstract will override the concrete definition we may have found
+                    // earlier in the path.
+                    hasJdkDefinition = !resolvedMethod.isAbstract();
+                  }
+
+                  // See the identical condition in the loop above for why an approximate match
+                  // may not discharge the obligation.
+                  if (match == MethodMatch.EXACT
+                      && resolvedMethod.isAbstract()
+                      && !resolvedMethod
+                          .getQualifiedSignature()
+                          .equals(resolvedMethodDecl.getQualifiedSignature())
+                      && resolvedMethodDecl.declaringType().isAssignableBy(ancestor)) {
+                    methodsThatMustBeImplemented.remove(resolvedMethodDecl);
+                  }
+
+                  break;
                 }
               }
             }
@@ -3799,6 +3860,137 @@ public class JavaParserUtil {
     }
 
     return result;
+  }
+
+  /**
+   * Returns an approximation of a method's signature that can always be computed, unlike {@link
+   * ResolvedMethodLikeDeclaration#getSignature()}, which resolves every parameter type and so
+   * throws an {@link UnsolvedSymbolException} for any method with a parameter whose type is not on
+   * the source path. Such a parameter is routine in Specimin: it names exactly the kind of type
+   * that Specimin synthesizes.
+   *
+   * <p>Each parameter type is reduced to its simple name with its type arguments stripped, so the
+   * result conflates overloads whose parameter types differ only in their package or in their type
+   * arguments. That is coarser than the override-equivalence of JLS 8.4.2, which compares erasures
+   * but not simple names, so use this only where the exact signature is unavailable.
+   *
+   * @param method The method
+   * @return an approximation of the method's signature, in the form {@code name(Simple1, Simple2)}
+   */
+  public static String getApproximateSignature(ResolvedMethodDeclaration method) {
+    return getApproximateSignatureWithTypeVariablesMap(method, List.of());
+  }
+
+  /**
+   * Stands to {@link #getSignatureFromResolvedMethodWithTypeVariablesMap(ResolvedMethodDeclaration,
+   * List)} as {@link #getApproximateSignature(ResolvedMethodDeclaration)} stands to {@link
+   * ResolvedMethodLikeDeclaration#getSignature()}: it substitutes away the type variables of a
+   * declaring type, and it never throws. Use it to compare a method against one declared in an
+   * ancestor of its declaring type.
+   *
+   * @param method The method
+   * @param typeVariablesMap The type variables map, which maps type variable declarations to their
+   *     resolved types
+   * @return an approximation of the method's signature after substitution
+   */
+  public static String getApproximateSignatureWithTypeVariablesMap(
+      ResolvedMethodDeclaration method,
+      List<Pair<ResolvedTypeParameterDeclaration, ResolvedType>> typeVariablesMap) {
+    MethodDeclaration ast =
+        method.toAst().orElse(null) instanceof MethodDeclaration methodDecl ? methodDecl : null;
+
+    StringJoiner parameters = new StringJoiner(", ", method.getName() + "(", ")");
+    for (int i = 0; i < method.getNumberOfParams(); i++) {
+      ResolvedParameterDeclaration parameter = method.getParam(i);
+      boolean variadic = parameter.isVariadic();
+      String described;
+      try {
+        ResolvedType type =
+            variadic ? parameter.getType().asArrayType().getComponentType() : parameter.getType();
+        described = getResolvedNameWithSubstitution(type, typeVariablesMap);
+      } catch (UnsolvedSymbolException ex) {
+        // Fall back to what the source says, which is available whenever the method came from a
+        // source file rather than from a jar or the JDK. A method that is neither resolvable nor
+        // attached to an AST is described as UNKNOWN_PARAMETER_TYPE, which matches nothing a
+        // caller could compare it against except another equally-unknown parameter.
+        described = ast == null ? UNKNOWN_PARAMETER_TYPE : ast.getParameter(i).getType().toString();
+      }
+      parameters.add(
+          getSimpleNameFromQualifiedName(eraseTypeArguments(described)) + (variadic ? "..." : ""));
+    }
+    return parameters.toString();
+  }
+
+  /**
+   * The AST equivalent of {@link #getApproximateSignature(ResolvedMethodDeclaration)}: the two
+   * agree whenever they are given the same method, so a resolved declaration and an AST node can be
+   * compared even though neither can be resolved into the other's world.
+   *
+   * @param method The method or constructor declaration
+   * @return an approximation of the method's signature, in the form {@code name(Simple1, Simple2)}
+   */
+  public static String getApproximateSignature(CallableDeclaration<?> method) {
+    StringJoiner parameters = new StringJoiner(", ", method.getNameAsString() + "(", ")");
+    for (Parameter parameter : method.getParameters()) {
+      parameters.add(
+          getSimpleNameFromQualifiedName(eraseTypeArguments(parameter.getType().toString()))
+              + (parameter.isVarArgs() ? "..." : ""));
+    }
+    return parameters.toString();
+  }
+
+  /**
+   * The {@link ResolvedMethodLikeDeclaration#getQualifiedSignature()} analogue of {@link
+   * #getApproximateSignature(ResolvedMethodDeclaration)}: it identifies a method across types, but
+   * never throws.
+   *
+   * @param method The method
+   * @return the qualified name of the method's declaring type, a dot, and the method's approximate
+   *     signature
+   */
+  public static String getApproximateQualifiedSignature(ResolvedMethodDeclaration method) {
+    return method.declaringType().getQualifiedName() + "." + getApproximateSignature(method);
+  }
+
+  /**
+   * Checks whether a resolved method declaration and a method declaration AST node are likely to be
+   * the same method. Use this only when the AST node is not resolvable and the two therefore cannot
+   * be compared by their exact signatures.
+   *
+   * @param resolved The resolved method declaration
+   * @param ast The method declaration AST node
+   * @return true if the two are likely to be the same method
+   */
+  public static boolean areMethodsLikelyEqual(
+      ResolvedMethodDeclaration resolved, MethodDeclaration ast) {
+    return getApproximateSignature(resolved).equals(getApproximateSignature(ast));
+  }
+
+  /**
+   * Removes every type argument list from a type's string form, which is most of what erasure (JLS
+   * 4.6) does to a parameterized type. Nested type arguments are removed with their enclosing list,
+   * and anything that follows the list, such as an array's brackets, is kept.
+   *
+   * @param type The string form of a type
+   * @return the same string with all {@code <...>} sections removed
+   */
+  private static String eraseTypeArguments(String type) {
+    if (type.indexOf('<') == -1) {
+      return type;
+    }
+    StringBuilder erased = new StringBuilder(type.length());
+    int depth = 0;
+    for (int i = 0; i < type.length(); i++) {
+      char c = type.charAt(i);
+      if (c == '<') {
+        depth++;
+      } else if (c == '>') {
+        depth--;
+      } else if (depth == 0) {
+        erased.append(c);
+      }
+    }
+    return erased.toString();
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
+++ b/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
@@ -58,11 +58,17 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
   private final Map<String, CompilationUnit> fqnToCompilationUnits;
 
   /**
-   * A map of abstract super method qualified signatures to their concrete implementations. This
-   * addresses cases where an abstract method is preserved because it is directly called but its
-   * concrete implementations are not, but the types containing those concrete implementations are
-   * also included in the slice. If we encounter the abstract super method after encountering the
-   * concrete implementation, then we use this map.
+   * A map of abstract super methods to their concrete implementations. This addresses cases where
+   * an abstract method is preserved because it is directly called but its concrete implementations
+   * are not, but the types containing those concrete implementations are also included in the
+   * slice. If we encounter the abstract super method after encountering the concrete
+   * implementation, then we use this map.
+   *
+   * <p>Keys are {@link JavaParserUtil#getApproximateQualifiedSignature} rather than qualified
+   * signatures, because an abstract method may well have a parameter whose type is not on the
+   * source path, and computing a qualified signature for such a method throws. The approximation
+   * loses nothing here: the only methods this map is asked about are matched by name and arity
+   * anyway, when the map is populated below.
    */
   private final Map<String, Set<MethodDeclaration>> methodsWithAbstractSuperDefinitions =
       new HashMap<>();
@@ -129,10 +135,9 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
         // Method declarations can always be resolved
         ResolvedMethodDeclaration resolvedMethod = Resolver.resolveGuaranteeNonNull(methodDecl);
         nonJDKMustImplementMethods.add(resolvedMethod);
-        if (methodsWithAbstractSuperDefinitions.containsKey(
-            resolvedMethod.getQualifiedSignature())) {
-          elements.addAll(
-              methodsWithAbstractSuperDefinitions.get(resolvedMethod.getQualifiedSignature()));
+        String key = JavaParserUtil.getApproximateQualifiedSignature(resolvedMethod);
+        if (methodsWithAbstractSuperDefinitions.containsKey(key)) {
+          elements.addAll(methodsWithAbstractSuperDefinitions.get(key));
         }
       }
     }
@@ -168,7 +173,9 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
                   && ancestorMethod.getNumberOfParams() == resolvedMethod.getNumberOfParams()
                   && ancestorMethod.isAbstract()) {
                 methodsWithAbstractSuperDefinitions
-                    .computeIfAbsent(ancestorMethod.getQualifiedSignature(), k -> new HashSet<>())
+                    .computeIfAbsent(
+                        JavaParserUtil.getApproximateQualifiedSignature(ancestorMethod),
+                        k -> new HashSet<>())
                     .add(method);
               }
             }
@@ -649,7 +656,7 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
       } else {
         // At least one parameter type may not be solvable. In this case, try comparing
         // simple names.
-        if (areAstAndResolvedMethodLikelyEqual(original, method)) {
+        if (JavaParserUtil.areMethodsLikelyEqual(original, method)) {
           result.add(method);
 
           if (method.isAbstract()) {
@@ -660,50 +667,5 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
     }
 
     return result;
-  }
-
-  /**
-   * Checks to see if a resolved method declaration and a method declaration AST node are likely to
-   * be the same method, based on their names and the simple names of their parameters. Use this
-   * method only when {@code ast} is not resolvable and you can't compare with qualified parameter
-   * types.
-   *
-   * @param resolved The resolved method declaration
-   * @param ast The method declaration AST node
-   * @return true if the method and AST node are likely to be the same method, false otherwise
-   */
-  private boolean areAstAndResolvedMethodLikelyEqual(
-      ResolvedMethodDeclaration resolved, MethodDeclaration ast) {
-    if (!ast.getNameAsString().equals(resolved.getName())) {
-      return false;
-    }
-
-    if (ast.getParameters().size() != resolved.getNumberOfParams()) {
-      return false;
-    }
-
-    for (int i = 0; i < ast.getParameters().size(); i++) {
-      String resolvedParamType;
-      try {
-        resolvedParamType = resolved.getParam(i).getType().describe();
-      } catch (UnsolvedSymbolException ex) {
-        // See if the AST version exists, and use that simple name
-        if (resolved.toAst().orElse(null) instanceof MethodDeclaration methodDecl) {
-          resolvedParamType = methodDecl.getParameter(i).getType().toString();
-        } else {
-          // If we cannot compare, we'll return false
-          return false;
-        }
-      }
-
-      if (!JavaParserUtil.getSimpleNameFromQualifiedName(resolvedParamType)
-          .equals(
-              JavaParserUtil.getSimpleNameFromQualifiedName(
-                  ast.getParameter(i).getType().toString()))) {
-        return false;
-      }
-    }
-
-    return true;
   }
 }

--- a/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
+++ b/src/main/java/org/checkerframework/specimin/StandardTypeRuleDependencyMap.java
@@ -167,8 +167,10 @@ public class StandardTypeRuleDependencyMap implements TypeRuleDependencyMap {
         try {
           for (ResolvedReferenceType ancestor : resolvedMethod.declaringType().getAllAncestors()) {
             // Approximate: check to see if name and arity matches.
+            // Ordered, because getDeclaredMethods() returns a set whose iteration order is not
+            // reproducible; see JavaParserUtil#getDeclaredMethodsInOrder.
             for (ResolvedMethodDeclaration ancestorMethod :
-                ancestor.getTypeDeclaration().get().getDeclaredMethods()) {
+                JavaParserUtil.getDeclaredMethodsInOrder(ancestor.getTypeDeclaration().get())) {
               if (ancestorMethod.getName().equals(resolvedMethod.getName())
                   && ancestorMethod.getNumberOfParams() == resolvedMethod.getNumberOfParams()
                   && ancestorMethod.isAbstract()) {

--- a/src/test/java/org/checkerframework/specimin/AbstractMethodUnsolvedParamTest.java
+++ b/src/test/java/org/checkerframework/specimin/AbstractMethodUnsolvedParamTest.java
@@ -1,0 +1,24 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The target method implements an interface method whose parameter type cannot be resolved, because
+ * the type is declared outside the root. Specimin used to crash with an {@code
+ * UnsolvedSymbolException} here, because it identified abstract methods by their qualified
+ * signature, and computing a qualified signature requires resolving every parameter type. This is a
+ * minimization of https://github.com/njit-jerse/specimin/issues/547.
+ *
+ * <p>The abstract declaration in {@code Rule} is preserved: the target method overrides it, so the
+ * override-compatibility rules of JLS 8.4.8.1 and 8.4.8.3 read it when type-checking the target.
+ */
+public class AbstractMethodUnsolvedParamTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "abstractmethodunsolvedparam",
+        new String[] {"com/example/LeaseExistsRule.java"},
+        new String[] {"com.example.LeaseExistsRule#apply(InstanceInfo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AmbiguousApproximateOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/AmbiguousApproximateOverloadTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Like {@link SameSimpleNameOverloadTest}, but neither of {@code Impl}'s two overloads can be
+ * matched exactly: {@code Rule#apply}'s own parameter type is off the source path, so no signature
+ * in the comparison can be computed and both overloads match {@code apply(Foo)} approximately.
+ *
+ * <p>Specimin cannot tell which of the two implements {@code Rule#apply}, so it preserves both.
+ * Preserving the wrong one alone would leave {@code Impl} without an implementation of an abstract
+ * method it inherits, which does not compile (JLS 8.1.1.1); preserving both only costs minimality,
+ * which Specimin trades away for compilability. This test pins that policy -- it also passes
+ * against a version that picks an arbitrary one of the two, because several passes over {@code
+ * Impl} happen to pick different ones and the slice is their union, so what it really guards
+ * against is a future change that resolves the ambiguity by preserving neither.
+ */
+public class AmbiguousApproximateOverloadTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "ambiguousapproximateoverload",
+        new String[] {"com/example/Target.java"},
+        new String[] {"com.example.Target#target(Foo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AmbiguousApproximateOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/AmbiguousApproximateOverloadTest.java
@@ -8,13 +8,9 @@ import org.junit.jupiter.api.Test;
  * matched exactly: {@code Rule#apply}'s own parameter type is off the source path, so no signature
  * in the comparison can be computed and both overloads match {@code apply(Foo)} approximately.
  *
- * <p>Specimin cannot tell which of the two implements {@code Rule#apply}, so it preserves both.
+ * <p>Specimin cannot tell which of the two implements {@code Rule#apply}, so it should preserve both.
  * Preserving the wrong one alone would leave {@code Impl} without an implementation of an abstract
- * method it inherits, which does not compile (JLS 8.1.1.1); preserving both only costs minimality,
- * which Specimin trades away for compilability. This test pins that policy -- it also passes
- * against a version that picks an arbitrary one of the two, because several passes over {@code
- * Impl} happen to pick different ones and the slice is their union, so what it really guards
- * against is a future change that resolves the ambiguity by preserving neither.
+ * method it inherits, which does not compile (JLS 8.1.1.1); preserving both only costs minimality.
  */
 public class AmbiguousApproximateOverloadTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/MustImplementUnsolvedParamTest.java
+++ b/src/test/java/org/checkerframework/specimin/MustImplementUnsolvedParamTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A variant of {@link AbstractMethodUnsolvedParamTest} in which the class that implements the
+ * interface is not the target: the target only calls the interface method and instantiates the
+ * implementing class. {@code LeaseExistsRule} therefore enters the slice as a type declaration, and
+ * JLS 8.1.1.1 requires a non-abstract class to implement every abstract method of its
+ * superinterfaces -- so {@code LeaseExistsRule#apply} must be preserved (with a stubbed body) or
+ * the output does not compile.
+ *
+ * <p>Specimin used to crash on this input for the same reason as {@link
+ * AbstractMethodUnsolvedParamTest}. Merely suppressing that crash is not enough: the machinery that
+ * finds must-implement methods also matches methods by signature, so the implementation is dropped
+ * and the output fails to compile.
+ */
+public class MustImplementUnsolvedParamTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "mustimplementunsolvedparam",
+        new String[] {"com/example/Target.java"},
+        new String[] {"com.example.Target#target(InstanceInfo)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/SameSimpleNameOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/SameSimpleNameOverloadTest.java
@@ -1,0 +1,32 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code Impl} declares two same-name, same-arity overloads whose parameter types have the same
+ * simple name but live in different packages, and only one of the two packages is on the source
+ * path. The unresolvable overload therefore matches {@code Rule#apply} only approximately, while
+ * the other matches exactly.
+ *
+ * <p>Specimin used to preserve whichever of the two it happened to visit first: {@link
+ * com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration#getDeclaredMethods}
+ * returns a set, and the resolved declaration is rebuilt on each call, so the iteration order
+ * follows fresh identity hash codes and varies from one call to the next. That made the output
+ * non-deterministic, and it let {@code apply(com.other.b.Foo)} -- which overrides nothing, since
+ * JLS 8.4.2 compares erasures and {@code com.other.b.Foo} is not {@code com.example.a.Foo} -- be
+ * preserved in place of the real implementation, dragging a synthetic {@code com.other.b.Foo} into
+ * the output with it.
+ *
+ * <p>The expected output keeps only {@code apply(com.example.a.Foo)}, which JLS 8.1.1.1 requires a
+ * non-abstract {@code Impl} to declare, and no {@code com.other.b} package at all.
+ */
+public class SameSimpleNameOverloadTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "samesimplenameoverload",
+        new String[] {"com/example/Target.java"},
+        new String[] {"com.example.Target#target(Foo)"});
+  }
+}

--- a/src/test/resources/abstractmethodunsolvedparam/expected/com/example/LeaseExistsRule.java
+++ b/src/test/resources/abstractmethodunsolvedparam/expected/com/example/LeaseExistsRule.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.other.InstanceInfo;
+
+public class LeaseExistsRule implements Rule {
+
+    public String apply(InstanceInfo instanceInfo) {
+        return "";
+    }
+}

--- a/src/test/resources/abstractmethodunsolvedparam/expected/com/example/Rule.java
+++ b/src/test/resources/abstractmethodunsolvedparam/expected/com/example/Rule.java
@@ -1,0 +1,8 @@
+package com.example;
+
+import com.other.InstanceInfo;
+
+public interface Rule {
+
+    String apply(InstanceInfo instanceInfo);
+}

--- a/src/test/resources/abstractmethodunsolvedparam/expected/com/other/InstanceInfo.java
+++ b/src/test/resources/abstractmethodunsolvedparam/expected/com/other/InstanceInfo.java
@@ -1,0 +1,4 @@
+package com.other;
+
+public class InstanceInfo {
+}

--- a/src/test/resources/abstractmethodunsolvedparam/input/com/example/LeaseExistsRule.java
+++ b/src/test/resources/abstractmethodunsolvedparam/input/com/example/LeaseExistsRule.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import com.other.InstanceInfo;
+
+public class LeaseExistsRule implements Rule {
+    public String apply(InstanceInfo instanceInfo) {
+        return "";
+    }
+}

--- a/src/test/resources/abstractmethodunsolvedparam/input/com/example/Rule.java
+++ b/src/test/resources/abstractmethodunsolvedparam/input/com/example/Rule.java
@@ -1,0 +1,7 @@
+package com.example;
+
+import com.other.InstanceInfo;
+
+public interface Rule {
+    String apply(InstanceInfo instanceInfo);
+}

--- a/src/test/resources/ambiguousapproximateoverload/expected/com/example/Impl.java
+++ b/src/test/resources/ambiguousapproximateoverload/expected/com/example/Impl.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import com.other.a.Foo;
+
+public class Impl implements Rule {
+
+    public String apply(com.other.b.Foo foo) {
+        throw new java.lang.Error();
+    }
+
+    public String apply(Foo foo) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/ambiguousapproximateoverload/expected/com/example/Rule.java
+++ b/src/test/resources/ambiguousapproximateoverload/expected/com/example/Rule.java
@@ -1,0 +1,8 @@
+package com.example;
+
+import com.other.a.Foo;
+
+public interface Rule {
+
+    String apply(Foo foo);
+}

--- a/src/test/resources/ambiguousapproximateoverload/expected/com/example/Target.java
+++ b/src/test/resources/ambiguousapproximateoverload/expected/com/example/Target.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.other.a.Foo;
+
+public class Target {
+
+    String target(Foo foo) {
+        Rule rule = new Impl();
+        return rule.apply(foo);
+    }
+}

--- a/src/test/resources/ambiguousapproximateoverload/expected/com/other/a/Foo.java
+++ b/src/test/resources/ambiguousapproximateoverload/expected/com/other/a/Foo.java
@@ -1,0 +1,4 @@
+package com.other.a;
+
+public class Foo {
+}

--- a/src/test/resources/ambiguousapproximateoverload/expected/com/other/b/Foo.java
+++ b/src/test/resources/ambiguousapproximateoverload/expected/com/other/b/Foo.java
@@ -1,0 +1,4 @@
+package com.other.b;
+
+public class Foo {
+}

--- a/src/test/resources/ambiguousapproximateoverload/input/com/example/Impl.java
+++ b/src/test/resources/ambiguousapproximateoverload/input/com/example/Impl.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import com.other.a.Foo;
+
+public class Impl implements Rule {
+    public String apply(com.other.b.Foo foo) {
+        return "other";
+    }
+
+    public String apply(Foo foo) {
+        return "real";
+    }
+}

--- a/src/test/resources/ambiguousapproximateoverload/input/com/example/Rule.java
+++ b/src/test/resources/ambiguousapproximateoverload/input/com/example/Rule.java
@@ -1,0 +1,7 @@
+package com.example;
+
+import com.other.a.Foo;
+
+public interface Rule {
+    String apply(Foo foo);
+}

--- a/src/test/resources/ambiguousapproximateoverload/input/com/example/Target.java
+++ b/src/test/resources/ambiguousapproximateoverload/input/com/example/Target.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.other.a.Foo;
+
+public class Target {
+    String target(Foo foo) {
+        Rule rule = new Impl();
+        return rule.apply(foo);
+    }
+}

--- a/src/test/resources/mustimplementunsolvedparam/expected/com/example/LeaseExistsRule.java
+++ b/src/test/resources/mustimplementunsolvedparam/expected/com/example/LeaseExistsRule.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.other.InstanceInfo;
+
+public class LeaseExistsRule implements Rule {
+
+    public String apply(InstanceInfo instanceInfo) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/mustimplementunsolvedparam/expected/com/example/Rule.java
+++ b/src/test/resources/mustimplementunsolvedparam/expected/com/example/Rule.java
@@ -1,0 +1,8 @@
+package com.example;
+
+import com.other.InstanceInfo;
+
+public interface Rule {
+
+    String apply(InstanceInfo instanceInfo);
+}

--- a/src/test/resources/mustimplementunsolvedparam/expected/com/example/Target.java
+++ b/src/test/resources/mustimplementunsolvedparam/expected/com/example/Target.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.other.InstanceInfo;
+
+public class Target {
+
+    String target(InstanceInfo info) {
+        Rule rule = new LeaseExistsRule();
+        return rule.apply(info);
+    }
+}

--- a/src/test/resources/mustimplementunsolvedparam/expected/com/other/InstanceInfo.java
+++ b/src/test/resources/mustimplementunsolvedparam/expected/com/other/InstanceInfo.java
@@ -1,0 +1,4 @@
+package com.other;
+
+public class InstanceInfo {
+}

--- a/src/test/resources/mustimplementunsolvedparam/input/com/example/LeaseExistsRule.java
+++ b/src/test/resources/mustimplementunsolvedparam/input/com/example/LeaseExistsRule.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import com.other.InstanceInfo;
+
+public class LeaseExistsRule implements Rule {
+    public String apply(InstanceInfo instanceInfo) {
+        return "lease";
+    }
+}

--- a/src/test/resources/mustimplementunsolvedparam/input/com/example/Rule.java
+++ b/src/test/resources/mustimplementunsolvedparam/input/com/example/Rule.java
@@ -1,0 +1,7 @@
+package com.example;
+
+import com.other.InstanceInfo;
+
+public interface Rule {
+    String apply(InstanceInfo instanceInfo);
+}

--- a/src/test/resources/mustimplementunsolvedparam/input/com/example/Target.java
+++ b/src/test/resources/mustimplementunsolvedparam/input/com/example/Target.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.other.InstanceInfo;
+
+public class Target {
+    String target(InstanceInfo info) {
+        Rule rule = new LeaseExistsRule();
+        return rule.apply(info);
+    }
+}

--- a/src/test/resources/samesimplenameoverload/expected/com/example/Impl.java
+++ b/src/test/resources/samesimplenameoverload/expected/com/example/Impl.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.example.a.Foo;
+
+public class Impl implements Rule {
+
+    public String apply(Foo foo) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/samesimplenameoverload/expected/com/example/Rule.java
+++ b/src/test/resources/samesimplenameoverload/expected/com/example/Rule.java
@@ -1,0 +1,8 @@
+package com.example;
+
+import com.example.a.Foo;
+
+public interface Rule {
+
+    String apply(Foo foo);
+}

--- a/src/test/resources/samesimplenameoverload/expected/com/example/Target.java
+++ b/src/test/resources/samesimplenameoverload/expected/com/example/Target.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.example.a.Foo;
+
+public class Target {
+
+    String target(Foo foo) {
+        Rule rule = new Impl();
+        return rule.apply(foo);
+    }
+}

--- a/src/test/resources/samesimplenameoverload/expected/com/example/a/Foo.java
+++ b/src/test/resources/samesimplenameoverload/expected/com/example/a/Foo.java
@@ -1,0 +1,4 @@
+package com.example.a;
+
+public class Foo {
+}

--- a/src/test/resources/samesimplenameoverload/input/com/example/Impl.java
+++ b/src/test/resources/samesimplenameoverload/input/com/example/Impl.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import com.example.a.Foo;
+
+public class Impl implements Rule {
+    // Declared first, and its parameter type is not on the source path, so this is the
+    // overload that matches only approximately.
+    public String apply(com.other.b.Foo foo) {
+        return "wrong";
+    }
+
+    // The real implementation of Rule#apply.
+    public String apply(Foo foo) {
+        return "right";
+    }
+}

--- a/src/test/resources/samesimplenameoverload/input/com/example/Rule.java
+++ b/src/test/resources/samesimplenameoverload/input/com/example/Rule.java
@@ -1,0 +1,7 @@
+package com.example;
+
+import com.example.a.Foo;
+
+public interface Rule {
+    String apply(Foo foo);
+}

--- a/src/test/resources/samesimplenameoverload/input/com/example/Target.java
+++ b/src/test/resources/samesimplenameoverload/input/com/example/Target.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.example.a.Foo;
+
+public class Target {
+    String target(Foo foo) {
+        Rule rule = new Impl();
+        return rule.apply(foo);
+    }
+}

--- a/src/test/resources/samesimplenameoverload/input/com/example/a/Foo.java
+++ b/src/test/resources/samesimplenameoverload/input/com/example/a/Foo.java
@@ -1,0 +1,4 @@
+package com.example.a;
+
+public class Foo {
+}


### PR DESCRIPTION
Should fix #547.

The problem was that our reasoning for "must-implement" methods made an incorrect assumption: it assumed that we could resolve the complete signature of such a method (probably because IIRC the first time we encountered the need for must-implement methods was when dealing with JDK interfaces). #547 was caused by a must-implement method with an unsolved parameter type. We actually don't _need_ the complete signature - just the method name and arity - and so we can use a notion of "approximate" signatures (with just the name and arity) instead, which is what this PR does. To accomplish that, we add a set of `getApproximateSignature` methods parallel to the existing `getSignature` methods in `JavaParserUtil`.