### PR TITLE
Audit for uses of non-deterministicly-ordered-output JavaParser methods in ways that could impact Specimin's output

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -2874,9 +2874,8 @@ public class JavaParserUtil {
         }
 
         // An approximately-applicable candidate is one the argument is not actually assignable to.
-        // javac can only have
-        // selected a method the argument is assignable to, so whenever any candidate is strictly
-        // applicable the approximate ones are noise.
+        // javac can only have selected a method the argument is assignable to, so whenever any
+        // candidate is strictly applicable the approximate ones are noise.
         List<ResolvedMethodDeclaration> candidates =
             strictlyApplicable.isEmpty() ? approximatelyApplicable : strictlyApplicable;
 

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -2611,6 +2611,43 @@ public class JavaParserUtil {
    */
   public static @Nullable Object tryFindCorrespondingDeclarationForConstraintQualifiedExpression(
       Expression expression) {
+    return findCorrespondingDeclarationForConstraintQualifiedExpression(expression, null);
+  }
+
+  /**
+   * Returns every declaration that a call whose scope's type is a lambda constraint type could be
+   * referring to, or an empty list if the call does not take that resolution path.
+   *
+   * <p>More than one candidate means Specimin could not tell the overloads apart: a lambda
+   * constraint type carries no usable information (JavaParser reports its bound as a bare,
+   * unbounded type variable), so every same-arity overload is admitted and none is more specific.
+   * {@link #tryFindCorrespondingDeclarationForConstraintQualifiedExpression} still has to answer
+   * with one of them, and its choice is arbitrary; the caller is expected to preserve all of them
+   * so that whichever the call really binds to survives into the output. TODO: this is definitely
+   * a workaround for an API problem here: Resolver#resolve can only return a single answer, but
+   * in this case Specimin can't decide between these candidates! Refactor so that this workaround
+   * isn't necessary.
+   *
+   * @param expression The expression to find the candidates of
+   * @return the candidate declarations
+   */
+  public static List<ResolvedMethodDeclaration> getConstraintQualifiedCallCandidates(
+      Expression expression) {
+    List<ResolvedMethodDeclaration> candidates = new ArrayList<>();
+    findCorrespondingDeclarationForConstraintQualifiedExpression(expression, candidates);
+    return candidates;
+  }
+
+  /**
+   * Implementation of {@link #tryFindCorrespondingDeclarationForConstraintQualifiedExpression} and
+   * {@link #getConstraintQualifiedCallCandidates}.
+   *
+   * @param expression The expression to find the declaration of (method, field)
+   * @param candidatesOut If non-null, every candidate considered is added to this list
+   * @return The resolved object, if it exists; null otherwise
+   */
+  private static @Nullable Object findCorrespondingDeclarationForConstraintQualifiedExpression(
+      Expression expression, @Nullable List<ResolvedMethodDeclaration> candidatesOut) {
     if (!expression.hasScope()) {
       return null;
     }
@@ -2814,7 +2851,10 @@ public class JavaParserUtil {
           && expression.isMethodCallExpr()) {
         List<@Nullable ResolvedType> argumentTypes =
             getArgumentTypesAsResolved(expression.asMethodCallExpr().getArguments());
-        List<ResolvedMethodDeclaration> applicable = new ArrayList<>();
+        substituteArgumentsThatAliasTheScope(
+            expression.asMethodCallExpr(), scope, declaringType, argumentTypes);
+        List<ResolvedMethodDeclaration> strictlyApplicable = new ArrayList<>();
+        List<ResolvedMethodDeclaration> approximatelyApplicable = new ArrayList<>();
 
         for (ResolvedMethodDeclaration potentialMethod :
             getDeclaredMethodsInOrder(declaringType.getTypeDeclaration().get())) {
@@ -2826,12 +2866,33 @@ public class JavaParserUtil {
             continue;
           }
 
-          if (isApplicableTo(potentialMethod, argumentTypes)) {
-            applicable.add(potentialMethod);
+          switch (getApplicability(potentialMethod, argumentTypes)) {
+            case STRICT -> strictlyApplicable.add(potentialMethod);
+            case APPROXIMATE -> approximatelyApplicable.add(potentialMethod);
+            case NONE -> {}
           }
         }
 
-        return getMostSpecific(applicable);
+        // An approximately-applicable candidate is one the argument is not actually assignable to.
+          // javac can only have
+        // selected a method the argument is assignable to, so whenever any candidate is strictly
+        // applicable the approximate ones are noise.
+        List<ResolvedMethodDeclaration> candidates =
+            strictlyApplicable.isEmpty() ? approximatelyApplicable : strictlyApplicable;
+
+        ResolvedMethodDeclaration mostSpecific = getMaximallySpecific(candidates);
+
+        if (mostSpecific != null || candidates.isEmpty()) {
+          return mostSpecific;
+        }
+
+        // No candidate is more specific than every other, so the one chosen below is arbitrary.
+        // A caller that passes a non-null candidatesOut should preserve them all.
+        if (candidatesOut != null) {
+          candidatesOut.addAll(candidates);
+        }
+
+        return candidates.get(0);
       }
     }
 
@@ -2839,43 +2900,140 @@ public class JavaParserUtil {
   }
 
   /**
-   * Checks whether a method is applicable to a call with the given argument types (JLS 15.12.2.2).
-   * {@code method} must have exactly {@code argumentTypes.size()} parameters.
+   * Replaces the type of every argument of {@code methodCall} that denotes the same variable as
+   * {@code scope} with {@code scopeType}, the concrete type that the scope's lambda constraint type
+   * was just resolved to.
+   *
+   * <p>This matters because a lambda constraint type constrains nothing on its own: JavaParser
+   * reports its bound as a bare, unbounded type variable, so {@link
+   * #couldArgumentBeTypeCompatibleWithParameterType} has to accept every reference parameter for
+   * one. An argument that is the very expression whose type this method just worked out is a special
+   * case where a concrete type is available, and supplying it lets an overload whose parameter type
+   * is unrelated to that concrete type be ruled out. The bound itself is no help here: it names a
+   * type variable of the functional interface, which shares its simple name with unrelated type
+   * variables elsewhere in the call. TODO: this is a heuristic; it would be better for Specimin to
+   * model the bounds exactly, so that this special case isn't necessary.
+   *
+   * @param methodCall The call whose arguments to substitute
+   * @param scope The call's scope
+   * @param scopeType The concrete type of the scope
+   * @param argumentTypes The argument types, modified in place
+   */
+  private static void substituteArgumentsThatAliasTheScope(
+      MethodCallExpr methodCall,
+      Expression scope,
+      ResolvedType scopeType,
+      List<@Nullable ResolvedType> argumentTypes) {
+    Node scopeDeclaration = getDeclarationAsAst(scope);
+
+    if (scopeDeclaration == null) {
+      return;
+    }
+
+    for (int i = 0; i < argumentTypes.size(); i++) {
+      ResolvedType argumentType = argumentTypes.get(i);
+
+      // Only a constraint type is worth replacing: any other type is already as precise as
+      // anything this could supply.
+      if (argumentType == null || !argumentType.isConstraint()) {
+        continue;
+      }
+
+      Node argumentDeclaration = getDeclarationAsAst(methodCall.getArgument(i));
+
+      // Reference equality is intentional: two variables of the same name in different scopes have
+      // structurally equal declarations (Node#equals is structural) but are not the same variable.
+      // Extracted into a local variable to minimize suppression scope.
+      @SuppressWarnings({"ReferenceEquality", "not.interned"})
+      boolean isSameVariable = argumentDeclaration == scopeDeclaration;
+
+      if (isSameVariable) {
+        argumentTypes.set(i, scopeType);
+      }
+    }
+  }
+
+  /**
+   * Returns the AST node declaring the variable that an expression names, or null if the expression
+   * does not name a variable or the declaration could not be found.
+   *
+   * @param expression The expression
+   * @return the declaration's AST node, or null
+   */
+  private static @Nullable Node getDeclarationAsAst(Expression expression) {
+    ResolvedValueDeclaration resolved;
+
+    if (expression.isNameExpr()) {
+      resolved = Resolver.resolve(expression.asNameExpr());
+    } else if (expression.isFieldAccessExpr()) {
+      resolved = Resolver.resolve(expression.asFieldAccessExpr());
+    } else {
+      return null;
+    }
+
+    return resolved == null ? null : resolved.toAst().orElse(null);
+  }
+
+  /** How well a method's parameters accept a call's arguments. */
+  private enum Applicability {
+    /** Every argument's type is assignable to its parameter's type (JLS 15.12.2.2). */
+    STRICT,
+    /**
+     * Some argument is accepted only by {@link #couldArgumentBeTypeCompatibleWithParameterType}'s
+     * accommodation for type variables and lambda constraint types, which does not check bounds.
+     */
+    APPROXIMATE,
+    /** Some argument cannot be passed to its parameter at all. */
+    NONE
+  }
+
+  /**
+   * Decides how well a method accepts a call's arguments (JLS 15.12.2.2). {@code method} must have
+   * exactly {@code argumentTypes.size()} parameters.
    *
    * <p>This is the {@link ResolvedMethodDeclaration} counterpart of {@link
    * #isNodeWithParametersACandidate}, which answers the same question about a candidate that
    * Specimin has an AST for; both decide a single parameter with {@link
-   * #couldArgumentBeTypeCompatibleWithParameterType}.
+   * #couldArgumentBeTypeCompatibleWithParameterType}. This one additionally reports whether that
+   * accommodation was needed, so that a caller choosing a single overload can prefer a candidate
+   * that did not need it.
    *
    * <p>An argument whose type could not be resolved, or a parameter whose type is off the source
-   * path, is treated as a mismatch: applicability cannot be established without both types.
+   * path, makes the method inapplicable: applicability cannot be established without both types.
    *
    * @param method The candidate method
    * @param argumentTypes The types of the call's arguments, in order; an element is null when that
    *     argument's type could not be resolved
-   * @return true if the method is applicable to those arguments
+   * @return how well the method accepts those arguments
    */
-  private static boolean isApplicableTo(
+  private static Applicability getApplicability(
       ResolvedMethodDeclaration method, List<@Nullable ResolvedType> argumentTypes) {
+    boolean isStrict = true;
+
     for (int i = 0; i < argumentTypes.size(); i++) {
       ResolvedType argType = argumentTypes.get(i);
 
       if (argType == null) {
-        return false;
+        return Applicability.NONE;
       }
 
       try {
-        if (!couldArgumentBeTypeCompatibleWithParameterType(
-            method.getParam(i).getType(), argType)) {
-          return false;
+        ResolvedType paramType = method.getParam(i).getType();
+
+        if (!paramType.isAssignableBy(argType)) {
+          if (!couldArgumentBeTypeCompatibleWithParameterType(paramType, argType)) {
+            return Applicability.NONE;
+          }
+
+          isStrict = false;
         }
       } catch (UnsolvedSymbolException ex) {
         // getParam().getType() throws when the parameter's type is off the source path.
-        return false;
+        return Applicability.NONE;
       }
     }
 
-    return true;
+    return isStrict ? Applicability.STRICT : Applicability.APPROXIMATE;
   }
 
   /**
@@ -2884,14 +3042,13 @@ public class JavaParserUtil {
    *
    * <p>Specificity is a partial order, so there need not be a maximal element (javac reports such a
    * call as ambiguous, but Specimin's approximate argument types can also produce a set of
-   * candidates that javac never would). In that case this returns the first candidate, which is
-   * arbitrary but reproducible as long as the caller supplies the candidates in a deterministic
-   * order -- see {@link #getDeclaredMethodsInOrder}.
+   * candidates that javac never would). Answering null rather than guessing lets the caller tell
+   * that case apart from a genuine choice, which it cannot do from the returned method alone.
    *
    * @param applicable The applicable methods, all of the same arity, in a deterministic order
-   * @return the most specific of them, or null if there are none
+   * @return the most specific of them, or null if there are none or none is maximal
    */
-  private static @Nullable ResolvedMethodDeclaration getMostSpecific(
+  private static @Nullable ResolvedMethodDeclaration getMaximallySpecific(
       List<ResolvedMethodDeclaration> applicable) {
     for (ResolvedMethodDeclaration candidate : applicable) {
       boolean beatsAll = true;
@@ -2914,7 +3071,7 @@ public class JavaParserUtil {
       }
     }
 
-    return applicable.isEmpty() ? null : applicable.get(0);
+    return null;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -2994,8 +2994,8 @@ public class JavaParserUtil {
    * #isNodeWithParametersACandidate}, which answers the same question about a candidate that
    * Specimin has an AST for; both decide a single parameter with {@link
    * #couldArgumentBeTypeCompatibleWithParameterType}. This one additionally reports whether that
-   * accommodation was needed, so that a caller choosing a single overload can prefer a candidate
-   * that did not need it.
+   * method's answer was an approximation for any parameter, so that a caller choosing a single
+   * overload can prefer a candidate that did not need it.
    *
    * <p>An argument whose type could not be resolved, or a parameter whose type is off the source
    * path, makes the method inapplicable: applicability cannot be established without both types.

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -2623,9 +2623,9 @@ public class JavaParserUtil {
    * unbounded type variable), so every same-arity overload is admitted and none is more specific.
    * {@link #tryFindCorrespondingDeclarationForConstraintQualifiedExpression} still has to answer
    * with one of them, and its choice is arbitrary; the caller is expected to preserve all of them
-   * so that whichever the call really binds to survives into the output. TODO: this is definitely
-   * a workaround for an API problem here: Resolver#resolve can only return a single answer, but
-   * in this case Specimin can't decide between these candidates! Refactor so that this workaround
+   * so that whichever the call really binds to survives into the output. TODO: this is definitely a
+   * workaround for an API problem here: Resolver#resolve can only return a single answer, but in
+   * this case Specimin can't decide between these candidates! Refactor so that this workaround
    * isn't necessary.
    *
    * @param expression The expression to find the candidates of
@@ -2874,7 +2874,7 @@ public class JavaParserUtil {
         }
 
         // An approximately-applicable candidate is one the argument is not actually assignable to.
-          // javac can only have
+        // javac can only have
         // selected a method the argument is assignable to, so whenever any candidate is strictly
         // applicable the approximate ones are noise.
         List<ResolvedMethodDeclaration> candidates =
@@ -2907,12 +2907,12 @@ public class JavaParserUtil {
    * <p>This matters because a lambda constraint type constrains nothing on its own: JavaParser
    * reports its bound as a bare, unbounded type variable, so {@link
    * #couldArgumentBeTypeCompatibleWithParameterType} has to accept every reference parameter for
-   * one. An argument that is the very expression whose type this method just worked out is a special
-   * case where a concrete type is available, and supplying it lets an overload whose parameter type
-   * is unrelated to that concrete type be ruled out. The bound itself is no help here: it names a
-   * type variable of the functional interface, which shares its simple name with unrelated type
-   * variables elsewhere in the call. TODO: this is a heuristic; it would be better for Specimin to
-   * model the bounds exactly, so that this special case isn't necessary.
+   * one. An argument that is the very expression whose type this method just worked out is a
+   * special case where a concrete type is available, and supplying it lets an overload whose
+   * parameter type is unrelated to that concrete type be ruled out. The bound itself is no help
+   * here: it names a type variable of the functional interface, which shares its simple name with
+   * unrelated type variables elsewhere in the call. TODO: this is a heuristic; it would be better
+   * for Specimin to model the bounds exactly, so that this special case isn't necessary.
    *
    * @param methodCall The call whose arguments to substitute
    * @param scope The call's scope

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -1893,20 +1893,7 @@ public class JavaParserUtil {
           continue;
         }
 
-        if (!resolvedParameterType.isAssignableBy(typeInCall)) {
-          // If either is a type variable and the other is a reference type, it is likely valid
-          // Note that isAssignableBy will return false in those cases
-          if (typeInCall.isTypeVariable() && resolvedParameterType.isReference()) {
-            continue;
-          }
-          if (resolvedParameterType.isTypeVariable() && typeInCall.isReference()) {
-            continue;
-          }
-          // JavaParser can't handle constraint types well. This isn't perfect (i.e., doesn't
-          // properly match bounds), but it should work for most cases.
-          if (typeInCall.isConstraint() && resolvedParameterType.isReference()) {
-            continue;
-          }
+        if (!couldArgumentBeTypeCompatibleWithParameterType(resolvedParameterType, typeInCall)) {
           return false;
         }
       }
@@ -1917,6 +1904,43 @@ public class JavaParserUtil {
     }
 
     return true;
+  }
+
+  /**
+   * Checks whether an argument of a given type could be passed to a parameter of a given type, i.e.
+   * whether the parameter type is assignable by the argument type (JLS 5.3).
+   *
+   * <p>This is deliberately more permissive than {@link ResolvedType#isAssignableBy}, which answers
+   * false for a type variable or a lambda constraint type even where the assignment is legal.
+   * Specimin sees both routinely, and treating them as incompatible would discard the real
+   * candidate. The implementation here is conservative in the sense that it preserves compilability
+   * at the possible expense of minimality: it does not check bounds, so it can admit a candidate
+   * that is not truly applicable.
+   *
+   * @param parameterType The parameter's type
+   * @param argumentType The argument's type
+   * @return true if an argument of that type may be passed to a parameter of that type
+   */
+  public static boolean couldArgumentBeTypeCompatibleWithParameterType(
+      ResolvedType parameterType, ResolvedType argumentType) {
+    if (parameterType.isAssignableBy(argumentType)) {
+      return true;
+    }
+
+    // If either is a type variable and the other is a reference type, it is likely valid.
+    if (argumentType.isTypeVariable() && parameterType.isReference()) {
+      return true;
+    }
+    if (parameterType.isTypeVariable() && argumentType.isReference()) {
+      return true;
+    }
+    // JavaParser can't handle constraint types well. This isn't perfect (i.e., doesn't properly
+    // match bounds), but it should work for most cases.
+    if (argumentType.isConstraint() && parameterType.isReference()) {
+      return true;
+    }
+
+    return false;
   }
 
   /**
@@ -2815,9 +2839,13 @@ public class JavaParserUtil {
   }
 
   /**
-   * Checks whether a method is applicable to a call with the given argument types, i.e. whether
-   * every argument's type is assignable to the corresponding parameter's type (JLS 15.12.2.2).
+   * Checks whether a method is applicable to a call with the given argument types (JLS 15.12.2.2).
    * {@code method} must have exactly {@code argumentTypes.size()} parameters.
+   *
+   * <p>This is the {@link ResolvedMethodDeclaration} counterpart of {@link
+   * #isNodeWithParametersACandidate}, which answers the same question about a candidate that
+   * Specimin has an AST for; both decide a single parameter with {@link
+   * #couldArgumentBeTypeCompatibleWithParameterType}.
    *
    * <p>An argument whose type could not be resolved, or a parameter whose type is off the source
    * path, is treated as a mismatch: applicability cannot be established without both types.
@@ -2837,7 +2865,8 @@ public class JavaParserUtil {
       }
 
       try {
-        if (!method.getParam(i).getType().isAssignableBy(argType)) {
+        if (!couldArgumentBeTypeCompatibleWithParameterType(
+            method.getParam(i).getType(), argType)) {
           return false;
         }
       } catch (UnsolvedSymbolException ex) {

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -1323,8 +1323,12 @@ public class JavaParserUtil {
     int numArgs = methodCall.getArguments().size();
     String name = methodCall.getNameAsString();
 
+    // Sorted, because getAllMethods() returns a set whose iteration order is not reproducible and
+    // the caller collects these into an ordered collection; see #getDeclaredMethodsInOrder. These
+    // are all JDK methods, so their signatures are always computable.
     return typeDecl.getAllMethods().stream()
         .filter(m -> m.getName().equals(name) && m.getParamTypes().size() == numArgs)
+        .sorted(Comparator.comparing(m -> m.getDeclaration().getQualifiedSignature()))
         .collect(Collectors.toList());
   }
 
@@ -2782,42 +2786,134 @@ public class JavaParserUtil {
       ResolvedType type = typeVariableToTypesMap.get(bound);
 
       if (type instanceof ResolvedReferenceType declaringType
-          && declaringType.getTypeDeclaration().isPresent()) {
-        if (expression.isMethodCallExpr())
-          for (ResolvedMethodDeclaration potentialMethod :
-              declaringType.getTypeDeclaration().get().getDeclaredMethods()) {
-            if (!potentialMethod
-                .getName()
-                .equals(expression.asMethodCallExpr().getNameAsString())) {
-              continue;
-            }
+          && declaringType.getTypeDeclaration().isPresent()
+          && expression.isMethodCallExpr()) {
+        List<@Nullable ResolvedType> argumentTypes =
+            getArgumentTypesAsResolved(expression.asMethodCallExpr().getArguments());
+        List<ResolvedMethodDeclaration> applicable = new ArrayList<>();
 
-            List<@Nullable ResolvedType> argumentTypes =
-                getArgumentTypesAsResolved(expression.asMethodCallExpr().getArguments());
-
-            if (argumentTypes.size() != potentialMethod.getNumberOfParams()) {
-              continue;
-            }
-
-            boolean match = true;
-            for (int i = 0; i < argumentTypes.size(); i++) {
-              ResolvedType argType = argumentTypes.get(i);
-              ResolvedType paramType = potentialMethod.getParam(i).getType();
-
-              if (argType == null || !paramType.isAssignableBy(argType)) {
-                match = false;
-                break;
-              }
-            }
-
-            if (match) {
-              return potentialMethod;
-            }
+        for (ResolvedMethodDeclaration potentialMethod :
+            getDeclaredMethodsInOrder(declaringType.getTypeDeclaration().get())) {
+          if (!potentialMethod.getName().equals(expression.asMethodCallExpr().getNameAsString())) {
+            continue;
           }
+
+          if (argumentTypes.size() != potentialMethod.getNumberOfParams()) {
+            continue;
+          }
+
+          if (isApplicableTo(potentialMethod, argumentTypes)) {
+            applicable.add(potentialMethod);
+          }
+        }
+
+        return getMostSpecific(applicable);
       }
     }
 
     return null;
+  }
+
+  /**
+   * Checks whether a method is applicable to a call with the given argument types, i.e. whether
+   * every argument's type is assignable to the corresponding parameter's type (JLS 15.12.2.2).
+   * {@code method} must have exactly {@code argumentTypes.size()} parameters.
+   *
+   * <p>An argument whose type could not be resolved, or a parameter whose type is off the source
+   * path, is treated as a mismatch: applicability cannot be established without both types.
+   *
+   * @param method The candidate method
+   * @param argumentTypes The types of the call's arguments, in order; an element is null when that
+   *     argument's type could not be resolved
+   * @return true if the method is applicable to those arguments
+   */
+  private static boolean isApplicableTo(
+      ResolvedMethodDeclaration method, List<@Nullable ResolvedType> argumentTypes) {
+    for (int i = 0; i < argumentTypes.size(); i++) {
+      ResolvedType argType = argumentTypes.get(i);
+
+      if (argType == null) {
+        return false;
+      }
+
+      try {
+        if (!method.getParam(i).getType().isAssignableBy(argType)) {
+          return false;
+        }
+      } catch (UnsolvedSymbolException ex) {
+        // getParam().getType() throws when the parameter's type is off the source path.
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Returns the most specific of a list of methods that are all applicable to the same call, per
+   * JLS 15.12.2.5: the one whose parameter types are all subtypes of every other candidate's.
+   *
+   * <p>Specificity is a partial order, so there need not be a maximal element (javac reports such a
+   * call as ambiguous, but Specimin's approximate argument types can also produce a set of
+   * candidates that javac never would). In that case this returns the first candidate, which is
+   * arbitrary but reproducible as long as the caller supplies the candidates in a deterministic
+   * order -- see {@link #getDeclaredMethodsInOrder}.
+   *
+   * @param applicable The applicable methods, all of the same arity, in a deterministic order
+   * @return the most specific of them, or null if there are none
+   */
+  private static @Nullable ResolvedMethodDeclaration getMostSpecific(
+      List<ResolvedMethodDeclaration> applicable) {
+    for (ResolvedMethodDeclaration candidate : applicable) {
+      boolean beatsAll = true;
+
+      for (ResolvedMethodDeclaration other : applicable) {
+        // Reference equality is intentional: a candidate is not compared against itself, but two
+        // distinct overloads must both be compared even if they happen to compare equal.
+        // Extracted into a local variable to minimize suppression scope.
+        @SuppressWarnings({"ReferenceEquality", "not.interned"})
+        boolean isSelf = candidate == other;
+
+        if (!isSelf && !isAtLeastAsSpecificAs(candidate, other)) {
+          beatsAll = false;
+          break;
+        }
+      }
+
+      if (beatsAll) {
+        return candidate;
+      }
+    }
+
+    return applicable.isEmpty() ? null : applicable.get(0);
+  }
+
+  /**
+   * Checks whether one method is at least as specific as another (JLS 15.12.2.5): each of {@code
+   * method}'s parameter types is assignable to the corresponding parameter type of {@code other}.
+   * Both methods must have the same number of parameters.
+   *
+   * <p>A parameter type that is unsolved makes the answer false, since specificity cannot be
+   * established without it.
+   *
+   * @param method The method that might be the more specific one
+   * @param other The method to compare against
+   * @return true if {@code method} is at least as specific as {@code other}
+   */
+  private static boolean isAtLeastAsSpecificAs(
+      ResolvedMethodDeclaration method, ResolvedMethodDeclaration other) {
+    for (int i = 0; i < method.getNumberOfParams(); i++) {
+      try {
+        if (!other.getParam(i).getType().isAssignableBy(method.getParam(i).getType())) {
+          return false;
+        }
+      } catch (UnsolvedSymbolException ex) {
+        // getParam().getType() throws when the parameter's type is unsolved.
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**
@@ -3342,13 +3438,24 @@ public class JavaParserUtil {
 
     String methodName = methodReference.getIdentifier();
 
+    // Sorted, because callers collect these candidates into ordered collections, and both
+    // getConstructors() and getAllMethods() are derived from sets that JavaParser rebuilds on each
+    // call; see #getDeclaredMethodsInOrder.
     if (methodName.equals("new")) {
-      return methodDeclaringType.asReferenceType().getTypeDeclaration().get().getConstructors();
+      return methodDeclaringType
+          .asReferenceType()
+          .getTypeDeclaration()
+          .get()
+          .getConstructors()
+          .stream()
+          .sorted(Comparator.comparing(JavaParserUtil::getDeclaredMethodOrderKey))
+          .toList();
     }
 
     // Method references must be on reference types
     return methodDeclaringType.asReferenceType().getAllMethods().stream()
         .filter(method -> method.getName().equals(methodName))
+        .sorted(Comparator.comparing(JavaParserUtil::getDeclaredMethodOrderKey))
         .toList();
   }
 
@@ -3472,10 +3579,17 @@ public class JavaParserUtil {
    */
   public static Set<ResolvedMethodDeclaration> getAllMustImplementMethods(
       TypeDeclaration<?> typeDecl) {
-    Set<ResolvedMethodDeclaration> methodsThatMustBeImplemented = new HashSet<>();
+    // Insertion-ordered, and filled in a reproducible order, because callers iterate the result:
+    // the order in which they see these methods decides the order of the declarations Specimin
+    // writes for them.
+    Set<ResolvedMethodDeclaration> methodsThatMustBeImplemented = new LinkedHashSet<>();
 
-    for (ResolvedReferenceTypeDeclaration jdkAncestor : getAllJDKAncestors(typeDecl)) {
-      for (ResolvedMethodDeclaration resolvedMethod : jdkAncestor.getDeclaredMethods()) {
+    List<ResolvedReferenceTypeDeclaration> jdkAncestors =
+        new ArrayList<>(getAllJDKAncestors(typeDecl));
+    jdkAncestors.sort(Comparator.comparing(ResolvedReferenceTypeDeclaration::getQualifiedName));
+
+    for (ResolvedReferenceTypeDeclaration jdkAncestor : jdkAncestors) {
+      for (ResolvedMethodDeclaration resolvedMethod : getDeclaredMethodsInOrder(jdkAncestor)) {
         // Skip methods that are already defined in java.lang.Object
         if (JavaLangUtils.isJavaLangObjectMethod(resolvedMethod.getSignature())) {
           continue;
@@ -3662,7 +3776,7 @@ public class JavaParserUtil {
    * @param method The method
    * @return the method's sort key
    */
-  private static String getDeclaredMethodOrderKey(ResolvedMethodDeclaration method) {
+  public static String getDeclaredMethodOrderKey(ResolvedMethodLikeDeclaration method) {
     StringBuilder key =
         new StringBuilder(method.getName()).append('/').append(method.getNumberOfParams());
 
@@ -3672,12 +3786,18 @@ public class JavaParserUtil {
       // The signature is unavailable exactly when a parameter type is off the source path. Such a
       // method is nearly always one Specimin parsed, so its source text is available and tells it
       // apart from an overload whose parameters merely share their simple names.
-      return key.append('/')
-          .append(
-              method.toAst().orElse(null) instanceof MethodDeclaration ast
-                  ? ast.getDeclarationAsString(false, false, false)
-                  : getApproximateSignature(method))
-          .toString();
+      String fallback;
+
+      if (method.toAst().orElse(null) instanceof CallableDeclaration<?> ast) {
+        fallback = ast.getDeclarationAsString(false, false, false);
+      } else if (method instanceof ResolvedMethodDeclaration resolvedMethod) {
+        fallback = getApproximateSignature(resolvedMethod);
+      } else {
+        // A constructor with no AST and no signature: nothing else is available to describe it.
+        fallback = "";
+      }
+
+      return key.append('/').append(fallback).toString();
     }
   }
 
@@ -3722,7 +3842,10 @@ public class JavaParserUtil {
       Set<ResolvedMethodDeclaration> methodsThatMustBeImplemented,
       Map<String, CompilationUnit> fqnToCompilationUnits) {
     List<MethodDeclaration> result = new ArrayList<>();
-    for (ResolvedMethodDeclaration resolvedMethodDecl : Set.copyOf(methodsThatMustBeImplemented)) {
+    // A List rather than a Set copy: this is only a snapshot to allow the loop to remove from
+    // methodsThatMustBeImplemented, and Set.copyOf would discard the caller's order (the iteration
+    // order of an immutable Set is randomized per JVM run).
+    for (ResolvedMethodDeclaration resolvedMethodDecl : List.copyOf(methodsThatMustBeImplemented)) {
       List<List<ResolvedReferenceType>> typesInBetween =
           getTypesInBetween(typeDecl, resolvedMethodDecl.declaringType());
 

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -18,6 +18,7 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
@@ -28,6 +29,7 @@ import com.github.javaparser.ast.type.UnknownType;
 import com.github.javaparser.resolution.Resolvable;
 import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodLikeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
@@ -276,6 +278,7 @@ public class Slicer {
 
       if (resolved != null) {
         generateUnsolvedSymbol = handleResolvedObject(node, resolved);
+        preserveAmbiguousConstraintQualifiedCandidates(node);
       } else if (erasure != null) {
         // Deliberately leaves generateUnsolvedSymbol set: this only adds the declaration, and
         // generation for a type whose erasure is already known is a no-op, because
@@ -300,6 +303,41 @@ public class Slicer {
 
     if (unsolvedSymbolGenerator.needToPostProcess(node)) {
       postProcessingWorklist.add(node);
+    }
+  }
+
+  /**
+   * Preserves every declaration that a call whose scope's type is a lambda constraint type could be
+   * referring to, when Specimin could not tell them apart.
+   *
+   * <p>Unlike {@link #preserveAmbiguousMethodRefCandidates}, this runs on a node that <em>did</em>
+   * resolve: {@link JavaParserUtil#tryFindCorrespondingDeclarationForConstraintQualifiedExpression}
+   * must answer with a single declaration, so on an ambiguity it picks one arbitrarily and the rest
+   * would be dropped. If the arbitrary pick is not the overload the call really binds to, the
+   * output does not compile. Preserving all of the candidates is the safe, conservative choice.
+   *
+   * <p>This is a workaround for a larger problem: the typing judgment still comes from the arbitrary
+   * pick. TODO: fix the Resolver API so that it can return multiple candidates in cases like this one.
+   *
+   * @param node The node that was resolved
+   */
+  private void preserveAmbiguousConstraintQualifiedCandidates(Node node) {
+    if (!(node instanceof MethodCallExpr methodCall) || !methodCall.hasScope()) {
+      return;
+    }
+
+    List<ResolvedMethodDeclaration> candidates =
+        JavaParserUtil.getConstraintQualifiedCallCandidates(methodCall);
+
+    // One candidate is not an ambiguity: it was already preserved as the resolution result.
+    if (candidates.size() < 2) {
+      return;
+    }
+
+    for (ResolvedMethodDeclaration candidate : candidates) {
+      // The return value says whether an unsolved symbol must be generated for the node, which is
+      // decided by the node's own resolution, not by these extra candidates.
+      handleResolvedObject(methodCall, candidate);
     }
   }
 

--- a/src/main/java/org/checkerframework/specimin/Slicer.java
+++ b/src/main/java/org/checkerframework/specimin/Slicer.java
@@ -316,8 +316,9 @@ public class Slicer {
    * would be dropped. If the arbitrary pick is not the overload the call really binds to, the
    * output does not compile. Preserving all of the candidates is the safe, conservative choice.
    *
-   * <p>This is a workaround for a larger problem: the typing judgment still comes from the arbitrary
-   * pick. TODO: fix the Resolver API so that it can return multiple candidates in cases like this one.
+   * <p>This is a workaround for a larger problem: the typing judgment still comes from the
+   * arbitrary pick. TODO: fix the Resolver API so that it can return multiple candidates in cases
+   * like this one.
    *
    * @param node The node that was resolved
    */

--- a/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
+++ b/src/main/java/org/checkerframework/specimin/unsolved/UnsolvedSymbolGenerator.java
@@ -4496,8 +4496,11 @@ public class UnsolvedSymbolGenerator {
         // cannot get the ResolvedMethodDeclarations from each type declaration since parameter
         // types could be unsolved
         if (refType.getTypeDeclaration().isPresent()) {
+          // Ordered, because the code below takes the first match as the least upper bound, and
+          // getDeclaredMethods() returns a set whose iteration order is not reproducible; see
+          // JavaParserUtil#getDeclaredMethodsInOrder.
           for (ResolvedMethodDeclaration methodDecl :
-              refType.getTypeDeclaration().get().getDeclaredMethods()) {
+              JavaParserUtil.getDeclaredMethodsInOrder(refType.getTypeDeclaration().get())) {
             MethodDeclaration methodDeclAst =
                 (MethodDeclaration)
                     JavaParserUtil.findAttachedNode(methodDecl, fqnsToCompilationUnits);

--- a/src/test/java/org/checkerframework/specimin/AmbiguousConstraintOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/AmbiguousConstraintOverloadTest.java
@@ -1,0 +1,40 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Checks that when Specimin cannot tell two overloads apart, it preserves both rather than
+ * committing to one.
+ *
+ * <p>The overloaded call's argument is a second lambda parameter, so its type is a lambda
+ * constraint type, which carries no usable information: JavaParser reports its bound as a bare,
+ * unbounded type variable. Both overloads are therefore admitted and neither is more specific, so
+ * the declaration {@code
+ * JavaParserUtil#tryFindCorrespondingDeclarationForConstraintQualifiedExpression} answers with is
+ * an arbitrary one. It is not the overload javac selects here, so preserving only it would leave
+ * the call with nothing to bind to.
+ *
+ * <p>The expected output therefore keeps {@code combine(Unrelated)} and {@code Unrelated} and
+ * {@code SqlOther} as well, none of which the call needs: minimality traded for compilability. This
+ * is a workaround rather than a fix, because the typing judgment still comes from the arbitrary
+ * pick; see {@code ../issues/constraint-typed-argument-forces-an-arbitrary-overload-choice.md}.
+ */
+public class AmbiguousConstraintOverloadTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "ambiguousconstraintoverload",
+        new String[] {
+          "com/example/Simple.java",
+          "com/example/sql/SqlNode.java",
+          "com/example/sql/SqlOther.java",
+          "com/example/sql/SqlParserPos.java",
+          "com/example/other/Unrelated.java",
+          "com/example/util/Util.java"
+        },
+        new String[] {
+          "com.example.Simple#toPos(Iterable<? extends SqlNode>, Iterable<? extends SqlNode>)"
+        });
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AmbiguousConstraintOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/AmbiguousConstraintOverloadTest.java
@@ -10,15 +10,13 @@ import org.junit.jupiter.api.Test;
  * <p>The overloaded call's argument is a second lambda parameter, so its type is a lambda
  * constraint type, which carries no usable information: JavaParser reports its bound as a bare,
  * unbounded type variable. Both overloads are therefore admitted and neither is more specific, so
- * the declaration {@code
- * JavaParserUtil#tryFindCorrespondingDeclarationForConstraintQualifiedExpression} answers with is
- * an arbitrary one. It is not the overload javac selects here, so preserving only it would leave
- * the call with nothing to bind to.
+ * the {@link Resolver} API answers with an arbitrary one. In this example, that arbitrary pick is
+ * not the overload javac selects, so preserving only it would leave the call with nothing to bind
+ * to.
  *
  * <p>The expected output therefore keeps {@code combine(Unrelated)} and {@code Unrelated} and
- * {@code SqlOther} as well, none of which the call needs: minimality traded for compilability. This
- * is a workaround rather than a fix, because the typing judgment still comes from the arbitrary
- * pick; see {@code ../issues/constraint-typed-argument-forces-an-arbitrary-overload-choice.md}.
+ * {@code SqlOther} as well, none of which the call really needs. In the future, changing the
+ * expected output to remove those expected files would be an improvement, not a regression.
  */
 public class AmbiguousConstraintOverloadTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/ConstraintArgOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/ConstraintArgOverloadTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A variant of {@link ConstraintScopeOverloadTest} in which the overloaded call's argument is
+ * itself the lambda parameter, so its type is a lambda constraint type rather than an ordinary
+ * reference type. Without Specimin's conservative logic for what arguments could be compatible with
+ * parameters, we might reject {@code combine(SqlNode)} and leaves only {@code combine(Object)},
+ * which would make the target method's return statement not compile.
+ */
+public class ConstraintArgOverloadTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "constraintargoverload",
+        new String[] {
+          "com/example/Simple.java",
+          "com/example/sql/SqlNode.java",
+          "com/example/sql/SqlOther.java",
+          "com/example/sql/SqlParserPos.java",
+          "com/example/util/Util.java"
+        },
+        new String[] {"com.example.Simple#toPos(Iterable<? extends SqlNode>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/ConstraintArgUnrelatedOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/ConstraintArgUnrelatedOverloadTest.java
@@ -7,12 +7,11 @@ import org.junit.jupiter.api.Test;
  * A variant of {@link ConstraintArgOverloadTest} in which the two overloads have <em>unrelated</em>
  * parameter types, so that only one of them is applicable at all.
  *
- * <p>{@code JavaParserUtil#couldArgumentBeTypeCompatibleWithParameterType} accepts any reference
- * parameter for a lambda constraint type, because JavaParser reports such a type's bound as a bare,
- * unbounded type variable that constrains nothing. Both overloads are therefore admitted as
- * applicable; neither is more specific than the other, since their parameter types are unrelated;
- * and the tie is broken by declaration order, which selects {@code combine(Unrelated)}. That drops
- * the only applicable overload from the output, so the call itself does not type-check.
+ * <p>JavaParser reports a lambda constraint's bound as a bare, unbounded type variable, so Specimin
+ * cannot tell which is the right one. So, it has to treat both overloads as applicable; neither is
+ * more specific than the other, since their parameter types are unrelated. This test's package
+ * names are chosen in such a way that an arbitrary choice will favor the unrelated option, leading
+ * to non-compiling output if Specimin doesn't have a fallback.
  */
 public class ConstraintArgUnrelatedOverloadTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/ConstraintArgUnrelatedOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/ConstraintArgUnrelatedOverloadTest.java
@@ -1,0 +1,32 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A variant of {@link ConstraintArgOverloadTest} in which the two overloads have <em>unrelated</em>
+ * parameter types, so that only one of them is applicable at all.
+ *
+ * <p>{@code JavaParserUtil#couldArgumentBeTypeCompatibleWithParameterType} accepts any reference
+ * parameter for a lambda constraint type, because JavaParser reports such a type's bound as a bare,
+ * unbounded type variable that constrains nothing. Both overloads are therefore admitted as
+ * applicable; neither is more specific than the other, since their parameter types are unrelated;
+ * and the tie is broken by declaration order, which selects {@code combine(Unrelated)}. That drops
+ * the only applicable overload from the output, so the call itself does not type-check.
+ */
+public class ConstraintArgUnrelatedOverloadTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "constraintargunrelatedoverload",
+        new String[] {
+          "com/example/Simple.java",
+          "com/example/sql/SqlNode.java",
+          "com/example/sql/SqlOther.java",
+          "com/example/sql/SqlParserPos.java",
+          "com/example/other/Unrelated.java",
+          "com/example/util/Util.java"
+        },
+        new String[] {"com.example.Simple#toPos(Iterable<? extends SqlNode>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/ConstraintScopeOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/ConstraintScopeOverloadTest.java
@@ -1,0 +1,26 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that when a call whose scope's type is a lambda constraint type invokes an
+ * overloaded method, Specimin resolves it to the most specific applicable overload, as JLS
+ * 15.12.2.5 requires. Preserving the other, less specific overload instead gives the call the wrong
+ * return type, which here makes the target method's return statement not compile.
+ */
+public class ConstraintScopeOverloadTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "constraintscopeoverload",
+        new String[] {
+          "com/example/Simple.java",
+          "com/example/sql/SqlNode.java",
+          "com/example/sql/SqlOther.java",
+          "com/example/sql/SqlParserPos.java",
+          "com/example/util/Util.java"
+        },
+        new String[] {"com.example.Simple#toPos(Iterable<? extends SqlNode>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarArgOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarArgOverloadTest.java
@@ -4,16 +4,16 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 /**
- * Checks that an overload admitted only by {@code
- * JavaParserUtil#couldArgumentBeTypeCompatibleWithParameterType}'s accommodation loses to one that
- * the argument is genuinely assignable to.
+ * Checks that an overload that Specimin only considers because of over-approximation does not have
+ * precedence over one that the argument is genuinely assignable to.
  *
- * <p>The argument's type here is the type variable {@code T}, so the accommodation admits {@code
- * combine(SqlNode)} even though {@code T} is not a {@code SqlNode}. That candidate then
- * <em>wins</em> on specificity, because {@code SqlNode} is a subtype of {@code Object}: JLS
+ * <p>The argument's type here is the type variable {@code T}, so Specimin's over-approximation
+ * (which accepts any type variable without considering bounds, due to JavaParser limitations)
+ * admits {@code combine(SqlNode)} even though {@code T} is not a {@code SqlNode}. That candidate
+ * then <em>wins</em> on specificity, because {@code SqlNode} is a subtype of {@code Object}: JLS
  * 15.12.2.5 is being applied to a candidate that JLS 15.12.2.2 should have excluded. javac selects
- * {@code combine(Object)}, and preserving {@code combine(SqlNode)} instead leaves the call unable
- * to compile.
+ * {@code combine(Object)}, and preserving {@code combine(SqlNode)} instead would leave the call
+ * unable to compile.
  */
 public class TypeVarArgOverloadTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/TypeVarArgOverloadTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarArgOverloadTest.java
@@ -1,0 +1,32 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Checks that an overload admitted only by {@code
+ * JavaParserUtil#couldArgumentBeTypeCompatibleWithParameterType}'s accommodation loses to one that
+ * the argument is genuinely assignable to.
+ *
+ * <p>The argument's type here is the type variable {@code T}, so the accommodation admits {@code
+ * combine(SqlNode)} even though {@code T} is not a {@code SqlNode}. That candidate then
+ * <em>wins</em> on specificity, because {@code SqlNode} is a subtype of {@code Object}: JLS
+ * 15.12.2.5 is being applied to a candidate that JLS 15.12.2.2 should have excluded. javac selects
+ * {@code combine(Object)}, and preserving {@code combine(SqlNode)} instead leaves the call unable
+ * to compile.
+ */
+public class TypeVarArgOverloadTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarargoverload",
+        new String[] {
+          "com/example/Simple.java",
+          "com/example/sql/SqlNode.java",
+          "com/example/sql/SqlOther.java",
+          "com/example/sql/SqlParserPos.java",
+          "com/example/util/Util.java"
+        },
+        new String[] {"com.example.Simple#toPos(Iterable<? extends SqlNode>, T)"});
+  }
+}

--- a/src/test/resources/ambiguousconstraintoverload/expected/com/example/Simple.java
+++ b/src/test/resources/ambiguousconstraintoverload/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+class Simple {
+
+  private static Iterable<SqlParserPos> toPos(
+      Iterable<? extends SqlNode> nodes, Iterable<? extends SqlNode> others) {
+    return Util.transform2(nodes, others, (node, other) -> node.combine(other));
+  }
+}

--- a/src/test/resources/ambiguousconstraintoverload/expected/com/example/other/Unrelated.java
+++ b/src/test/resources/ambiguousconstraintoverload/expected/com/example/other/Unrelated.java
@@ -1,0 +1,3 @@
+package com.example.other;
+
+public class Unrelated {}

--- a/src/test/resources/ambiguousconstraintoverload/expected/com/example/sql/SqlNode.java
+++ b/src/test/resources/ambiguousconstraintoverload/expected/com/example/sql/SqlNode.java
@@ -1,0 +1,14 @@
+package com.example.sql;
+
+import com.example.other.Unrelated;
+
+public class SqlNode {
+
+  public SqlOther combine(Unrelated u) {
+    throw new java.lang.Error();
+  }
+
+  public SqlParserPos combine(SqlNode n) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/ambiguousconstraintoverload/expected/com/example/sql/SqlOther.java
+++ b/src/test/resources/ambiguousconstraintoverload/expected/com/example/sql/SqlOther.java
@@ -1,0 +1,3 @@
+package com.example.sql;
+
+public class SqlOther {}

--- a/src/test/resources/ambiguousconstraintoverload/expected/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/ambiguousconstraintoverload/expected/com/example/sql/SqlParserPos.java
@@ -1,0 +1,3 @@
+package com.example.sql;
+
+public class SqlParserPos {}

--- a/src/test/resources/ambiguousconstraintoverload/expected/com/example/util/Util.java
+++ b/src/test/resources/ambiguousconstraintoverload/expected/com/example/util/Util.java
@@ -1,0 +1,11 @@
+package com.example.util;
+
+public class Util {
+
+  public static <F, G, T> Iterable<T> transform2(
+      Iterable<? extends F> a,
+      Iterable<? extends G> b,
+      java.util.function.BiFunction<? super F, ? super G, ? extends T> function) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/ambiguousconstraintoverload/input/com/example/Simple.java
+++ b/src/test/resources/ambiguousconstraintoverload/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+class Simple {
+    private static Iterable<SqlParserPos> toPos(
+            Iterable<? extends SqlNode> nodes, Iterable<? extends SqlNode> others) {
+        return Util.transform2(nodes, others, (node, other) -> node.combine(other));
+    }
+}

--- a/src/test/resources/ambiguousconstraintoverload/input/com/example/other/Unrelated.java
+++ b/src/test/resources/ambiguousconstraintoverload/input/com/example/other/Unrelated.java
@@ -1,0 +1,4 @@
+package com.example.other;
+
+public class Unrelated {
+}

--- a/src/test/resources/ambiguousconstraintoverload/input/com/example/sql/SqlNode.java
+++ b/src/test/resources/ambiguousconstraintoverload/input/com/example/sql/SqlNode.java
@@ -1,0 +1,13 @@
+package com.example.sql;
+
+import com.example.other.Unrelated;
+
+public class SqlNode {
+    public SqlOther combine(Unrelated u) {
+        throw new java.lang.Error();
+    }
+
+    public SqlParserPos combine(SqlNode n) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/ambiguousconstraintoverload/input/com/example/sql/SqlOther.java
+++ b/src/test/resources/ambiguousconstraintoverload/input/com/example/sql/SqlOther.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlOther {
+}

--- a/src/test/resources/ambiguousconstraintoverload/input/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/ambiguousconstraintoverload/input/com/example/sql/SqlParserPos.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlParserPos {
+}

--- a/src/test/resources/ambiguousconstraintoverload/input/com/example/util/Util.java
+++ b/src/test/resources/ambiguousconstraintoverload/input/com/example/util/Util.java
@@ -1,0 +1,9 @@
+package com.example.util;
+
+public class Util {
+    public static <F, G, T> Iterable<T> transform2(Iterable<? extends F> a,
+                                                   Iterable<? extends G> b,
+                                                   java.util.function.BiFunction<? super F, ? super G, ? extends T> function) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constraintargoverload/expected/com/example/Simple.java
+++ b/src/test/resources/constraintargoverload/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+class Simple {
+
+  private static Iterable<SqlParserPos> toPos(Iterable<? extends SqlNode> nodes) {
+    return Util.transform(nodes, node -> node.combine(node));
+  }
+}

--- a/src/test/resources/constraintargoverload/expected/com/example/sql/SqlNode.java
+++ b/src/test/resources/constraintargoverload/expected/com/example/sql/SqlNode.java
@@ -1,0 +1,8 @@
+package com.example.sql;
+
+public class SqlNode {
+
+  public SqlParserPos combine(SqlNode n) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/constraintargoverload/expected/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/constraintargoverload/expected/com/example/sql/SqlParserPos.java
@@ -1,0 +1,3 @@
+package com.example.sql;
+
+public class SqlParserPos {}

--- a/src/test/resources/constraintargoverload/expected/com/example/util/Util.java
+++ b/src/test/resources/constraintargoverload/expected/com/example/util/Util.java
@@ -1,0 +1,10 @@
+package com.example.util;
+
+public class Util {
+
+  public static <F, T> Iterable<T> transform(
+      Iterable<? extends F> iterable,
+      java.util.function.Function<? super F, ? extends T> function) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/constraintargoverload/input/com/example/Simple.java
+++ b/src/test/resources/constraintargoverload/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+class Simple {
+    private static Iterable<SqlParserPos> toPos(
+            Iterable<? extends SqlNode> nodes) {
+        return Util.transform(nodes, node -> node.combine(node));
+    }
+}

--- a/src/test/resources/constraintargoverload/input/com/example/sql/SqlNode.java
+++ b/src/test/resources/constraintargoverload/input/com/example/sql/SqlNode.java
@@ -1,0 +1,11 @@
+package com.example.sql;
+
+public class SqlNode {
+    public SqlOther combine(Object o) {
+        throw new java.lang.Error();
+    }
+
+    public SqlParserPos combine(SqlNode n) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constraintargoverload/input/com/example/sql/SqlOther.java
+++ b/src/test/resources/constraintargoverload/input/com/example/sql/SqlOther.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlOther {
+}

--- a/src/test/resources/constraintargoverload/input/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/constraintargoverload/input/com/example/sql/SqlParserPos.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlParserPos {
+}

--- a/src/test/resources/constraintargoverload/input/com/example/util/Util.java
+++ b/src/test/resources/constraintargoverload/input/com/example/util/Util.java
@@ -1,0 +1,8 @@
+package com.example.util;
+
+public class Util {
+    public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable,
+                                               java.util.function.Function<? super F, ? extends T> function) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constraintargunrelatedoverload/expected/com/example/Simple.java
+++ b/src/test/resources/constraintargunrelatedoverload/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+class Simple {
+
+  private static Iterable<SqlParserPos> toPos(Iterable<? extends SqlNode> nodes) {
+    return Util.transform(nodes, node -> node.combine(node));
+  }
+}

--- a/src/test/resources/constraintargunrelatedoverload/expected/com/example/sql/SqlNode.java
+++ b/src/test/resources/constraintargunrelatedoverload/expected/com/example/sql/SqlNode.java
@@ -1,0 +1,8 @@
+package com.example.sql;
+
+public class SqlNode {
+
+  public SqlParserPos combine(SqlNode n) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/constraintargunrelatedoverload/expected/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/constraintargunrelatedoverload/expected/com/example/sql/SqlParserPos.java
@@ -1,0 +1,3 @@
+package com.example.sql;
+
+public class SqlParserPos {}

--- a/src/test/resources/constraintargunrelatedoverload/expected/com/example/util/Util.java
+++ b/src/test/resources/constraintargunrelatedoverload/expected/com/example/util/Util.java
@@ -1,0 +1,10 @@
+package com.example.util;
+
+public class Util {
+
+  public static <F, T> Iterable<T> transform(
+      Iterable<? extends F> iterable,
+      java.util.function.Function<? super F, ? extends T> function) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/constraintargunrelatedoverload/input/com/example/Simple.java
+++ b/src/test/resources/constraintargunrelatedoverload/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+class Simple {
+    private static Iterable<SqlParserPos> toPos(
+            Iterable<? extends SqlNode> nodes) {
+        return Util.transform(nodes, node -> node.combine(node));
+    }
+}

--- a/src/test/resources/constraintargunrelatedoverload/input/com/example/other/Unrelated.java
+++ b/src/test/resources/constraintargunrelatedoverload/input/com/example/other/Unrelated.java
@@ -1,0 +1,4 @@
+package com.example.other;
+
+public class Unrelated {
+}

--- a/src/test/resources/constraintargunrelatedoverload/input/com/example/sql/SqlNode.java
+++ b/src/test/resources/constraintargunrelatedoverload/input/com/example/sql/SqlNode.java
@@ -1,0 +1,14 @@
+package com.example.sql;
+
+import com.example.other.Unrelated;
+
+public class SqlNode {
+    // Not applicable to combine(node): Unrelated is unrelated to SqlNode.
+    public SqlOther combine(Unrelated u) {
+        throw new java.lang.Error();
+    }
+
+    public SqlParserPos combine(SqlNode n) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constraintargunrelatedoverload/input/com/example/sql/SqlOther.java
+++ b/src/test/resources/constraintargunrelatedoverload/input/com/example/sql/SqlOther.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlOther {
+}

--- a/src/test/resources/constraintargunrelatedoverload/input/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/constraintargunrelatedoverload/input/com/example/sql/SqlParserPos.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlParserPos {
+}

--- a/src/test/resources/constraintargunrelatedoverload/input/com/example/util/Util.java
+++ b/src/test/resources/constraintargunrelatedoverload/input/com/example/util/Util.java
@@ -1,0 +1,8 @@
+package com.example.util;
+
+public class Util {
+    public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable,
+                                               java.util.function.Function<? super F, ? extends T> function) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constraintscopeoverload/expected/com/example/Simple.java
+++ b/src/test/resources/constraintscopeoverload/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+class Simple {
+
+  private static Iterable<SqlParserPos> toPos(Iterable<? extends SqlNode> nodes) {
+    return Util.transform(nodes, node -> node.getParserPosition("x"));
+  }
+}

--- a/src/test/resources/constraintscopeoverload/expected/com/example/sql/SqlNode.java
+++ b/src/test/resources/constraintscopeoverload/expected/com/example/sql/SqlNode.java
@@ -1,0 +1,8 @@
+package com.example.sql;
+
+public class SqlNode {
+
+  public SqlParserPos getParserPosition(String s) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/constraintscopeoverload/expected/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/constraintscopeoverload/expected/com/example/sql/SqlParserPos.java
@@ -1,0 +1,3 @@
+package com.example.sql;
+
+public class SqlParserPos {}

--- a/src/test/resources/constraintscopeoverload/expected/com/example/util/Util.java
+++ b/src/test/resources/constraintscopeoverload/expected/com/example/util/Util.java
@@ -1,0 +1,10 @@
+package com.example.util;
+
+public class Util {
+
+  public static <F, T> Iterable<T> transform(
+      Iterable<? extends F> iterable,
+      java.util.function.Function<? super F, ? extends T> function) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/constraintscopeoverload/input/com/example/Simple.java
+++ b/src/test/resources/constraintscopeoverload/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+class Simple {
+    // Target method.
+    private static Iterable<SqlParserPos> toPos(
+            Iterable<? extends SqlNode> nodes) {
+        return Util.transform(nodes, node -> node.getParserPosition("x"));
+    }
+}

--- a/src/test/resources/constraintscopeoverload/input/com/example/sql/SqlNode.java
+++ b/src/test/resources/constraintscopeoverload/input/com/example/sql/SqlNode.java
@@ -1,0 +1,11 @@
+package com.example.sql;
+
+public class SqlNode {
+    public SqlOther getParserPosition(Object o) {
+        throw new java.lang.Error();
+    }
+
+    public SqlParserPos getParserPosition(String s) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/constraintscopeoverload/input/com/example/sql/SqlOther.java
+++ b/src/test/resources/constraintscopeoverload/input/com/example/sql/SqlOther.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlOther {
+}

--- a/src/test/resources/constraintscopeoverload/input/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/constraintscopeoverload/input/com/example/sql/SqlParserPos.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlParserPos {
+}

--- a/src/test/resources/constraintscopeoverload/input/com/example/util/Util.java
+++ b/src/test/resources/constraintscopeoverload/input/com/example/util/Util.java
@@ -1,0 +1,8 @@
+package com.example.util;
+
+public class Util {
+    public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable,
+                                               java.util.function.Function<? super F, ? extends T> function) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarargoverload/expected/com/example/Simple.java
+++ b/src/test/resources/typevarargoverload/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+class Simple {
+
+  private static <T> Iterable<SqlParserPos> toPos(Iterable<? extends SqlNode> nodes, T t) {
+    return Util.transform(nodes, node -> node.combine(t));
+  }
+}

--- a/src/test/resources/typevarargoverload/expected/com/example/sql/SqlNode.java
+++ b/src/test/resources/typevarargoverload/expected/com/example/sql/SqlNode.java
@@ -1,0 +1,8 @@
+package com.example.sql;
+
+public class SqlNode {
+
+  public SqlParserPos combine(Object o) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/typevarargoverload/expected/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/typevarargoverload/expected/com/example/sql/SqlParserPos.java
@@ -1,0 +1,3 @@
+package com.example.sql;
+
+public class SqlParserPos {}

--- a/src/test/resources/typevarargoverload/expected/com/example/util/Util.java
+++ b/src/test/resources/typevarargoverload/expected/com/example/util/Util.java
@@ -1,0 +1,10 @@
+package com.example.util;
+
+public class Util {
+
+  public static <F, T> Iterable<T> transform(
+      Iterable<? extends F> iterable,
+      java.util.function.Function<? super F, ? extends T> function) {
+    throw new java.lang.Error();
+  }
+}

--- a/src/test/resources/typevarargoverload/input/com/example/Simple.java
+++ b/src/test/resources/typevarargoverload/input/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+class Simple {
+    private static <T> Iterable<SqlParserPos> toPos(
+            Iterable<? extends SqlNode> nodes, T t) {
+        return Util.transform(nodes, node -> node.combine(t));
+    }
+}

--- a/src/test/resources/typevarargoverload/input/com/example/sql/SqlNode.java
+++ b/src/test/resources/typevarargoverload/input/com/example/sql/SqlNode.java
@@ -1,0 +1,12 @@
+package com.example.sql;
+
+public class SqlNode {
+    // Not applicable to an argument of type T: javac does not select it.
+    public SqlOther combine(SqlNode n) {
+        throw new java.lang.Error();
+    }
+
+    public SqlParserPos combine(Object o) {
+        throw new java.lang.Error();
+    }
+}

--- a/src/test/resources/typevarargoverload/input/com/example/sql/SqlOther.java
+++ b/src/test/resources/typevarargoverload/input/com/example/sql/SqlOther.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlOther {
+}

--- a/src/test/resources/typevarargoverload/input/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/typevarargoverload/input/com/example/sql/SqlParserPos.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlParserPos {
+}

--- a/src/test/resources/typevarargoverload/input/com/example/util/Util.java
+++ b/src/test/resources/typevarargoverload/input/com/example/util/Util.java
@@ -1,0 +1,8 @@
+package com.example.util;
+
+public class Util {
+    public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable,
+                                               java.util.function.Function<? super F, ? extends T> function) {
+        throw new java.lang.Error();
+    }
+}


### PR DESCRIPTION
In #553, one sub-problem that I had to solve was that we were iterating over a JavaParser method (`ResolvedReferenceTypeDeclaration#getDeclaredMethods`) that returns its results in non-deterministic order - in fact, JavaParser returns different orders each time this method runs (it re-hashes the results and order them by hash). This non-determinism was leaking into Specimin's output.

This PR is the result of an audit of Specimin's use of that method and similar APIs. I found one genuine bug (see the new test case) that can be triggered today, and a number of latent possible bugs (none of which I managed to trigger). The genuine bug required more than just iterating in deterministic order to fix, because we were returning the _first_ match for overloaded methods (in the non-deterministically ordered set...), rather than the most-specific.