### PR TITLE
Re-implement JavaParserUtil#erase

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -331,11 +331,29 @@ public class JavaParserUtil {
   /**
    * Erases type arguments from a method or type signature string.
    *
+   * <p>A string whose angle brackets do not balance is not a type or a signature, and is returned
+   * unchanged: it is most likely a fragment of a parameter list that was split at a comma which was
+   * really inside a type argument, and there is no erasure of such a fragment to compute.
+   *
    * @param signature the signature
    * @return the same signature without type arguments
    */
   public static String erase(String signature) {
-    return signature.replaceAll("<.*>", "");
+    StringBuilder erased = new StringBuilder(signature.length());
+    int depth = 0;
+    for (int i = 0; i < signature.length(); i++) {
+      char c = signature.charAt(i);
+      if (c == '<') {
+        depth++;
+      } else if (c == '>') {
+        if (--depth < 0) {
+          return signature;
+        }
+      } else if (depth == 0) {
+        erased.append(c);
+      }
+    }
+    return depth == 0 ? erased.toString() : signature;
   }
 
   /**

--- a/src/test/java/org/checkerframework/specimin/JavaParserUtilEraseTest.java
+++ b/src/test/java/org/checkerframework/specimin/JavaParserUtilEraseTest.java
@@ -1,0 +1,61 @@
+package org.checkerframework.specimin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/** This class unit tests the erase method in JavaParserUtil. */
+public class JavaParserUtilEraseTest {
+
+  /** A type with no type arguments at all is its own erasure. */
+  @Test
+  public void testNoTypeArguments() {
+    assertEquals("Lease", JavaParserUtil.erase("Lease"));
+    assertEquals("java.util.Map.Entry", JavaParserUtil.erase("java.util.Map.Entry"));
+    assertEquals("int[]", JavaParserUtil.erase("int[]"));
+    assertEquals("apply(Lease, boolean)", JavaParserUtil.erase("apply(Lease, boolean)"));
+  }
+
+  /** A single type argument list is deleted, wherever in the string it ends. */
+  @Test
+  public void testOneTypeArgumentList() {
+    assertEquals("Lease", JavaParserUtil.erase("Lease<InstanceInfo>"));
+    assertEquals("Map[]", JavaParserUtil.erase("Map<K, V>[]"));
+    assertEquals("java.util.List", JavaParserUtil.erase("java.util.List<java.util.Map<K,V>>"));
+    assertEquals("java.util.Map.Entry", JavaParserUtil.erase("java.util.Map.Entry<K,V>"));
+    assertEquals("? extends Foo", JavaParserUtil.erase("? extends Foo<Bar>"));
+    assertEquals(
+        "apply(Lease, boolean)", JavaParserUtil.erase("apply(Lease<InstanceInfo>, boolean)"));
+  }
+
+  /**
+   * A member type of a parameterized type carries a type argument list of its own (JLS 4.5), so the
+   * name of the member type sits between two of them and must survive.
+   */
+  @Test
+  public void testQualifiedMemberType() {
+    assertEquals("com.foo.Outer.Inner", JavaParserUtil.erase("com.foo.Outer<A>.Inner<B>"));
+    assertEquals("Outer.Middle.Inner", JavaParserUtil.erase("Outer<A>.Middle<B>.Inner<C>"));
+  }
+
+  /** Every parameter of a signature has its own type argument list, and its own erasure. */
+  @Test
+  public void testSignatureWithSeveralGenericParameters() {
+    assertEquals(
+        "foo(java.util.List, java.util.Map)",
+        JavaParserUtil.erase("foo(java.util.List<String>, java.util.Map<K,V>)"));
+    assertEquals(
+        "foo(Outer.Inner, java.util.List)",
+        JavaParserUtil.erase("foo(Outer<A>.Inner<B>, java.util.List<String>)"));
+  }
+
+  /**
+   * A fragment whose angle brackets do not balance is not a type or a signature, and has no erasure
+   * to compute.
+   */
+  @Test
+  public void testUnbalanced() {
+    assertEquals("java.util.Map<K", JavaParserUtil.erase("java.util.Map<K"));
+    assertEquals("V>", JavaParserUtil.erase("V>"));
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/QualifiedInnerTypeErasureTest.java
+++ b/src/test/java/org/checkerframework/specimin/QualifiedInnerTypeErasureTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code Impl#apply} has one parameter whose type is not on the source path, so Specimin cannot
+ * compute its signature and compares it against {@code Rule#apply} by {@link
+ * JavaParserUtil#areMethodsLikelyEqual} instead. That comparison erases the type arguments of the
+ * other parameter, whose type {@code Outer<String>.Inner<Integer>} carries two type argument lists:
+ * one for the enclosing type and one for the member type (JLS 4.5).
+ *
+ * <p>Erasing everything between the first {@code <} and the last {@code >} deletes {@code Inner}
+ * along with the arguments, so the two sides of the comparison disagree and {@code Rule#apply} is
+ * not recognized as a method that {@code Impl#apply} overrides. Specimin then drops it, which
+ * leaves {@code Rule} with no abstract method and the lambda in the target with nothing to
+ * implement: "Rule is not a functional interface" (JLS 9.8).
+ */
+public class QualifiedInnerTypeErasureTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "qualifiedinnertypeerasure",
+        new String[] {"com/example/Target.java"},
+        new String[] {"com.example.Target#target(Outer<String>.Inner<Integer>, Missing)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/QualifiedInnerTypeErasureTest.java
+++ b/src/test/java/org/checkerframework/specimin/QualifiedInnerTypeErasureTest.java
@@ -5,16 +5,12 @@ import org.junit.jupiter.api.Test;
 
 /**
  * {@code Impl#apply} has one parameter whose type is not on the source path, so Specimin cannot
- * compute its signature and compares it against {@code Rule#apply} by {@link
- * JavaParserUtil#areMethodsLikelyEqual} instead. That comparison erases the type arguments of the
- * other parameter, whose type {@code Outer<String>.Inner<Integer>} carries two type argument lists:
- * one for the enclosing type and one for the member type (JLS 4.5).
+ * compute its signature and compares it against {@code Rule#apply} approximately. That comparison
+ * erases the type arguments of the other parameter, whose type {@code Outer<String>.Inner<Integer>}
+ * carries two type argument lists: one for the enclosing type and one for the member type.
  *
- * <p>Erasing everything between the first {@code <} and the last {@code >} deletes {@code Inner}
- * along with the arguments, so the two sides of the comparison disagree and {@code Rule#apply} is
- * not recognized as a method that {@code Impl#apply} overrides. Specimin then drops it, which
- * leaves {@code Rule} with no abstract method and the lambda in the target with nothing to
- * implement: "Rule is not a functional interface" (JLS 9.8).
+ * <p>The purpose of this test is to rule out an incorrect implementation of erasure in that comparison
+ * that greedily deletes everything between angle brackets (which Specimin used to have).
  */
 public class QualifiedInnerTypeErasureTest {
   @Test

--- a/src/test/resources/qualifiedinnertypeerasure/expected/com/example/Impl.java
+++ b/src/test/resources/qualifiedinnertypeerasure/expected/com/example/Impl.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.other.Missing;
+
+public class Impl implements Rule {
+
+  public String apply(Outer<String>.Inner<Integer> x, Missing y) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/qualifiedinnertypeerasure/expected/com/example/Outer.java
+++ b/src/test/resources/qualifiedinnertypeerasure/expected/com/example/Outer.java
@@ -1,0 +1,6 @@
+package com.example;
+
+public class Outer<T> {
+
+  public class Inner<U> {}
+}

--- a/src/test/resources/qualifiedinnertypeerasure/expected/com/example/Rule.java
+++ b/src/test/resources/qualifiedinnertypeerasure/expected/com/example/Rule.java
@@ -1,0 +1,8 @@
+package com.example;
+
+import com.other.Missing;
+
+public interface Rule {
+
+  String apply(Outer<String>.Inner<Integer> x, Missing y);
+}

--- a/src/test/resources/qualifiedinnertypeerasure/expected/com/example/Target.java
+++ b/src/test/resources/qualifiedinnertypeerasure/expected/com/example/Target.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.other.Missing;
+
+public class Target {
+
+  String target(Outer<String>.Inner<Integer> x, Missing y) {
+    Impl impl = new Impl();
+    Rule other = (a, b) -> "lambda";
+    return impl.apply(x, y) + other.hashCode();
+  }
+}

--- a/src/test/resources/qualifiedinnertypeerasure/expected/com/other/Missing.java
+++ b/src/test/resources/qualifiedinnertypeerasure/expected/com/other/Missing.java
@@ -1,0 +1,3 @@
+package com.other;
+public class Missing {
+}

--- a/src/test/resources/qualifiedinnertypeerasure/input/com/example/Impl.java
+++ b/src/test/resources/qualifiedinnertypeerasure/input/com/example/Impl.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import com.other.Missing;
+
+public class Impl implements Rule {
+    @Override
+    public String apply(Outer<String>.Inner<Integer> x, Missing y) {
+        return x.describe();
+    }
+}

--- a/src/test/resources/qualifiedinnertypeerasure/input/com/example/Outer.java
+++ b/src/test/resources/qualifiedinnertypeerasure/input/com/example/Outer.java
@@ -1,0 +1,9 @@
+package com.example;
+
+public class Outer<T> {
+    public class Inner<U> {
+        public String describe() {
+            return "inner";
+        }
+    }
+}

--- a/src/test/resources/qualifiedinnertypeerasure/input/com/example/Rule.java
+++ b/src/test/resources/qualifiedinnertypeerasure/input/com/example/Rule.java
@@ -1,0 +1,7 @@
+package com.example;
+
+import com.other.Missing;
+
+public interface Rule {
+    String apply(Outer<String>.Inner<Integer> x, Missing y);
+}

--- a/src/test/resources/qualifiedinnertypeerasure/input/com/example/Target.java
+++ b/src/test/resources/qualifiedinnertypeerasure/input/com/example/Target.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.other.Missing;
+
+public class Target {
+    String target(Outer<String>.Inner<Integer> x, Missing y) {
+        Impl impl = new Impl();
+        Rule other = (a, b) -> "lambda";
+        return impl.apply(x, y) + other.hashCode();
+    }
+}


### PR DESCRIPTION
The new test `src/test/java/org/checkerframework/specimin/QualifiedInnerTypeErasureTest.java` used to fail, because the previous `erase()` implementation greedily removed too much from the type. This implementation gets it right. Also added a unit test suite for the function, since its contract is pretty clear and we should probably have one.